### PR TITLE
Add SafeSkill security badge (30/100 — Blocked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Persistent, local memory for MCP agents.
   <img alt="macOS" src="https://img.shields.io/badge/macOS-000000?style=flat-square&logo=apple&logoColor=white">
   <img alt="Windows" src="https://img.shields.io/badge/Windows-0078D4?style=flat-square&logo=windows&logoColor=white">
   <img alt="Linux" src="https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black">
+[![SafeSkill 30/100](https://img.shields.io/badge/SafeSkill-30%2F100_Blocked-red)](https://safeskill.dev/scan/skynetcmd-m3-memory)
 </p>
 
 Works with Claude Code, Gemini CLI, Aider, OpenCode, and any MCP-compatible agent. Quick one-line command to have your agent install chat log sub-system which saves verbatim chat log info, before compaction, with zero lag/latency and 100% retrieval recall. Just tell your AI agent "install m3-memory chat log sub-system" and your agent will automatically install it with all the proper hooks with some minimal customization questions from you (you can accept the default answers).


### PR DESCRIPTION
## 🔴 SafeSkill Security Scan Results

| Metric | Value |
|:-------|:------|
| **Overall Score** | **30/100** (Blocked) |
| Code Score | 99/100 |
| Content Score | 47/100 |
| Findings | 84 findings detected (6 critical) |
| Taint Flows | 0 |
| Files Scanned | 4 |
| Scan Duration | 0.9s |

### Top Findings

- 🔴 **critical**: Tool/shell abuse instruction detected (dotfile-modification): "echo 'export POSTGRES_SERVER="YOUR_SERVER_IP"' >> ~/.bashrc" (`docs/install_linux_homelab.md:121`)
- 🔴 **critical**: Tool/shell abuse instruction detected (dotfile-modification): "echo 'export CHROMA_BASE_URL="http://YOUR_SERVER_IP:8000"' >> ~/.bashrc" (`docs/install_linux_homelab.md:122`)
- 🔴 **critical**: Tool/shell abuse instruction detected (dotfile-modification): "echo 'eval "$(fnm env --use-on-cd)"' >> ~/.bashrc" (`docs/install_linux_homelab.md:221`)
- 🔴 **critical**: Tool/shell abuse instruction detected (dotfile-modification): "echo 'export POSTGRES_SERVER="YOUR_SERVER_IP"' >> ~/.zshrc" (`docs/install_macos_homelab.md:108`)
- 🔴 **critical**: Tool/shell abuse instruction detected (dotfile-modification): "echo 'export CHROMA_BASE_URL="http://YOUR_SERVER_IP:8000"' >> ~/.zshrc" (`docs/install_macos_homelab.md:109`)

[View full report on SafeSkill](https://safeskill.dev/scan/skynetcmd-m3-memory)

---

### About SafeSkill

[SafeSkill](https://safeskill.dev) is a **free, open-source** security scanner for AI tools, MCP servers, and Claude Code skills. We scan for code exploits, prompt injection, and data exfiltration risks.

**False positive?** We take accuracy seriously. If any finding above is incorrect, please [open an issue](https://github.com/OyadotAI/safeskill/issues/new?title=False+positive+in+skynetcmd%2Fm3-memory&labels=false-positive) and we will fix it immediately.

- [GitHub](https://github.com/OyadotAI/safeskill) | [Website](https://safeskill.dev) | [Docs](https://safeskill.dev/docs)
- Built by [Oya.ai](https://oya.ai) -- AI Employees Builder
