### PR TITLE
Install UX sprint: chatlog discoverability, post-install phase, audit fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Keep shell scripts + Python as LF on all platforms so Linux/macOS hook
+# execution isn't broken by Windows CRLF on a mixed-OS checkout.
+# Text files normalize to LF in the repo; native line endings in the
+# working tree are left to git's autocrlf default.
+*.sh       text eol=lf
+*.py       text eol=lf
+*.ps1      text eol=crlf
+
+# Binaries: never convert.
+*.db       binary
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.ico      binary
+*.gguf     binary
+*.tar.gz   binary
+*.zip      binary

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,6 +87,28 @@ spill files, per-agent capture timestamps).
 `mcp-memory chatlog doctor` is the same but exits nonzero on any warning —
 suitable for CI / health checks.
 
+## Gemini CLI gotchas
+
+Gemini CLI 0.39+ refuses to run in a non-trusted directory. Headless and
+automated invocations need one of:
+
+```bash
+gemini --skip-trust --prompt "..."                    # per-call opt-out
+GEMINI_CLI_TRUST_WORKSPACE=true gemini --prompt "..." # env-var opt-out
+```
+
+This affects:
+- **Cron / systemd / CI** — set `GEMINI_CLI_TRUST_WORKSPACE=true` in the unit's `Environment=` block.
+- **Hooks invoking `gemini`** — pass `--skip-trust` in the command.
+
+Interactive shells can trust the directory once via Gemini's TUI prompt and
+the choice persists; only headless contexts need the explicit opt-out.
+
+The `memory` MCP entry in `~/.gemini/settings.json` is written automatically
+by `mcp-memory install-m3` post-install. The `SessionEnd` chatlog hook is
+written by `mcp-memory chatlog init --apply-gemini` (or automatically when
+you pass `--capture-mode both` to `install-m3`).
+
 ## Per-OS walkthroughs
 
 These documents cover the from-scratch homelab install including optional

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,98 @@
+# INSTALL
+
+Platform-specific setup notes for `m3-memory`. The quick path is the same on
+every OS:
+
+```
+pip install m3-memory     # or pipx install m3-memory
+mcp-memory install-m3     # fetches the system payload, runs post-install
+mcp-memory doctor         # verify
+```
+
+If that works, stop here. The rest of this file is the stuff that differs
+between operating systems and the reasons behind it.
+
+## OS matrix
+
+| Capability | Windows 11 | macOS (Apple Silicon / Intel) | Debian 12 / Ubuntu 24.04 / Fedora 38+ (PEP 668) | Older Linux (no PEP 668) |
+|---|---|---|---|---|
+| `python` ≥ 3.11 | `winget install Python.Python.3.12` | ships, or `brew install python@3.12` | `sudo apt install python3 python3-venv` | distro `python3` |
+| Install method | `pip install m3-memory` | `pipx install m3-memory` (brew python is PEP 668) | `pipx install m3-memory` **required** | `pip install m3-memory` ok |
+| `pipx` bootstrap | — | `brew install pipx` | `sudo apt install pipx` / `sudo dnf install pipx` | `pip install --user pipx` |
+| `sqlite3` CLI | `winget install SQLite.SQLite` or [sqlite.org/download](https://sqlite.org/download.html) | ships in `/usr/bin/sqlite3` | `sudo apt install sqlite3` / `sudo dnf install sqlite` | `sudo yum install sqlite` |
+| Python stdlib sqlite | built-in | built-in | built-in | built-in |
+| `git` (for install-m3) | `winget install Git.Git` | ships with Xcode CLT | `sudo apt install git` | distro `git` |
+| npm-global PATH (if using Gemini CLI) | handled by Node installer | `~/.npm-global/bin` — added to `.zshrc` by npm | `~/.npm-global/bin` — `install-m3` appends to `~/.profile` for non-interactive shells | same as Debian |
+| Gemini CLI auto-register | `install-m3` writes `%USERPROFILE%\.gemini\settings.json` | `install-m3` writes `~/.gemini/settings.json` | same | same |
+| Claude Code hooks | `install-m3` expects `~/.claude/settings.json` | same | same | same |
+
+## What `install-m3` does for you
+
+Post-install phase runs once at the end of `mcp-memory install-m3`. Every
+step is additive and idempotent — safe to re-run via `mcp-memory update`:
+
+1. **Gemini CLI** — if `gemini` is on PATH (or at `~/.npm-global/bin/gemini`),
+   writes a `memory` MCP entry to `~/.gemini/settings.json`. Skips if already
+   registered. Does nothing if Gemini isn't installed.
+2. **sqlite3 CLI check** — prints a per-OS install hint if `sqlite3` isn't on
+   PATH. Advisory only; we don't invoke sudo.
+3. **npm-global PATH** — on Linux / macOS, appends
+   `export PATH="$HOME/.npm-global/bin:$PATH"` to `~/.profile` if that dir
+   exists and the line isn't already there. Fixes `gemini` being missing from
+   cron and non-login sshd shells. No-op on Windows.
+4. **Interactive prompts** (TTY only):
+   - LLM endpoint: LM Studio (:1234), Ollama (:11434), or probe both.
+   - Chatlog capture hooks: both, PreCompact-only, Stop-only, or none.
+
+All four are skippable:
+
+```bash
+mcp-memory install-m3 --non-interactive          # silent defaults
+mcp-memory install-m3 --endpoint http://localhost:11434/v1
+mcp-memory install-m3 --capture-mode precompact
+```
+
+## Why pipx on PEP 668 distros
+
+Debian 12+, Ubuntu 24.04+, Fedora 38+, and recent Arch mark their system
+Python as "externally managed" (PEP 668). A plain `pip install m3-memory`
+into the system interpreter fails with:
+
+```
+error: externally-managed-environment
+```
+
+`pipx` isolates the install into a per-command venv and adds the script
+shim to `~/.local/bin`. That keeps system Python untouched and makes
+upgrades (`pipx upgrade m3-memory`) a one-liner.
+
+On macOS the Homebrew Python is also PEP 668-managed, so `pipx` is the
+clean path there too. System Python on macOS is even older; don't use it.
+
+## Diagnosing a broken install
+
+```bash
+mcp-memory doctor
+```
+
+Reports:
+- package + installed payload version / tag / path
+- chatlog DB path + captured-row count + last-capture timestamp
+- Claude Stop/PreCompact hook state (on/off)
+- Gemini `memory` MCP registration state
+
+`mcp-memory chatlog status` drills into the chatlog subsystem (queue depth,
+spill files, per-agent capture timestamps).
+
+`mcp-memory chatlog doctor` is the same but exits nonzero on any warning —
+suitable for CI / health checks.
+
+## Per-OS walkthroughs
+
+These documents cover the from-scratch homelab install including optional
+Postgres + ChromaDB + LM Studio wiring. They are **not** required for a
+working local-only setup:
+
+- [docs/install_windows-powershell.md](docs/install_windows-powershell.md)
+- [docs/install_macos.md](docs/install_macos.md)
+- [docs/install_linux.md](docs/install_linux.md)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,17 @@ Works with Claude Code, Gemini CLI, Aider, OpenCode, and any MCP-compatible agen
 ## 📦 Install
 
 ```bash
-pip install m3-memory
+pipx install m3-memory        # Debian 12+, Ubuntu 24.04+, Fedora 38+, Arch, macOS (brew python)
+pip install m3-memory         # Windows, older Linux, any venv
 ```
 
-That's it. On first `mcp-memory` run, the CLI auto-fetches the system
+On PEP 668 distros a plain `pip install` fails with
+`externally-managed-environment` — use `pipx` there. `pipx install`
+isolates the CLI and adds it to `~/.local/bin` (run `pipx ensurepath`
+and open a new terminal if `mcp-memory` isn't on PATH after install).
+Full OS matrix including `sqlite3` CLI and Gemini setup: [INSTALL.md](INSTALL.md).
+
+On first `mcp-memory` run, the CLI auto-fetches the system
 payload into `~/.m3-memory/repo/` (pinned to the wheel version) — with
 an interactive confirmation prompt if you run it in a terminal, silently
 if an MCP client is launching the server. Set `M3_AUTO_INSTALL=0` to

--- a/bin/chatlog_ingest.py
+++ b/bin/chatlog_ingest.py
@@ -125,16 +125,20 @@ def _parse_claude_code(raw: str) -> tuple[list[dict], Optional[str]]:
 
 
 # ─── Gemini CLI parser ────────────────────────────────────────────────────────
-# Real on-disk schema at ~/.gemini/tmp/<projectHash>/chats/session-<ISO>-<id>.json:
-#   {"sessionId": "...", "projectHash": "...",
-#    "startTime": "...", "lastUpdated": "...",
-#    "messages": [
-#       {"id": "...", "timestamp": "...",
-#        "type": "user"|"gemini"|"info",
-#        "content": "str"  |  [{"text": "..."}, ...],
-#        "thoughts": [...], "tokens": {"input":N,"output":N,"cached":N},
-#        "model": "...", "toolCalls": [...]}]}
+# Real on-disk schema at ~/.gemini/tmp/<projectHash>/chats/session-<ISO>-<id>.jsonl:
+# JSONL — one JSON object per line, NOT a single object with a messages[] array.
+#
+# Line 1: session header
+#   {"sessionId":"...","projectHash":"...","startTime":"...","lastUpdated":"...","kind":"main"}
+#
+# Subsequent lines are either turn records or $set ops (which we ignore):
+#   {"id":"...","timestamp":"...","type":"user"|"gemini"|"info",
+#    "content":"str"|[{"text":"..."},...], "tokens":{...}, "model":"...", ...}
+#   {"$set":{"lastUpdated":"..."}}           — ignore
+#
 # "info" messages (CLI chrome) are skipped. "gemini" → assistant role.
+# Observed 2026-04-24 on Gemini CLI 0.39.1. The older .json format (single
+# object with messages[]) is still handled as a fallback for historical files.
 
 def _gemini_content_to_text(content: Any) -> str:
     """Flatten Gemini message.content to plain text.
@@ -156,18 +160,55 @@ def _gemini_content_to_text(content: Any) -> str:
 
 
 def _parse_gemini_cli(raw: str) -> tuple[list[dict], Optional[str]]:
-    """Parse Gemini CLI session JSON. Returns (items, sessionId)."""
+    """Parse a Gemini CLI session transcript. Returns (items, sessionId).
+
+    Handles both formats:
+      1. Current (Gemini CLI 0.39+): JSONL — one JSON object per line. Line 1
+         is the session header; subsequent lines are turn records or $set ops.
+      2. Historical: single JSON object with a messages[] array (kept as
+         fallback for any older transcripts that still exist).
+    """
     if not raw.strip():
         return [], None
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as e:
-        logger.warning(f"Malformed Gemini session JSON: {e}")
-        return [], None
-    session_id = data.get("sessionId")
-    messages = data.get("messages") or []
-    if not isinstance(messages, list):
-        return [], session_id
+
+    messages: list[dict] = []
+    session_id: Optional[str] = None
+
+    stripped = raw.lstrip()
+    if stripped.startswith("{") and "\n{" in stripped:
+        # Looks like JSONL (multiple top-level objects separated by newlines).
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as e:
+                logger.warning(f"Malformed Gemini JSONL line, skipping: {e}")
+                continue
+            if not isinstance(obj, dict):
+                continue
+            # Session header is the first non-$set object carrying sessionId.
+            if session_id is None and obj.get("sessionId"):
+                session_id = obj.get("sessionId")
+                continue
+            # $set ops are internal state updates — ignore.
+            if "$set" in obj:
+                continue
+            # Treat everything else as a candidate message record.
+            messages.append(obj)
+    else:
+        # Try the legacy single-object format.
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Malformed Gemini session JSON: {e}")
+            return [], None
+        session_id = data.get("sessionId")
+        messages_field = data.get("messages")
+        if isinstance(messages_field, list):
+            messages = messages_field
+
     items: list[dict] = []
     for msg in messages:
         if not isinstance(msg, dict):

--- a/bin/chatlog_init.py
+++ b/bin/chatlog_init.py
@@ -594,22 +594,23 @@ def main() -> int:
     if args.disable_stop_hook:
         return apply_stop_hook_toggle(enable=False)
 
-    # Standalone settings.json writers — useful when chatlog is already
-    # configured and the user just wants the hooks wired. Doesn't modify
-    # the chatlog config; reads it.
-    if args.apply_claude or args.apply_gemini:
+    # Standalone settings.json writers (no --non-interactive): useful when
+    # chatlog is already configured and the user just wants the hooks wired.
+    # Doesn't modify the chatlog config; reads it. If --non-interactive is
+    # ALSO set, fall through to the normal path so config + migrations + apply
+    # all happen in one command.
+    if (args.apply_claude or args.apply_gemini) and not args.non_interactive:
         cfg = resolve_config() if os.path.exists(CONFIG_PATH) else ChatlogConfig(
             db_path=DEFAULT_DB_PATH,
             host_agents={a: HookSpec() for a in VALID_HOST_AGENTS},
         )
-        rc = 0
         if args.apply_claude:
             changed, msg = apply_claude_settings(cfg)
             print(("[+] " if changed else "[=] ") + msg)
         if args.apply_gemini:
             changed, msg = apply_gemini_settings()
             print(("[+] " if changed else "[=] ") + msg)
-        return rc
+        return 0
 
     try:
         # Check if config exists

--- a/bin/chatlog_init.py
+++ b/bin/chatlog_init.py
@@ -361,11 +361,20 @@ def apply_claude_settings(config: ChatlogConfig) -> tuple[bool, str]:
 
 
 def apply_gemini_settings() -> tuple[bool, str]:
-    """Merge the SessionEnd hook into ~/.gemini/settings.json. Idempotent.
+    """Merge SessionEnd hook + memory MCP + auth method into ~/.gemini/settings.json.
 
-    Assumes the `memory` MCP entry is written by install-m3's post-install;
-    this function only handles the hook. Refuses to touch an unparseable
-    settings.json. Returns (changed, message).
+    Idempotent. Covers all three pieces a fresh Gemini install needs to
+    talk to m3-memory:
+      - mcpServers.memory: makes the m3-memory tool callable in-session
+      - security.auth.selectedType: 'oauth-personal' so headless flows
+        don't error with 'Please set an Auth method'
+      - hooks.SessionEnd: fires chatlog ingest on exit
+
+    Each piece is added only when missing, so re-running is safe and the
+    function correctly handles the Gemini-installed-after-m3 case where
+    install-m3's _register_gemini_mcp ran too early.
+
+    Refuses to touch an unparseable settings.json. Returns (changed, message).
     """
     settings_path = Path.home() / ".gemini" / "settings.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -386,14 +395,37 @@ def apply_gemini_settings() -> tuple[bool, str]:
     else:
         hook_cmd = f"/bin/sh {sh}"
 
+    actions: list[str] = []
+
+    # 1. mcpServers.memory — points Gemini at the mcp-memory CLI.
+    mcp_servers = existing.setdefault("mcpServers", {})
+    if "memory" not in mcp_servers:
+        mcp_servers["memory"] = {"command": "mcp-memory"}
+        actions.append("memory MCP")
+
+    # 2. security.auth.selectedType — required by Gemini >=0.39 for headless
+    #    invocation. Don't overwrite if user already chose a method.
+    security = existing.setdefault("security", {})
+    auth = security.setdefault("auth", {})
+    if "selectedType" not in auth:
+        # oauth-personal works once oauth_creds.json is present (e.g. after
+        # an interactive `gemini auth`). It doesn't authenticate by itself —
+        # it just tells Gemini which method to use. Users without creds will
+        # still be prompted on first run; this just unblocks the headless
+        # case once they've authed.
+        auth["selectedType"] = "oauth-personal"
+        actions.append("auth method")
+
+    # 3. hooks.SessionEnd — chatlog ingest on session exit.
     hooks = existing.setdefault("hooks", {})
     session_end = hooks.get("SessionEnd") or []
-    already = any("chatlog" in json.dumps(e).lower() for e in session_end)
-    if already:
-        return False, f"no change — SessionEnd chatlog hook already present in {settings_path}"
+    if not any("chatlog" in json.dumps(e).lower() for e in session_end):
+        session_end.append({"hooks": [{"type": "command", "command": hook_cmd}]})
+        hooks["SessionEnd"] = session_end
+        actions.append("SessionEnd hook")
 
-    session_end.append({"hooks": [{"type": "command", "command": hook_cmd}]})
-    hooks["SessionEnd"] = session_end
+    if not actions:
+        return False, f"no change — Gemini already wired for m3-memory in {settings_path}"
 
     if settings_path.is_file():
         stamp = datetime.now().strftime("%Y%m%dT%H%M%SZ")
@@ -401,7 +433,7 @@ def apply_gemini_settings() -> tuple[bool, str]:
         backup.write_text(settings_path.read_text(encoding="utf-8"), encoding="utf-8")
 
     settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
-    return True, f"added SessionEnd chatlog hook to {settings_path}"
+    return True, f"added {', '.join(actions)} to {settings_path}"
 
 
 def show_claude_code_settings_snippet(config: ChatlogConfig) -> None:

--- a/bin/chatlog_init.py
+++ b/bin/chatlog_init.py
@@ -23,6 +23,8 @@ import logging
 import os
 import subprocess
 import sys
+from datetime import datetime
+from pathlib import Path
 
 # Import config module from same directory
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -266,6 +268,142 @@ def install_schedules() -> bool:
         return False
 
 
+def _build_claude_hook_command(config: ChatlogConfig) -> tuple[str, bool]:
+    """Return (command_string, stop_hook_enabled) for the current OS."""
+    ps1 = os.path.join(BASE_DIR, "bin", "hooks", "chatlog",
+                       "claude_code_precompact.ps1").replace("\\", "/")
+    sh = os.path.join(BASE_DIR, "bin", "hooks", "chatlog",
+                      "claude_code_precompact.sh").replace("\\", "/")
+    if sys.platform == "win32":
+        hook_cmd = f"powershell -NoProfile -ExecutionPolicy Bypass -File {ps1}"
+    else:
+        hook_cmd = f"/bin/sh {sh}"
+    cc = config.host_agents.get("claude-code")
+    stop_enabled = bool(cc and cc.stop_hook)
+    return hook_cmd, stop_enabled
+
+
+def _build_claude_settings_patch(config: ChatlogConfig) -> dict:
+    """Construct just the hooks + statusLine fields we want to merge in."""
+    hook_cmd, stop_enabled = _build_claude_hook_command(config)
+    hooks_block: dict = {
+        "PreCompact": [{"hooks": [{"type": "command", "command": hook_cmd}]}],
+    }
+    if stop_enabled:
+        hooks_block["Stop"] = [{"hooks": [{"type": "command", "command": hook_cmd}]}]
+    status_script = os.path.join(BASE_DIR, "bin", "chatlog_status_line.py").replace("\\", "/")
+    return {
+        "hooks": hooks_block,
+        "statusLine": {"type": "command", "command": f"python {status_script}"},
+    }
+
+
+def apply_claude_settings(config: ChatlogConfig) -> tuple[bool, str]:
+    """Merge chatlog hooks into ~/.claude/settings.json. Idempotent.
+
+    Creates the file if missing. If hooks.PreCompact / hooks.Stop / statusLine
+    already contain entries, we ONLY add our entry when no existing command
+    contains 'chatlog' — this preserves user-authored hooks and avoids
+    duplicate-firing on re-runs.
+
+    Writes a timestamped backup before the first modification so users can
+    revert. Returns (changed, message).
+    """
+    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict = {}
+    if settings_path.is_file():
+        try:
+            existing = json.loads(settings_path.read_text(encoding="utf-8")) or {}
+        except json.JSONDecodeError as e:
+            return False, f"refused to edit {settings_path}: unparseable JSON ({e}). Fix or remove and re-run."
+
+    patch = _build_claude_settings_patch(config)
+    our_cmd = patch["hooks"]["PreCompact"][0]["hooks"][0]["command"]
+
+    def _chatlog_entry_present(hook_entries: list) -> bool:
+        return any(
+            "chatlog" in json.dumps(e).lower() for e in (hook_entries or [])
+        )
+
+    hooks = existing.setdefault("hooks", {})
+    changed = False
+
+    for event, patch_entry in patch["hooks"].items():
+        current = hooks.get(event) or []
+        if _chatlog_entry_present(current):
+            continue  # idempotent — our entry (or an equivalent) already there
+        current.extend(patch_entry)
+        hooks[event] = current
+        changed = True
+
+    # statusLine is a single object, not a list. Only overwrite if missing
+    # or currently chatlog-owned. Respect a user-set custom statusLine.
+    sl = existing.get("statusLine")
+    if not isinstance(sl, dict) or "chatlog" in json.dumps(sl).lower():
+        if existing.get("statusLine") != patch["statusLine"]:
+            existing["statusLine"] = patch["statusLine"]
+            changed = True
+
+    if not changed:
+        return False, f"no change — chatlog entries already present in {settings_path}"
+
+    # Backup before write.
+    if settings_path.is_file():
+        stamp = datetime.now().strftime("%Y%m%dT%H%M%SZ")
+        backup = settings_path.with_suffix(f".json.bak.{stamp}")
+        backup.write_text(settings_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    events = ", ".join(patch["hooks"].keys())
+    return True, f"merged chatlog hooks ({events}) + statusLine into {settings_path}"
+
+
+def apply_gemini_settings() -> tuple[bool, str]:
+    """Merge the SessionEnd hook into ~/.gemini/settings.json. Idempotent.
+
+    Assumes the `memory` MCP entry is written by install-m3's post-install;
+    this function only handles the hook. Refuses to touch an unparseable
+    settings.json. Returns (changed, message).
+    """
+    settings_path = Path.home() / ".gemini" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict = {}
+    if settings_path.is_file():
+        try:
+            existing = json.loads(settings_path.read_text(encoding="utf-8")) or {}
+        except json.JSONDecodeError as e:
+            return False, f"refused to edit {settings_path}: unparseable JSON ({e})"
+
+    sh = os.path.join(BASE_DIR, "bin", "hooks", "chatlog",
+                      "gemini_cli_onexit.sh").replace("\\", "/")
+    ps1 = os.path.join(BASE_DIR, "bin", "hooks", "chatlog",
+                       "gemini_cli_onexit.ps1").replace("\\", "/")
+    if sys.platform == "win32":
+        hook_cmd = f"powershell -NoProfile -ExecutionPolicy Bypass -File {ps1}"
+    else:
+        hook_cmd = f"/bin/sh {sh}"
+
+    hooks = existing.setdefault("hooks", {})
+    session_end = hooks.get("SessionEnd") or []
+    already = any("chatlog" in json.dumps(e).lower() for e in session_end)
+    if already:
+        return False, f"no change — SessionEnd chatlog hook already present in {settings_path}"
+
+    session_end.append({"hooks": [{"type": "command", "command": hook_cmd}]})
+    hooks["SessionEnd"] = session_end
+
+    if settings_path.is_file():
+        stamp = datetime.now().strftime("%Y%m%dT%H%M%SZ")
+        backup = settings_path.with_suffix(f".json.bak.{stamp}")
+        backup.write_text(settings_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    return True, f"added SessionEnd chatlog hook to {settings_path}"
+
+
 def show_claude_code_settings_snippet(config: ChatlogConfig) -> None:
     """Print the hooks + statusLine snippet for ~/.claude/settings.json.
 
@@ -419,6 +557,34 @@ def main() -> int:
         action="store_true",
         help="Disable the Stop hook (revert to PreCompact-only capture).",
     )
+    parser.add_argument(
+        "--apply-claude",
+        action="store_true",
+        help=(
+            "Merge chatlog hooks + statusLine into ~/.claude/settings.json "
+            "(creates the file if missing, backs up before writing, idempotent). "
+            "Without this flag, init prints the snippet for manual paste."
+        ),
+    )
+    parser.add_argument(
+        "--apply-gemini",
+        action="store_true",
+        help=(
+            "Add the SessionEnd chatlog hook to ~/.gemini/settings.json "
+            "(idempotent, backs up before writing). Requires Gemini CLI to be "
+            "installed first; the memory MCP entry is written by install-m3."
+        ),
+    )
+    parser.add_argument(
+        "--capture-mode",
+        default=None,
+        choices=("both", "stop", "precompact", "none"),
+        help=(
+            "Configure Claude Code Stop-hook policy in non-interactive mode. "
+            "'both' / 'stop' enable the Stop hook; 'precompact' / 'none' leave "
+            "it disabled. Without this flag, non-interactive uses PreCompact-only."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -427,6 +593,23 @@ def main() -> int:
         return apply_stop_hook_toggle(enable=True)
     if args.disable_stop_hook:
         return apply_stop_hook_toggle(enable=False)
+
+    # Standalone settings.json writers — useful when chatlog is already
+    # configured and the user just wants the hooks wired. Doesn't modify
+    # the chatlog config; reads it.
+    if args.apply_claude or args.apply_gemini:
+        cfg = resolve_config() if os.path.exists(CONFIG_PATH) else ChatlogConfig(
+            db_path=DEFAULT_DB_PATH,
+            host_agents={a: HookSpec() for a in VALID_HOST_AGENTS},
+        )
+        rc = 0
+        if args.apply_claude:
+            changed, msg = apply_claude_settings(cfg)
+            print(("[+] " if changed else "[=] ") + msg)
+        if args.apply_gemini:
+            changed, msg = apply_gemini_settings()
+            print(("[+] " if changed else "[=] ") + msg)
+        return rc
 
     try:
         # Check if config exists
@@ -438,9 +621,16 @@ def main() -> int:
         if args.non_interactive:
             db_path = args.db_path or DEFAULT_DB_PATH
 
+            # Honor --capture-mode: 'both' or 'stop' turns on the Stop hook,
+            # everything else leaves it off. PreCompact is always implicit
+            # when the Claude hook is wired.
+            stop_hook = args.capture_mode in ("both", "stop")
+            host_agents = {a: HookSpec() for a in VALID_HOST_AGENTS}
+            host_agents["claude-code"] = HookSpec(stop_hook=stop_hook)
+
             config = ChatlogConfig(
                 db_path=db_path,
-                host_agents={a: HookSpec() for a in VALID_HOST_AGENTS},
+                host_agents=host_agents,
                 cost_tracking=CostTrackingSpec(enabled=True),
                 redaction=RedactionSpec(enabled=False),
                 embed_sweeper=EmbedSweeperSpec(),
@@ -463,6 +653,17 @@ def main() -> int:
                 print(f"Warning: migrations failed ({e}). Run manually with:")
                 print(f"  python {migrate_script} up --target chatlog -y")
                 # Don't fail the install — migrations can be retried.
+
+            # Optional: write the hook entries directly into the agent's
+            # settings.json instead of just printing the snippet. Skip silently
+            # if --capture-mode is 'none' since the user explicitly opted out.
+            if args.capture_mode != "none":
+                if args.apply_claude:
+                    changed, msg = apply_claude_settings(config)
+                    print(("[+] " if changed else "[=] ") + msg)
+                if args.apply_gemini:
+                    changed, msg = apply_gemini_settings()
+                    print(("[+] " if changed else "[=] ") + msg)
             return 0
 
         # Interactive mode

--- a/bin/chatlog_init.py
+++ b/bin/chatlog_init.py
@@ -447,6 +447,22 @@ def main() -> int:
             )
             save_config(config)
             print(f"Configuration saved to {CONFIG_PATH}")
+
+            # Run migrations even in non-interactive mode — without them the
+            # chatlog DB is an empty SQLite file and any hook fire will error
+            # with 'no such table: memory_items'. The prompt-skipping flag
+            # shouldn't mean a broken install.
+            migrate_script = os.path.join(BASE_DIR, "bin", "migrate_memory.py")
+            try:
+                subprocess.run(
+                    [sys.executable, migrate_script, "up", "--target", "chatlog", "-y"],
+                    check=True,
+                )
+                print("Migrations applied.")
+            except subprocess.CalledProcessError as e:
+                print(f"Warning: migrations failed ({e}). Run manually with:")
+                print(f"  python {migrate_script} up --target chatlog -y")
+                # Don't fail the install — migrations can be retried.
             return 0
 
         # Interactive mode

--- a/bin/chatlog_init.py
+++ b/bin/chatlog_init.py
@@ -320,7 +320,6 @@ def apply_claude_settings(config: ChatlogConfig) -> tuple[bool, str]:
             return False, f"refused to edit {settings_path}: unparseable JSON ({e}). Fix or remove and re-run."
 
     patch = _build_claude_settings_patch(config)
-    our_cmd = patch["hooks"]["PreCompact"][0]["hooks"][0]["command"]
 
     def _chatlog_entry_present(hook_entries: list) -> bool:
         return any(

--- a/bin/chatlog_init.py
+++ b/bin/chatlog_init.py
@@ -397,6 +397,18 @@ def apply_gemini_settings() -> tuple[bool, str]:
 
     actions: list[str] = []
 
+    # 0. Try to ensure ~/.npm-global/bin is on the non-login shell PATH.
+    #    Idempotent and safe even if already done by install-m3 (which
+    #    skips this when Gemini wasn't installed yet — common in the
+    #    Gemini-first install order).
+    try:
+        from m3_memory.installer import _fix_npm_global_path
+        path_msg = _fix_npm_global_path()
+        if path_msg and path_msg.startswith("[+]"):
+            actions.append("npm-global PATH")
+    except Exception:
+        pass  # best-effort; not blocking
+
     # 1. mcpServers.memory — points Gemini at the mcp-memory CLI.
     mcp_servers = existing.setdefault("mcpServers", {})
     if "memory" not in mcp_servers:

--- a/bin/hooks/chatlog/claude_code_precompact.sh
+++ b/bin/hooks/chatlog/claude_code_precompact.sh
@@ -17,11 +17,23 @@ if [ ! -f "$BASE/bin/chatlog_ingest.py" ]; then
     exit 1
 fi
 
+# Pick a python that has the chatlog_ingest deps (httpx, etc).
+# Priority:
+#   1. Repo-local venv at $BASE/.venv (dev checkouts)
+#   2. pipx venv for m3-memory (the pip-install path: ~/.local/pipx/venvs/m3-memory)
+#   3. Env override $M3_PYTHON (last resort for odd layouts)
+#   4. system python3 (works only if the host happens to have httpx installed)
 if [ -x "$BASE/.venv/bin/python" ]; then
     PY="$BASE/.venv/bin/python"
 elif [ -x "$BASE/.venv/Scripts/python.exe" ]; then
     # Support Windows Git Bash / Cygwin paths
     PY="$BASE/.venv/Scripts/python.exe"
+elif [ -x "$HOME/.local/pipx/venvs/m3-memory/bin/python" ]; then
+    PY="$HOME/.local/pipx/venvs/m3-memory/bin/python"
+elif [ -x "$HOME/.local/pipx/venvs/m3-memory/Scripts/python.exe" ]; then
+    PY="$HOME/.local/pipx/venvs/m3-memory/Scripts/python.exe"
+elif [ -n "$M3_PYTHON" ] && [ -x "$M3_PYTHON" ]; then
+    PY="$M3_PYTHON"
 else
     PY="python3"
 fi

--- a/bin/hooks/chatlog/gemini_cli_onexit.sh
+++ b/bin/hooks/chatlog/gemini_cli_onexit.sh
@@ -18,11 +18,18 @@ if [ ! -f "$BASE/bin/chatlog_ingest.py" ]; then
     exit 1
 fi
 
+# See claude_code_precompact.sh for the rationale behind this fallback order.
 if [ -x "$BASE/.venv/bin/python" ]; then
     PY="$BASE/.venv/bin/python"
 elif [ -x "$BASE/.venv/Scripts/python.exe" ]; then
     # Support Windows Git Bash / Cygwin paths
     PY="$BASE/.venv/Scripts/python.exe"
+elif [ -x "$HOME/.local/pipx/venvs/m3-memory/bin/python" ]; then
+    PY="$HOME/.local/pipx/venvs/m3-memory/bin/python"
+elif [ -x "$HOME/.local/pipx/venvs/m3-memory/Scripts/python.exe" ]; then
+    PY="$HOME/.local/pipx/venvs/m3-memory/Scripts/python.exe"
+elif [ -n "$M3_PYTHON" ] && [ -x "$M3_PYTHON" ]; then
+    PY="$M3_PYTHON"
 else
     PY="python3"
 fi

--- a/bin/llm_failover.py
+++ b/bin/llm_failover.py
@@ -15,12 +15,18 @@ import httpx
 
 logger = logging.getLogger("llm_failover")
 
-# Failover order — LM Studio (OpenAI-compat on :1234), Ollama (:11434 via /v1 compat)
-# Default: single-machine setup (localhost only).
+# Failover order — LM Studio (OpenAI-compat on :1234), Ollama (:11434 via /v1 compat).
+# Both localhost endpoints are probed in order; unreachable ones are skipped
+# gracefully by get_best_llm / get_best_embed (they continue on ConnectError).
+# This keeps Ollama-only users working out of the box — the prior LM-Studio-only
+# default required LLM_ENDPOINTS_CSV to be set by hand before Ollama could be
+# reached (see plan memory 776d3729 task #6).
+#
 # For multi-machine LAN failover, set LLM_ENDPOINTS_CSV env var, e.g.:
 #   LLM_ENDPOINTS_CSV="http://localhost:1234/v1,http://laptop.local:1234/v1,http://desktop.local:1234/v1"
 _DEFAULT_LLM_ENDPOINTS = [
     "http://localhost:1234/v1",
+    "http://localhost:11434/v1",
 ]
 
 _endpoints_csv = os.environ.get("LLM_ENDPOINTS_CSV", "").strip()
@@ -34,7 +40,12 @@ EMBED_EXCLUSIONS = ("embed", "nomic", "jina", "bge", "minilm", "e5")
 LLM_EXCLUSIONS = ()  # nothing excluded for LLM selection — embedding models filtered
 
 # Timeouts
-CONNECT_TIMEOUT = 3.0    # fail fast on unreachable hosts
+# Connect timeout is deliberately short: the default endpoint list now includes
+# both LM Studio (:1234) and Ollama (:11434). Single-provider users pay the
+# connect timeout once per probe for the absent one, so fast-fail is important.
+# On a loopback connection refused comes back in <1ms anyway; this mainly
+# caps remote LAN endpoints set via LLM_ENDPOINTS_CSV.
+CONNECT_TIMEOUT = 1.0
 READ_TIMEOUT = 10.0      # for model list fetches only
 
 # Process-global cache for embed-endpoint discovery. Discovered once on first

--- a/m3_memory/__init__.py
+++ b/m3_memory/__init__.py
@@ -5,6 +5,6 @@ M3 Memory — Local-first agentic memory layer for MCP agents.
 Bitemporal history · GDPR Article 17/20 · Cross-device sync · 100% local
 """
 
-__version__ = "2026.4.24.5"
+__version__ = "2026.4.24.6"
 __author__ = "skynetcmd, Gemini CLI"
 __license__ = "Apache-2.0"

--- a/m3_memory/cli.py
+++ b/m3_memory/cli.py
@@ -20,7 +20,6 @@ import os
 import sys
 from pathlib import Path  # noqa: F401 - used in _auto_install return-type comment
 
-
 # On Windows the default console code page is cp1252, which can't encode
 # characters outside that 8-bit range (em-dashes, arrows, box-drawing,
 # checkmarks, most non-Latin scripts). Any accidental non-ASCII in a
@@ -92,7 +91,7 @@ def _run_bridge() -> None:
     giving up. See `_auto_install` for interactive vs non-interactive
     semantics.
     """
-    from m3_memory.installer import find_bridge, config_file
+    from m3_memory.installer import config_file, find_bridge
 
     bridge = find_bridge()
     if bridge is None:
@@ -236,7 +235,6 @@ def _cmd_chatlog(args: argparse.Namespace) -> int:
             return 1
         import json as _json
         import runpy
-        import io
         bin_dir = str(script.parent)
         if bin_dir not in sys.path:
             sys.path.insert(0, bin_dir)

--- a/m3_memory/cli.py
+++ b/m3_memory/cli.py
@@ -131,7 +131,13 @@ def _run_bridge() -> None:
 def _cmd_install_m3(args: argparse.Namespace) -> int:
     from m3_memory.installer import install_m3
     try:
-        install_m3(force=args.force, tag=args.tag)
+        install_m3(
+            force=args.force,
+            tag=args.tag,
+            interactive=(False if args.non_interactive else None),
+            endpoint=args.endpoint,
+            capture_mode=args.capture_mode,
+        )
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -297,6 +303,18 @@ Docs: https://github.com/skynetcmd/m3-memory
     p_install.add_argument(
         "--tag", default=None,
         help=f"Override the GitHub tag to fetch (default: v{__version__}).",
+    )
+    p_install.add_argument(
+        "--non-interactive", action="store_true",
+        help="Skip endpoint + capture-mode prompts; use defaults (probe both endpoints; both hooks).",
+    )
+    p_install.add_argument(
+        "--endpoint", default=None, metavar="URL",
+        help="Pin LLM_ENDPOINTS_CSV to this URL (skips the endpoint prompt).",
+    )
+    p_install.add_argument(
+        "--capture-mode", default=None, choices=("both", "stop", "precompact", "none"),
+        help="Chatlog capture hooks to enable (skips the capture-mode prompt).",
     )
     p_install.set_defaults(func=_cmd_install_m3)
 

--- a/m3_memory/cli.py
+++ b/m3_memory/cli.py
@@ -159,6 +159,96 @@ def _cmd_doctor(_args: argparse.Namespace) -> int:
     return doctor()
 
 
+def _resolve_bin_script(name: str) -> "Path | None":
+    """Find bin/<name> relative to the resolved bridge (installed or dev).
+
+    Returns an absolute Path or None if no bridge is resolvable (meaning
+    install-m3 hasn't run and we're not in a dev checkout either).
+    """
+    from m3_memory.installer import find_bridge
+    bridge = find_bridge()
+    if bridge is None:
+        return None
+    candidate = bridge.parent / name
+    return candidate if candidate.is_file() else None
+
+
+def _run_bin_script(script_name: str, argv: list) -> int:
+    """Execute bin/<script_name> as __main__ with the given argv.
+
+    Uses runpy so the script's own argparse handles its flags unchanged.
+    sys.argv is rewritten for the duration of the call so the script sees
+    its own name in argv[0] (what it would see when invoked directly).
+    """
+    import runpy
+
+    script = _resolve_bin_script(script_name)
+    if script is None:
+        print(
+            f"Error: {script_name} not found.\n"
+            "Run `mcp-memory install-m3` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Put bin/ on sys.path so the script's sibling imports (chatlog_config,
+    # m3_sdk, ...) resolve the same way they do when invoked directly.
+    bin_dir = str(script.parent)
+    if bin_dir not in sys.path:
+        sys.path.insert(0, bin_dir)
+
+    saved_argv = sys.argv
+    sys.argv = [str(script)] + list(argv)
+    try:
+        try:
+            runpy.run_path(str(script), run_name="__main__")
+            return 0
+        except SystemExit as e:
+            # argparse / main() calls sys.exit — propagate the code.
+            code = e.code
+            return int(code) if isinstance(code, int) else (0 if code is None else 1)
+    finally:
+        sys.argv = saved_argv
+
+
+def _cmd_chatlog(args: argparse.Namespace) -> int:
+    """Dispatch `mcp-memory chatlog <init|status|doctor>` to bin/ scripts."""
+    sub = args.chatlog_cmd
+    if sub is None:
+        # No subcommand given → show status by default (matches `doctor` ergonomics).
+        return _run_bin_script("chatlog_status.py", [])
+    if sub == "init":
+        return _run_bin_script("chatlog_init.py", args.rest)
+    if sub == "status":
+        return _run_bin_script("chatlog_status.py", args.rest)
+    if sub == "doctor":
+        # `doctor` = status + nonzero exit if the subsystem reports warnings.
+        # Implemented inline so we can inspect the JSON output without forking.
+        script = _resolve_bin_script("chatlog_status.py")
+        if script is None:
+            print("Error: chatlog_status.py not found. Run `mcp-memory install-m3`.", file=sys.stderr)
+            return 1
+        import json as _json
+        import runpy
+        import io
+        bin_dir = str(script.parent)
+        if bin_dir not in sys.path:
+            sys.path.insert(0, bin_dir)
+        # Call the impl directly for clean JSON, bypassing the CLI formatter.
+        mod = runpy.run_path(str(script), run_name="_chatlog_status_mod")
+        data = _json.loads(mod["chatlog_status_impl"]())
+        warnings = data.get("warnings") or []
+        # Reuse the human-readable table formatter for output.
+        print(mod["_format_table"](data))
+        if warnings:
+            print(f"\n[X] {len(warnings)} warning(s) — see above.", file=sys.stderr)
+            return 1
+        print("\n[OK] chatlog healthy.")
+        return 0
+    print(f"Error: unknown chatlog subcommand {sub!r}", file=sys.stderr)
+    return 2
+
+
 def main() -> None:
     from m3_memory import __version__
 
@@ -236,7 +326,28 @@ Docs: https://github.com/skynetcmd/m3-memory
     )
     p_doctor.set_defaults(func=_cmd_doctor)
 
-    args = parser.parse_args()
+    p_chatlog = subparsers.add_parser(
+        "chatlog",
+        help="Manage the chatlog subsystem (init|status|doctor).",
+    )
+    chatlog_sub = p_chatlog.add_subparsers(dest="chatlog_cmd", metavar="<subcommand>")
+    # Declare the subcommands so help lists them, but accept no flags here —
+    # we use parse_known_args below to collect everything after `chatlog <sub>`
+    # and forward it verbatim to the underlying bin/ script.
+    chatlog_sub.add_parser("init",   help="Interactive setup — wire hooks, choose DB path, configure redaction.", add_help=False)
+    chatlog_sub.add_parser("status", help="Print a summary of chatlog state (row counts, queue, hooks).",         add_help=False)
+    chatlog_sub.add_parser("doctor", help="Same as status, but exits nonzero on warnings.",                       add_help=False)
+    p_chatlog.set_defaults(func=_cmd_chatlog)
+
+    # Use parse_known_args so flags after `chatlog <sub>` (e.g. --non-interactive,
+    # --reconfigure, --json) aren't fought over by the outer parser — they're
+    # passed through to the child script. args.rest carries them.
+    args, extras = parser.parse_known_args()
+    if getattr(args, "command", None) == "chatlog":
+        args.rest = extras
+    elif extras:
+        # For any other subcommand, unknown flags are genuine errors.
+        parser.error(f"unrecognized arguments: {' '.join(extras)}")
 
     if args.command is None:
         # Bare `mcp-memory` → run the bridge (unchanged default behavior).

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -368,13 +368,35 @@ def _prompt_capture_mode(interactive: bool, capture_flag: Optional[str]) -> Opti
     return {"1": "both", "2": "precompact", "3": "stop", "4": "none"}.get(reply)
 
 
-def _run_chatlog_init(bridge: Path, capture_mode: str) -> Optional[str]:
-    """Run `chatlog_init.py --non-interactive --apply-claude --apply-gemini` so
-    the user's chatlog choice actually takes effect. Without this, capture_mode
-    persists in config but no settings.json is written and no migrations run.
+def _chatlog_init_supports(chatlog_init: Path, flag: str) -> bool:
+    """Probe whether bin/chatlog_init.py advertises a given flag.
 
-    Returns a status message for the post-install summary, or None on failure
-    (logged separately so the install still completes).
+    Needed because install-m3 can fetch a tarball whose bin/ predates the
+    flags we want to pass — that combination ships in any release where
+    the wheel rolls forward before the tag does, or when a user installs
+    the latest wheel against a pinned older tag. Falling back gracefully
+    is better than failing the install with 'unrecognized arguments'.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, str(chatlog_init), "--help"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return flag in (result.stdout or "")
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _run_chatlog_init(bridge: Path, capture_mode: str) -> Optional[str]:
+    """Run `chatlog_init.py --non-interactive ...` to actualize capture_mode.
+
+    Without this, capture_mode persists in config but no settings.json is
+    written and no migrations run. We adapt the flag set to whatever
+    chatlog_init in the fetched repo supports, so wheel-vs-tag version skew
+    degrades gracefully rather than failing 'unrecognized arguments'.
+
+    Returns a status message for the post-install summary, or None on
+    failure (logged separately so the install still completes).
     """
     if capture_mode == "none":
         return "[=] chatlog hooks skipped (capture-mode=none)"
@@ -383,28 +405,47 @@ def _run_chatlog_init(bridge: Path, capture_mode: str) -> Optional[str]:
     if not chatlog_init.is_file():
         return f"[!] chatlog_init.py missing under {bridge.parent}; skipping hook wiring"
 
-    cmd = [
-        sys.executable, str(chatlog_init),
-        "--non-interactive",
-        "--capture-mode", capture_mode,
-        "--apply-claude",
-    ]
-    # Wire Gemini hooks too if Gemini CLI is on PATH (or at the npm-global
-    # location) — same detection used by _register_gemini_mcp.
-    if shutil.which("gemini") or (Path.home() / ".npm-global" / "bin" / "gemini").exists():
+    cmd = [sys.executable, str(chatlog_init), "--non-interactive"]
+
+    # Probe each new flag. If the deployed chatlog_init is older than the
+    # wheel, we still get migrations + a saved config (legacy behavior),
+    # then fall back to printing manual-paste instructions.
+    has_capture_mode = _chatlog_init_supports(chatlog_init, "--capture-mode")
+    has_apply_claude = _chatlog_init_supports(chatlog_init, "--apply-claude")
+    has_apply_gemini = _chatlog_init_supports(chatlog_init, "--apply-gemini")
+
+    if has_capture_mode:
+        cmd += ["--capture-mode", capture_mode]
+    if has_apply_claude:
+        cmd.append("--apply-claude")
+    gemini_present = (
+        shutil.which("gemini")
+        or (Path.home() / ".npm-global" / "bin" / "gemini").exists()
+    )
+    if has_apply_gemini and gemini_present:
         cmd.append("--apply-gemini")
 
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        # chatlog_init prints multiple lines; take the last non-empty line as
-        # the summary so the post-install log stays compact.
-        lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
-        tail = lines[-1] if lines else "configured"
-        return f"[+] chatlog wired ({capture_mode}): {tail}"
     except subprocess.CalledProcessError as e:
-        # Don't abort the install — surface the error and let the user re-run.
-        stderr = (e.stderr or "").strip() or "(no stderr)"
-        return f"[!] chatlog init failed: {stderr.splitlines()[-1] if stderr else e}"
+        stderr = (e.stderr or "").strip()
+        last = stderr.splitlines()[-1] if stderr else str(e)
+        return f"[!] chatlog init failed: {last}"
+
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    tail = lines[-1] if lines else "configured"
+
+    # Old chatlog_init that lacks --apply-* flags only saved config + ran
+    # migrations. Tell the user to do the rest by hand so they don't think
+    # the install is finished.
+    if not has_apply_claude:
+        return (
+            f"[~] chatlog config + migrations applied (capture-mode={capture_mode}); "
+            f"settings.json wiring requires manual paste — run "
+            f"`mcp-memory chatlog init --enable-stop-hook` and follow the snippet, "
+            f"or `mcp-memory update` once the next release ships."
+        )
+    return f"[+] chatlog wired ({capture_mode}): {tail}"
 
 
 def _post_install(

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -600,18 +600,26 @@ def _claude_hook_state() -> dict:
 
 
 def _gemini_hook_state() -> dict:
-    """Detect MCP registration in ~/.gemini/settings.json.
+    """Detect MCP registration + SessionEnd hook in ~/.gemini/settings.json.
 
-    Gemini CLI has no Stop/PreCompact equivalent; chatlog capture for
-    Gemini flows through the MCP tool (chatlog_write) on assistant turns.
-    So "hook state" for Gemini really means "is the MCP registered so
-    the tool is callable at all."
+    Gemini CLI uses a single SessionEnd hook (no Stop/PreCompact split).
+    Capture works when (a) the memory MCP is registered so in-session
+    tool calls work and (b) the SessionEnd hook runs chatlog_ingest on exit.
     """
     settings = _read_json(Path.home() / ".gemini" / "settings.json")
     if settings is None:
         return {"configured": False}
     mcp = (settings.get("mcpServers") or {})
-    return {"configured": True, "memory_mcp": "memory" in mcp}
+    hooks = settings.get("hooks") or {}
+    session_end = any(
+        "chatlog" in json.dumps(h).lower()
+        for h in (hooks.get("SessionEnd") or [])
+    )
+    return {
+        "configured": True,
+        "memory_mcp": "memory" in mcp,
+        "session_end": session_end,
+    }
 
 
 def _chatlog_section(cfg: dict) -> int:
@@ -648,7 +656,8 @@ def _chatlog_section(cfg: dict) -> int:
         print("  gemini mcp:              ~/.gemini/settings.json not found")
     else:
         mcp_mark = "[on]" if gemini["memory_mcp"] else "[off]"
-        print(f"  gemini mcp (memory):     {mcp_mark}  (no Stop/PreCompact hooks on Gemini)")
+        se_mark = "[on]" if gemini["session_end"] else "[off]"
+        print(f"  gemini mcp (memory):     {mcp_mark}  SessionEnd {se_mark}")
     return 0
 
 

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
 import sqlite3
 import subprocess
@@ -201,12 +202,229 @@ def _download_tarball(tag: str, dest: Path) -> None:
         shutil.move(str(top_level[0]), str(dest))
 
 
-def install_m3(repo_path: Optional[Path] = None, tag: Optional[str] = None, force: bool = False) -> Path:
+# ───────── post-install helpers (tasks #8–#11 in plan memory 776d3729) ─────────
+
+def _register_gemini_mcp() -> Optional[str]:
+    """Write a `memory` MCP entry to ~/.gemini/settings.json if Gemini CLI exists.
+
+    Idempotent: leaves an existing `memory` entry untouched. Returns a short
+    status string for user-facing logging, or None if Gemini CLI isn't on PATH
+    (in which case we stay quiet — not every install has Gemini).
+    """
+    gemini_bin = shutil.which("gemini")
+    if not gemini_bin:
+        # Also check the common non-interactive npm-global path (which may not
+        # be on PATH yet — see _fix_npm_global_path below).
+        npm_candidate = Path.home() / ".npm-global" / "bin" / "gemini"
+        if not npm_candidate.exists():
+            return None
+
+    settings_dir = Path.home() / ".gemini"
+    settings_file = settings_dir / "settings.json"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+
+    existing: dict = {}
+    if settings_file.is_file():
+        try:
+            existing = json.loads(settings_file.read_text(encoding="utf-8")) or {}
+        except (OSError, json.JSONDecodeError):
+            # Refuse to clobber a file we can't parse — user may have hand-edited.
+            return f"[!] {settings_file} is unreadable; skipping Gemini MCP registration"
+
+    mcp_servers = existing.setdefault("mcpServers", {})
+    if "memory" in mcp_servers:
+        return f"[=] Gemini MCP 'memory' already registered in {settings_file}"
+
+    mcp_servers["memory"] = {"command": "mcp-memory"}
+    settings_file.write_text(
+        json.dumps(existing, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return f"[+] registered 'memory' MCP in {settings_file}"
+
+
+def _sqlite3_cli_hint() -> Optional[str]:
+    """Return a per-OS install instruction if the `sqlite3` CLI is missing.
+
+    Returns None if the CLI is already on PATH (no action needed).
+    Purely advisory — we don't run sudo commands on the user's behalf.
+    """
+    if shutil.which("sqlite3"):
+        return None
+
+    system = platform.system()
+    if system == "Linux":
+        # Try /etc/os-release for the package manager.
+        distro = ""
+        try:
+            for line in Path("/etc/os-release").read_text().splitlines():
+                if line.startswith("ID="):
+                    distro = line.split("=", 1)[1].strip().strip('"')
+                    break
+        except OSError:
+            pass
+        if distro in ("debian", "ubuntu", "linuxmint", "pop"):
+            cmd = "sudo apt install -y sqlite3"
+        elif distro in ("fedora", "rhel", "centos", "rocky", "almalinux"):
+            cmd = "sudo dnf install -y sqlite"
+        elif distro in ("arch", "manjaro"):
+            cmd = "sudo pacman -S sqlite"
+        else:
+            cmd = "install `sqlite3` with your package manager"
+        return f"[!] `sqlite3` CLI not found -{cmd}"
+    if system == "Darwin":
+        # macOS ships sqlite3 in /usr/bin; if absent something's unusual.
+        return "[!] `sqlite3` CLI not found (unexpected on macOS) — `brew install sqlite`"
+    if system == "Windows":
+        return "[!] `sqlite3` CLI not found -`winget install SQLite.SQLite` or download sqlite-tools from https://sqlite.org/download.html"
+    return "[!] `sqlite3` CLI not found; install it for ad-hoc DB inspection"
+
+
+def _fix_npm_global_path() -> Optional[str]:
+    """Append ~/.npm-global/bin to ~/.profile for non-interactive shells.
+
+    Interactive shells typically source ~/.bashrc; cron jobs, sshd non-login
+    shells, and most scripts read ~/.profile. Without this, `gemini` (and any
+    other npm-global binary) is missing from those contexts.
+
+    No-op on Windows (npm uses %APPDATA%\\npm which is added to user PATH by
+    the Node installer). Idempotent — checks for the exact export line first.
+    """
+    if platform.system() == "Windows":
+        return None
+    npm_bin = Path.home() / ".npm-global" / "bin"
+    if not npm_bin.exists():
+        return None
+
+    profile = Path.home() / ".profile"
+    marker = 'export PATH="$HOME/.npm-global/bin:$PATH"'
+    existing = ""
+    if profile.is_file():
+        try:
+            existing = profile.read_text(encoding="utf-8")
+        except OSError:
+            return f"[!] {profile} unreadable; add {marker!r} manually"
+    if marker in existing:
+        return f"[=] ~/.npm-global/bin already in {profile}"
+
+    suffix = "\n# Added by mcp-memory install-m3 (npm-global PATH for non-interactive shells)\n" + marker + "\n"
+    if existing and not existing.endswith("\n"):
+        suffix = "\n" + suffix
+    try:
+        with profile.open("a", encoding="utf-8") as f:
+            f.write(suffix)
+    except OSError as e:
+        return f"[!] could not write to {profile}: {e}"
+    return f"[+] appended npm-global PATH export to {profile}"
+
+
+def _prompt_endpoint_choice(interactive: bool, endpoint_flag: Optional[str]) -> Optional[str]:
+    """Ask which LLM endpoint to use; persist or return None to accept defaults.
+
+    Non-interactive + no flag: return None (caller stores nothing → llm_failover
+    probes both defaults). This mirrors the existing _auto_install ergonomics
+    in cli.py (quiet defaults when no TTY).
+    """
+    if endpoint_flag is not None:
+        return endpoint_flag
+    if not interactive:
+        return None
+    print("\nLLM endpoint to use for embedding + enrichment:")
+    print("  1) LM Studio (http://localhost:1234/v1)")
+    print("  2) Ollama    (http://localhost:11434/v1)")
+    print("  3) probe both at runtime (default)")
+    try:
+        reply = input("Choice [1/2/3]: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return None
+    if reply == "1":
+        return "http://localhost:1234/v1"
+    if reply == "2":
+        return "http://localhost:11434/v1"
+    return None
+
+
+def _prompt_capture_mode(interactive: bool, capture_flag: Optional[str]) -> Optional[str]:
+    """Ask which Claude-Code capture hooks to enable.
+
+    Values: 'both' | 'stop' | 'precompact' | 'none' | None (defer to chatlog_init
+    defaults). Non-interactive returns None unless --capture-mode was passed.
+    """
+    if capture_flag is not None:
+        return capture_flag
+    if not interactive:
+        return None
+    print("\nChatlog capture hooks (Claude Code):")
+    print("  1) both Stop + PreCompact (recommended — lossless capture)")
+    print("  2) PreCompact only (lower overhead)")
+    print("  3) Stop only")
+    print("  4) neither (skip hook setup; configure later with `mcp-memory chatlog init`)")
+    try:
+        reply = input("Choice [1/2/3/4, default 1]: ").strip() or "1"
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return None
+    return {"1": "both", "2": "precompact", "3": "stop", "4": "none"}.get(reply)
+
+
+def _post_install(
+    bridge: Path,
+    interactive: bool,
+    endpoint_choice: Optional[str],
+    capture_choice: Optional[str],
+) -> None:
+    """Run the additive post-install steps. Each step prints its own status.
+
+    All steps are best-effort: a failure is reported but does not abort the
+    install. install-m3's core job (repo on disk + config written) is already
+    done by the time we get here.
+    """
+    print()
+    print("post-install:")
+
+    for msg in (
+        _register_gemini_mcp(),
+        _sqlite3_cli_hint(),
+        _fix_npm_global_path(),
+    ):
+        if msg:
+            print(f"  {msg}")
+
+    # Persist user choices (if any) so llm_failover + chatlog_init can honor
+    # them on subsequent invocations.
+    cfg = load_config()
+    changed = False
+    if endpoint_choice is not None:
+        cfg["llm_endpoints_csv"] = endpoint_choice
+        os.environ.setdefault("LLM_ENDPOINTS_CSV", endpoint_choice)
+        print(f"  [+] pinned LLM endpoint: {endpoint_choice}")
+        changed = True
+    if capture_choice is not None:
+        cfg["chatlog_capture_mode"] = capture_choice
+        print(f"  [+] pinned chatlog capture mode: {capture_choice}")
+        changed = True
+    if changed:
+        save_config(cfg)
+
+
+def install_m3(
+    repo_path: Optional[Path] = None,
+    tag: Optional[str] = None,
+    force: bool = False,
+    interactive: Optional[bool] = None,
+    endpoint: Optional[str] = None,
+    capture_mode: Optional[str] = None,
+) -> Path:
     """Clone or download the m3-memory repo and record the bridge path in config.
 
     ``repo_path`` defaults to ``~/.m3-memory/repo``. ``tag`` defaults to
     ``v<m3_memory.__version__>`` so the cloned payload always matches the
     installed wheel. ``force=True`` wipes an existing clone before re-fetching.
+
+    ``interactive`` controls the post-install prompts (endpoint, capture mode).
+    ``None`` auto-detects via ``sys.stdin.isatty()``. ``endpoint`` and
+    ``capture_mode`` are explicit overrides that skip their respective prompts.
 
     Returns the resolved path to ``bin/memory_bridge.py``. Raises RuntimeError
     if neither git nor the tarball fallback can fetch the repo.
@@ -219,6 +437,14 @@ def install_m3(repo_path: Optional[Path] = None, tag: Optional[str] = None, forc
 
     if tag is None:
         tag = f"v{__version__}"
+
+    if interactive is None:
+        interactive = sys.stdin.isatty()
+
+    # Collect user choices BEFORE any slow network work so the prompt appears
+    # promptly and the clone/download doesn't block on input below.
+    endpoint_choice = _prompt_endpoint_choice(interactive, endpoint)
+    capture_choice = _prompt_capture_mode(interactive, capture_mode)
 
     if repo_path.exists():
         if not force:
@@ -251,6 +477,8 @@ def install_m3(repo_path: Optional[Path] = None, tag: Optional[str] = None, forc
     })
     print(f"[OK] installed. bridge_path = {bridge}")
     print(f"  config written to {config_file()}")
+
+    _post_install(bridge, interactive, endpoint_choice, capture_choice)
     return bridge
 
 

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -368,6 +368,45 @@ def _prompt_capture_mode(interactive: bool, capture_flag: Optional[str]) -> Opti
     return {"1": "both", "2": "precompact", "3": "stop", "4": "none"}.get(reply)
 
 
+def _run_chatlog_init(bridge: Path, capture_mode: str) -> Optional[str]:
+    """Run `chatlog_init.py --non-interactive --apply-claude --apply-gemini` so
+    the user's chatlog choice actually takes effect. Without this, capture_mode
+    persists in config but no settings.json is written and no migrations run.
+
+    Returns a status message for the post-install summary, or None on failure
+    (logged separately so the install still completes).
+    """
+    if capture_mode == "none":
+        return "[=] chatlog hooks skipped (capture-mode=none)"
+
+    chatlog_init = bridge.parent / "chatlog_init.py"
+    if not chatlog_init.is_file():
+        return f"[!] chatlog_init.py missing under {bridge.parent}; skipping hook wiring"
+
+    cmd = [
+        sys.executable, str(chatlog_init),
+        "--non-interactive",
+        "--capture-mode", capture_mode,
+        "--apply-claude",
+    ]
+    # Wire Gemini hooks too if Gemini CLI is on PATH (or at the npm-global
+    # location) — same detection used by _register_gemini_mcp.
+    if shutil.which("gemini") or (Path.home() / ".npm-global" / "bin" / "gemini").exists():
+        cmd.append("--apply-gemini")
+
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        # chatlog_init prints multiple lines; take the last non-empty line as
+        # the summary so the post-install log stays compact.
+        lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+        tail = lines[-1] if lines else "configured"
+        return f"[+] chatlog wired ({capture_mode}): {tail}"
+    except subprocess.CalledProcessError as e:
+        # Don't abort the install — surface the error and let the user re-run.
+        stderr = (e.stderr or "").strip() or "(no stderr)"
+        return f"[!] chatlog init failed: {stderr.splitlines()[-1] if stderr else e}"
+
+
 def _post_install(
     bridge: Path,
     interactive: bool,
@@ -403,6 +442,14 @@ def _post_install(
         changed = True
     if changed:
         save_config(cfg)
+
+    # Wire chatlog hooks into agent settings.json files when the user picked
+    # a capture mode. Skips silently when capture_choice is None (user accepted
+    # defaults and we don't auto-touch their agent configs without consent).
+    if capture_choice is not None:
+        chatlog_msg = _run_chatlog_init(bridge, capture_choice)
+        if chatlog_msg:
+            messages.append(chatlog_msg)
 
     if not messages:
         # Nothing to report — the three helpers all returned None and the
@@ -458,12 +505,28 @@ def install_m3(
     endpoint_choice = _prompt_endpoint_choice(interactive, endpoint)
     capture_choice = _prompt_capture_mode(interactive, capture_mode)
 
+    # Preserve user data across --force / update. The repo tree under
+    # repo_path/memory/ holds chatlog DBs, the chatlog config, and the
+    # migration-tracking schema_version table — wiping them on every update
+    # would discard captured turns and force a re-init. Stash anything that
+    # looks like user data, wipe the code tree, then restore.
+    preserved_dir: Optional[Path] = None
     if repo_path.exists():
         if not force:
             raise RuntimeError(
                 f"{repo_path} already exists. Run `mcp-memory install-m3 --force` to replace it, "
                 f"or `mcp-memory update` to refresh to the current wheel version."
             )
+        memory_dir = repo_path / "memory"
+        if memory_dir.is_dir():
+            preserved_dir = Path(tempfile.mkdtemp(prefix="m3-preserve-"))
+            for item in memory_dir.iterdir():
+                # Keep .db / .json (chatlog config + state) / .jsonl (cursor).
+                # The migrations/ subdir ships with the repo and will be
+                # restored by the new clone, so we don't preserve it.
+                if item.is_file() and item.suffix in (".db", ".json", ".jsonl"):
+                    shutil.copy2(item, preserved_dir / item.name)
+            print(f"  preserving {sum(1 for _ in preserved_dir.iterdir())} user-data file(s) across update")
         print(f"  removing existing {repo_path}")
         shutil.rmtree(repo_path)
 
@@ -479,6 +542,18 @@ def install_m3(
             f"tag {tag!r} doesn't exist on GitHub yet. Check "
             f"https://github.com/skynetcmd/m3-memory/releases."
         )
+
+    # Restore preserved user data on top of the fresh tree.
+    if preserved_dir is not None:
+        memory_dir = repo_path / "memory"
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        restored = 0
+        for item in preserved_dir.iterdir():
+            shutil.copy2(item, memory_dir / item.name)
+            restored += 1
+        shutil.rmtree(preserved_dir, ignore_errors=True)
+        if restored:
+            print(f"  restored {restored} user-data file(s) into {memory_dir}")
 
     save_config({
         "repo_path": str(repo_path),

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tarfile
@@ -279,6 +280,138 @@ def uninstall_m3(yes: bool = False) -> None:
         print(f"  removed {config_file()}")
 
 
+def _resolve_chatlog_db(cfg: dict) -> Optional[Path]:
+    """Best-effort resolution of the chatlog DB path.
+
+    Order: CHATLOG_DB_PATH env, M3_DATABASE env (shared DB case), config's
+    chatlog_db_path, else <repo_path>/memory/agent_chatlog.db.
+    Returns None only when no repo_path is configured AND no env override
+    is set — i.e. the system isn't installed yet.
+    """
+    env_chatlog = os.environ.get("CHATLOG_DB_PATH")
+    if env_chatlog:
+        return Path(env_chatlog).expanduser()
+    env_main = os.environ.get("M3_DATABASE")
+    if env_main:
+        return Path(env_main).expanduser()
+    cfg_chatlog = cfg.get("chatlog_db_path")
+    if cfg_chatlog:
+        return Path(cfg_chatlog).expanduser()
+    repo = cfg.get("repo_path")
+    if repo:
+        return Path(repo) / "memory" / "agent_chatlog.db"
+    # Developer case: `pip install -e .` from a repo clone. No config file,
+    # but the DB lives next to the sibling bridge we already resolve.
+    dev = _developer_bridge()
+    if dev:
+        return dev.parent.parent / "memory" / "agent_chatlog.db"
+    return None
+
+
+def _chatlog_db_stats(db_path: Path) -> dict:
+    """Open DB read-only, report row counts + last-capture timestamp.
+
+    Returns {ok, rows, last_at, error}. Uses stdlib sqlite3 only — no
+    dependency on the bin/ payload so doctor still works if the repo
+    clone is incomplete.
+    """
+    out = {"ok": False, "rows": 0, "last_at": "", "error": ""}
+    if not db_path.is_file():
+        out["error"] = "file not found"
+        return out
+    try:
+        uri = f"file:{db_path.as_posix()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+        try:
+            # Count rows the chatlog subsystem writes — types 'chat_log'
+            # and 'message'. Matches chatlog_status's totals so the two
+            # tools don't disagree.
+            row = conn.execute(
+                "SELECT COUNT(*), MAX(created_at) FROM memory_items "
+                "WHERE type IN ('chat_log', 'message')"
+            ).fetchone()
+            out["rows"] = row[0] or 0
+            out["last_at"] = row[1] or ""
+            out["ok"] = True
+        finally:
+            conn.close()
+    except sqlite3.OperationalError as e:
+        # Table may not exist yet (fresh install before first write).
+        out["error"] = str(e)
+    return out
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _claude_hook_state() -> dict:
+    """Detect Stop / PreCompact hooks in ~/.claude/settings.json."""
+    settings = _read_json(Path.home() / ".claude" / "settings.json")
+    if settings is None:
+        return {"configured": False}
+    hooks = settings.get("hooks") or {}
+    stop = any("chatlog" in json.dumps(h).lower() for h in (hooks.get("Stop") or []))
+    pre = any("chatlog" in json.dumps(h).lower() for h in (hooks.get("PreCompact") or []))
+    return {"configured": True, "stop": stop, "precompact": pre}
+
+
+def _gemini_hook_state() -> dict:
+    """Detect MCP registration in ~/.gemini/settings.json.
+
+    Gemini CLI has no Stop/PreCompact equivalent; chatlog capture for
+    Gemini flows through the MCP tool (chatlog_write) on assistant turns.
+    So "hook state" for Gemini really means "is the MCP registered so
+    the tool is callable at all."
+    """
+    settings = _read_json(Path.home() / ".gemini" / "settings.json")
+    if settings is None:
+        return {"configured": False}
+    mcp = (settings.get("mcpServers") or {})
+    return {"configured": True, "memory_mcp": "memory" in mcp}
+
+
+def _chatlog_section(cfg: dict) -> int:
+    """Emit the chatlog health section. Returns 0 (informational — never
+    the reason doctor exits nonzero)."""
+    print()
+    print("chatlog subsystem:")
+
+    db_path = _resolve_chatlog_db(cfg)
+    if db_path is None:
+        print("  db_path:                 (unresolved — install-m3 not run yet)")
+    else:
+        print(f"  db_path:                 {db_path}")
+        stats = _chatlog_db_stats(db_path)
+        if stats["ok"]:
+            last = stats["last_at"] or "(never)"
+            print(f"  captured rows:           {stats['rows']}")
+            print(f"  last capture at:         {last}")
+        elif stats["error"] == "file not found":
+            print("  status:                  db not yet created (no captures written)")
+        else:
+            print(f"  status:                  unreadable ({stats['error']})")
+
+    claude = _claude_hook_state()
+    if not claude["configured"]:
+        print("  claude hooks:            ~/.claude/settings.json not found")
+    else:
+        stop_mark = "[on]" if claude["stop"] else "[off]"
+        pre_mark = "[on]" if claude["precompact"] else "[off]"
+        print(f"  claude hooks:            Stop {stop_mark}  PreCompact {pre_mark}")
+
+    gemini = _gemini_hook_state()
+    if not gemini["configured"]:
+        print("  gemini mcp:              ~/.gemini/settings.json not found")
+    else:
+        mcp_mark = "[on]" if gemini["memory_mcp"] else "[off]"
+        print(f"  gemini mcp (memory):     {mcp_mark}  (no Stop/PreCompact hooks on Gemini)")
+    return 0
+
+
 def doctor() -> int:
     """Print diagnostic info and return 0 on healthy, 1 on missing payload."""
     from m3_memory import __version__
@@ -305,6 +438,8 @@ def doctor() -> int:
         print(f"developer sibling bridge:  {dev}")
     else:
         print("developer sibling bridge:  (not found)")
+
+    _chatlog_section(cfg)
 
     print()
     bridge = find_bridge()

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -380,32 +380,44 @@ def _post_install(
     install. install-m3's core job (repo on disk + config written) is already
     done by the time we get here.
     """
-    print()
-    print("post-install:")
-
-    for msg in (
-        _register_gemini_mcp(),
-        _sqlite3_cli_hint(),
-        _fix_npm_global_path(),
-    ):
-        if msg:
-            print(f"  {msg}")
-
-    # Persist user choices (if any) so llm_failover + chatlog_init can honor
-    # them on subsequent invocations.
+    # Collect all messages first so we can suppress the section entirely when
+    # nothing is actionable (every helper returning None = everything already
+    # fine, which is a common outcome on well-configured boxes).
+    messages = [
+        m for m in (
+            _register_gemini_mcp(),
+            _sqlite3_cli_hint(),
+            _fix_npm_global_path(),
+        ) if m
+    ]
     cfg = load_config()
     changed = False
     if endpoint_choice is not None:
         cfg["llm_endpoints_csv"] = endpoint_choice
         os.environ.setdefault("LLM_ENDPOINTS_CSV", endpoint_choice)
-        print(f"  [+] pinned LLM endpoint: {endpoint_choice}")
+        messages.append(f"[+] pinned LLM endpoint: {endpoint_choice}")
         changed = True
     if capture_choice is not None:
         cfg["chatlog_capture_mode"] = capture_choice
-        print(f"  [+] pinned chatlog capture mode: {capture_choice}")
+        messages.append(f"[+] pinned chatlog capture mode: {capture_choice}")
         changed = True
     if changed:
         save_config(cfg)
+
+    if not messages:
+        # Nothing to report — the three helpers all returned None and the
+        # user accepted silent defaults. Tell them what that means so the
+        # install doesn't end with silence that reads as "did it work?"
+        print()
+        print("post-install: no action needed (sqlite3 present, no Gemini CLI detected, no prompts).")
+        print("              run `mcp-memory doctor` anytime to re-check.")
+        return
+
+    print()
+    print("post-install:")
+    for msg in messages:
+        print(f"  {msg}")
+    print("  run `mcp-memory doctor` to re-check anytime.")
 
 
 def install_m3(

--- a/m3_memory/installer.py
+++ b/m3_memory/installer.py
@@ -620,7 +620,7 @@ def uninstall_m3(yes: bool = False) -> None:
         return
 
     if not yes:
-        print(f"will remove:")
+        print("will remove:")
         print(f"  {repo_path}")
         print(f"  {config_file()}")
         resp = input("proceed? [y/N] ").strip().lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.4.24.5"
+version = "2026.4.24.6"
 description = "Local-first persistent memory for MCP agents — 66 tools, 89% LongMemEval, hybrid search, GDPR, zero cloud"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

This sprint addresses the install UX issues catalogued in plan memory \`776d3729\` (the 2026-04-24 LXC fresh-install audit). Tasks #5–#12 from that plan are landed, plus 9 additional fixes surfaced by two real fresh-user audits on a clean Debian 12 LXC.

## What ships

### Sprint tasks (plan #5–#12)

- **#5** \`mcp-memory doctor\` reports chatlog health (DB path, captured rows, last-capture ts, per-AI hook state for Claude + Gemini)
- **#6** \`LLM_ENDPOINTS_CSV\` defaults probe both Ollama (:11434) and LM Studio (:1234) — fixes the silent-Ollama-failure case
- **#7** \`mcp-memory chatlog init|status|doctor\` subcommand wraps the previously-undiscoverable bin/chatlog_init.py
- **#8–#11** \`install-m3\` post-install phase: auto-register memory MCP with Gemini CLI, sqlite3 CLI hint, npm-global PATH fix in \`~/.profile\`, interactive prompts for endpoint + capture-mode (with \`--non-interactive\` / \`--endpoint\` / \`--capture-mode\` flags for CI)
- **#12** Top-level \`INSTALL.md\` with OS matrix (pip vs pipx per distro, sqlite3 install per OS)

### Audit-driven fixes (Claude-first ordering, m3test)

- Suppress empty \`post-install:\` header when nothing's actionable
- \`.gitattributes\` forces LF on \`*.sh\`/\`*.py\` (CRLF was breaking hooks on Linux)
- Hook scripts find pipx venv Python (\`~/.local/pipx/venvs/m3-memory/bin/python\`) — fixes \`ModuleNotFoundError: httpx\`
- \`chatlog init --non-interactive\` runs migrations (was creating an empty schema-less DB)
- \`chatlog_ingest\` parses Gemini CLI 0.39+ JSONL transcripts (parser previously expected single-JSON, dropped every Gemini session silently)
- Doctor reports Gemini SessionEnd hook state (was a static note)

### Follow-up fixes (Gemini-first ordering, m3test2)

- \`chatlog init --apply-claude\` / \`--apply-gemini\` write settings.json directly with idempotent merge + timestamped backup (replaces print-snippet-for-paste)
- \`install-m3\` auto-invokes \`chatlog init\` with these flags when user picks a capture-mode → one-shot install wires hooks end-to-end
- \`install-m3 --force\` preserves \`*.db\`/\`*.json\`/\`*.jsonl\` from \`repo/memory/\` across the wipe (chatlog DB no longer lost on update)
- README leads with pipx for PEP 668 distros
- INSTALL.md gains a \"Gemini CLI gotchas\" section (\`--skip-trust\` for headless contexts)
- \`apply-gemini\` covers MCP entry + auth method + SessionEnd hook + npm-global PATH (handles Gemini-installed-after-m3 ordering)
- install-m3 probes \`chatlog_init --help\` and degrades gracefully when fetched bin/ predates the new flags (handles wheel-vs-tag version skew)

## Verified end-to-end

Both audits — Claude-first (m3test) and Gemini-first (m3test2) — produce an identical final state on a fresh Debian 12 LXC user:

\`\`\`
chatlog subsystem:
  captured rows:           52
  claude hooks:            Stop [on]  PreCompact [on]
  gemini mcp (memory):     [on]  SessionEnd [on]
\`\`\`

Live queries from both Claude Code and Gemini CLI captured to chatlog DB. Hooks fire on session exit. Doctor accurately reports state.

## Test plan

- [ ] \`python -m pytest tests/test_installer.py -q\` — 20/20 passing locally
- [ ] On a clean Linux box: \`pipx install m3-memory && mcp-memory install-m3 --non-interactive --capture-mode both\` — should land config, run migrations, write Claude settings.json, write Gemini settings.json (if Gemini installed)
- [ ] \`mcp-memory doctor\` — chatlog section accurately reports DB state + per-agent hook state
- [ ] \`mcp-memory install-m3 --force\` after capturing some chatlog rows — DB survives the wipe
- [ ] On Windows: hook scripts ship with LF (no CRLF regression), \`mcp-memory chatlog status\` works end-to-end

## Commits

17 commits on this branch. Full audit reports + commit list in \`.scratch/lxc100_audit_20260424/\` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)