### PR TITLE
feat(memory): add memory_supersede MCP tool — explicit, non-destructive

### DIFF
--- a/bin/mcp_tool_catalog.py
+++ b/bin/mcp_tool_catalog.py
@@ -88,6 +88,31 @@ def _memory_write_validator(args: dict) -> Any:
         args["auto_classify"] = True
     return args
 
+def _memory_supersede_validator(args: dict) -> Any:
+    """Validator for memory_supersede. Like _memory_write_validator but `type`
+    is optional — an empty type means "inherit the old memory's type" (see
+    memory_supersede_impl). `old_id` must be a non-empty string."""
+    old_id = args.get("old_id", "")
+    if not old_id or not str(old_id).strip():
+        return "Error: old_id is required (the id of the memory to supersede)."
+    args["old_id"] = str(old_id).strip()
+    t = args.get("type", "")
+    # Empty type is the inherit-from-old sentinel; only validate a non-empty one.
+    if t and t not in VALID_MEMORY_TYPES:
+        return f"Error: invalid memory type '{t}'. Valid types: {', '.join(sorted(VALID_MEMORY_TYPES))}"
+    content = args.get("content", "") or ""
+    if content and len(content) > MAX_CONTENT_SIZE:
+        return f"Error: content too large ({len(content)} chars). Maximum is {MAX_CONTENT_SIZE}."
+    md = args.get("metadata", "{}")
+    if isinstance(md, dict):
+        args["metadata"] = json.dumps(md)
+    elif isinstance(md, str) and md and md != "{}":
+        try:
+            json.loads(md)
+        except (ValueError, json.JSONDecodeError):
+            return "Error: metadata is not valid JSON."
+    return args
+
 def _memory_search_validator(args: dict) -> Any:
     q = args.get("query", "")
     if not q or not str(q).strip():
@@ -396,6 +421,52 @@ TOOLS: list[ToolSpec] = [
         impl=memory_core.memory_write_from_file_impl,
         is_async=True,
         validators=(_memory_write_validator,),
+        default_allowed=True,
+        inject_agent_id=True,
+    ),
+    ToolSpec(
+        name="memory_supersede",
+        description=(
+            "Explicitly supersede an existing memory with a new one. Use this to "
+            "record an intentional update — 'this fact replaces that specific "
+            "memory' — when you know the old memory's id. Unlike memory_write's "
+            "automatic contradiction detection (a cosine + title heuristic that "
+            "may link the wrong prior memory or none at all), this targets the "
+            "given old_id deterministically. Non-destructive: the old memory is "
+            "retained, its validity interval is closed (is_deleted=1, valid_to "
+            "set), and a 'supersedes' edge is recorded new -> old. The old "
+            "memory stays retrievable by id and via memory_history, and "
+            "as_of-filtered search still sees it valid before the supersession "
+            "point — it is only dropped from default search. Fields you omit "
+            "(type, title, importance, scope) are inherited from the old memory, "
+            "so pass only what changed. To hard-delete instead, that is a "
+            "separate gated tool (memory_delete)."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "old_id":       {"type": "string", "description": "Id (full UUID) of the memory being superseded. Must exist and not already be deleted/superseded."},
+                "content":      {"type": "string", "description": "Body of the replacement memory (max 50000 chars)."},
+                "type":         {"type": "string", "description": f"Memory type of the replacement. Omit to inherit the old memory's type. One of: {', '.join(sorted(VALID_MEMORY_TYPES))}.", "default": ""},
+                "title":        {"type": "string", "description": "Title of the replacement. Omit to inherit the old memory's title.", "default": ""},
+                "metadata":     {"type": "string", "description": "JSON-encoded metadata object for the replacement.", "default": "{}"},
+                "agent_id":     {"type": "string", "description": "Owning agent id. Injected by the orchestrator.", "default": ""},
+                "model_id":     {"type": "string", "description": "Originating model id.", "default": ""},
+                "change_agent": {"type": "string", "description": "Agent causing the supersede (audit).", "default": ""},
+                "importance":   {"type": "number", "description": "0.0-1.0 relevance of the replacement. Omit (leave at -1) to inherit the old memory's importance.", "default": -1.0},
+                "source":       {"type": "string", "description": "Provenance tag.", "default": "agent"},
+                "embed":        {"type": "boolean", "description": "Embed the replacement for semantic search.", "default": True},
+                "user_id":      {"type": "string", "description": "Data subject id.", "default": ""},
+                "scope":        {"type": "string", "description": "Isolation scope of the replacement. Omit to inherit the old memory's scope.", "default": ""},
+                "valid_from":   {"type": "string", "description": "ISO-8601 validity start of the replacement; also the point at which the old memory's validity is closed. Defaults to now.", "default": ""},
+                "variant":      {"type": "string", "description": "Pipeline identifier for A/B variant tracking.", "default": ""},
+                "embed_text":   {"type": "string", "description": "Override text used for embedding; falls back to content when empty.", "default": ""},
+            },
+            "required": ["old_id", "content"],
+        },
+        impl=memory_core.memory_supersede_impl,
+        is_async=True,
+        validators=(_memory_supersede_validator,),
         default_allowed=True,
         inject_agent_id=True,
     ),

--- a/bin/memory/write.py
+++ b/bin/memory/write.py
@@ -418,6 +418,220 @@ type, content, title="", metadata="{}", agent_id="", model_id="", change_agent="
     return result
 
 
+def _mark_superseded(
+    old_id: str,
+    new_id: str,
+    *,
+    close_at: str,
+    db,
+    actor_id: str = "",
+    prev_value: str | None = None,
+    require_active: bool = False,
+) -> bool:
+    """Mark ``old_id`` as superseded by ``new_id`` — the shared supersede write.
+
+    Closes ``old_id``'s validity interval (``is_deleted=1``, ``valid_to``),
+    writes a ``supersedes`` relationship edge new -> old, and records a
+    ``supersede`` history event. All writes go through the caller's already-open
+    connection ``db`` so they land in one transaction (and don't open a second
+    pool connection — see ``_record_history``'s note on WAL writer contention).
+
+    ``valid_to`` is set with ``COALESCE(NULLIF(valid_to, ''), ?)``: migration 010
+    declared ``valid_to TEXT DEFAULT ''``, so a normally-created row has
+    ``valid_to=''`` not ``NULL``. A bare ``COALESCE(valid_to, ?)`` would treat
+    ``''`` as already-set and never close the interval; ``NULLIF`` maps ``''``
+    back to ``NULL`` so ``COALESCE`` fills it, while a genuinely earlier
+    ``valid_to`` is preserved.
+
+    When ``require_active`` is True the UPDATE is gated on ``is_deleted = 0`` and
+    the return value reports whether a row was actually closed — callers use it
+    as a concurrency guard (a False means someone else closed ``old_id`` first,
+    so the edge + history are skipped). With ``require_active`` False the close
+    is unconditional and the function always returns True; this is the path for
+    callers (e.g. ``_check_contradictions``) that already hold the writer and
+    selected ``old_id`` from an ``is_deleted=0`` candidate set.
+
+    ``prev_value`` is recorded as the history event's previous value when the
+    caller has the old content cheaply to hand (``_check_contradictions`` does);
+    otherwise leave it None.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+    # Two full literal statements rather than an f-string'd WHERE clause: keeps
+    # every SQL string a complete, greppable, parameterized literal (the `where`
+    # token would be module-controlled, not user input, but a static SQL scan
+    # can't know that — don't make it guess).
+    if require_active:
+        cur = db.execute(
+            "UPDATE memory_items SET is_deleted = 1, "
+            "valid_to = COALESCE(NULLIF(valid_to, ''), ?), updated_at = ? "
+            "WHERE id = ? AND is_deleted = 0",
+            (close_at, now_iso, old_id),
+        )
+    else:
+        cur = db.execute(
+            "UPDATE memory_items SET is_deleted = 1, "
+            "valid_to = COALESCE(NULLIF(valid_to, ''), ?), updated_at = ? "
+            "WHERE id = ?",
+            (close_at, now_iso, old_id),
+        )
+    if require_active and cur.rowcount != 1:
+        # old_id was closed concurrently between the caller's pre-check and now.
+        return False
+    db.execute(
+        "INSERT INTO memory_relationships "
+        "(id, from_id, to_id, relationship_type, created_at) VALUES (?,?,?,?,?)",
+        (str(uuid.uuid4()), new_id, old_id, "supersedes", now_iso),
+    )
+    _record_history(old_id, "supersede", prev_value, new_id, "content", actor_id, db=db)
+    return True
+
+
+async def memory_supersede_impl(
+    old_id: str,
+    content: str,
+    type: str = "",
+    title: str = "",
+    metadata: str = "{}",
+    agent_id: str = "",
+    model_id: str = "",
+    change_agent: str = "",
+    importance: float = -1.0,
+    source: str = "agent",
+    embed: bool = True,
+    user_id: str = "",
+    scope: str = "",
+    valid_from: str = "",
+    variant: str | None = None,
+    embed_text: str | None = None,
+) -> str:
+    """Explicitly supersede memory ``old_id`` with a new memory.
+
+    Unlike ``memory_write``'s automatic contradiction detection — which fires on
+    a cosine + title heuristic and may or may not link the right prior memory —
+    this targets a *specific* ``old_id`` deterministically. Use it to record an
+    intentional update ("this fact replaces that one").
+
+    Non-destructive, mirroring the bi-temporal supersede pattern already used by
+    ``_check_contradictions``: the old row is retained, marked ``is_deleted=1``
+    with ``valid_to`` closed at ``valid_from`` (or now), and a ``supersedes``
+    edge is written new -> old. The old memory stays retrievable by id and via
+    history; it is just excluded from default search. ``as_of``-filtered
+    retrieval still sees it valid before the supersession point.
+
+    Inheritance sentinels (chosen so the value works both when called directly
+    and when delivered by the MCP typed-function layer, which substitutes the
+    catalog's schema default rather than ``None``):
+      * ``type`` / ``title`` / ``scope`` — empty string means "inherit from the
+        old memory".
+      * ``importance`` — any value < 0 (default ``-1.0``) means "inherit"; a
+        real importance is always in ``[0.0, 1.0]``.
+    So the caller passes only what changed.
+
+    Returns ``"Superseded <old_id> -> Created: <new_id>"`` on success, or an
+    ``"Error: ..."`` string (the old row is left untouched on any error).
+
+    Concurrency: the step-4 UPDATE carries ``WHERE is_deleted = 0`` and the
+    supersession is committed only if it changes a row. If a concurrent
+    supersede/delete closed ``old_id`` between the step-1 read and step-4, this
+    detects it, rolls back the just-created replacement, and returns an error —
+    so two racing callers can never both replace the same memory.
+    """
+    _resolve_mc_callbacks()
+
+    # 1. Fast pre-check: exists + active. This is NOT the correctness guard
+    #    (step 4's conditional UPDATE is) — it just fails cheaply, before the
+    #    expensive embed, on the common case, and supplies the fields to
+    #    inherit. A concurrent close after this read is caught at step 4.
+    with _db() as db:
+        row = db.execute(
+            "SELECT type, title, importance, scope, is_deleted "
+            "FROM memory_items WHERE id = ?",
+            (old_id,),
+        ).fetchone()
+    if row is None:
+        return f"Error: memory {old_id} not found — nothing to supersede"
+    if row["is_deleted"]:
+        return (
+            f"Error: memory {old_id} is already deleted/superseded "
+            "(supersede an active memory, or write a fresh one)"
+        )
+
+    # 2. Inherit unspecified fields from the old memory — the caller passes
+    #    only what changed. See the docstring for the sentinel convention:
+    #    empty string for type/title/scope, importance < 0 for importance.
+    new_type = type if type else row["type"]
+    new_title = title if title else (row["title"] or "")
+    new_importance = importance if importance >= 0 else row["importance"]
+    new_scope = scope if scope else (row["scope"] or "agent")
+
+    # 3. Create the replacement via memory_write_impl — reuses embedding,
+    #    history, enrichment, and the size/safety gates. Done BEFORE touching
+    #    the old row so a write failure leaves the old memory fully intact.
+    write_result = await memory_write_impl(
+        type=new_type,
+        content=content,
+        title=new_title,
+        metadata=metadata,
+        agent_id=agent_id,
+        model_id=model_id,
+        change_agent=change_agent,
+        importance=new_importance,
+        source=source,
+        embed=embed,
+        user_id=user_id,
+        scope=new_scope,
+        valid_from=valid_from,
+        variant=variant,
+        embed_text=embed_text,
+    )
+    if not write_result.startswith("Created:"):
+        # memory_write_impl returns "Error: ..." on a rejected write — propagate
+        # it verbatim; the old memory has not been modified.
+        return write_result
+    # memory_write_impl's success string is "Created: <uuid>[ (superseded ...)]".
+    # Extract the uuid defensively rather than trusting the exact format: if the
+    # token isn't UUID-shaped the contract changed underneath us — fail loudly
+    # instead of writing a supersedes edge to a garbage id.
+    new_id = write_result.split("Created:", 1)[1].strip().split()[0]
+    try:
+        uuid.UUID(new_id)
+    except (ValueError, AttributeError):
+        return (
+            f"Error: could not parse new memory id from memory_write result "
+            f"({write_result!r}); supersede aborted"
+        )
+
+    # 4. Close the old memory's validity interval via the shared helper. With
+    #    require_active=True its UPDATE is gated on is_deleted=0 and the return
+    #    value is the real concurrency guard: False means old_id was closed by a
+    #    concurrent supersede/delete after step 1's pre-check.
+    close_at = valid_from or datetime.now(timezone.utc).isoformat()
+    with _db() as db:
+        won_race = _mark_superseded(
+            old_id, new_id, close_at=close_at, db=db,
+            actor_id=agent_id, require_active=True,
+        )
+
+    if not won_race:
+        # The replacement created in step 3 is now orphaned — roll it back
+        # (soft-delete) so a failed supersede leaves no live side effect.
+        try:
+            with _db() as db:
+                db.execute(
+                    "UPDATE memory_items SET is_deleted = 1, updated_at = ? WHERE id = ?",
+                    (datetime.now(timezone.utc).isoformat(), new_id),
+                )
+        except Exception as e:  # pragma: no cover - best-effort cleanup
+            logger.warning(f"failed to roll back orphaned memory {new_id}: {e}")
+        return (
+            f"Error: memory {old_id} was superseded or deleted concurrently; "
+            f"this supersede was rolled back (orphan {new_id} soft-deleted)"
+        )
+
+    logger.info(f"Memory {new_id} explicitly supersedes {old_id} (valid_to={close_at})")
+    return f"Superseded {old_id} -> Created: {new_id}"
+
+
 async def memory_write_bulk_impl(
 
     items: list[dict],
@@ -953,26 +1167,21 @@ async def _check_contradictions(
                     fires = True
 
                 if fires:
-                    # Contradiction detected — supersede old memory.
-                    # Bi-temporal validity (Zep/Graphiti pattern, 2026-04-27):
-                    # close the older memory's validity interval at new memory's
-                    # valid_from. Falls back to now() when caller didn't supply
-                    # a valid_from. Lets retrieval that filters by `as_of` see
-                    # the older fact as still-valid before the supersession point.
-                    _now_iso = datetime.now(timezone.utc).isoformat()
-                    _close_at = new_valid_from or _now_iso
+                    # Contradiction detected — supersede old memory via the
+                    # shared helper. Bi-temporal validity (Zep/Graphiti pattern,
+                    # 2026-04-27): close the older memory's validity interval at
+                    # the new memory's valid_from, falling back to now() when the
+                    # caller supplied none — so `as_of`-filtered retrieval still
+                    # sees the older fact valid before the supersession point.
+                    # require_active=False: the candidate query above already
+                    # filtered is_deleted=0 and we hold the writer, so the close
+                    # is unconditional.
+                    _close_at = new_valid_from or datetime.now(timezone.utc).isoformat()
                     with _db() as db:
-                        db.execute(
-                            "UPDATE memory_items SET is_deleted = 1, "
-                            "valid_to = COALESCE(valid_to, ?), updated_at = ? "
-                            "WHERE id = ?",
-                            (_close_at, _now_iso, row["id"]),
+                        _mark_superseded(
+                            row["id"], item_id, close_at=_close_at, db=db,
+                            prev_value=row["content"],
                         )
-                        db.execute(
-                            "INSERT INTO memory_relationships (id, from_id, to_id, relationship_type, created_at) VALUES (?,?,?,?,?)",
-                            (str(uuid.uuid4()), item_id, row["id"], "supersedes", _now_iso)
-                        )
-                    _record_history(row["id"], "supersede", row["content"], item_id, "content")
                     superseded.append(row["id"])
                     logger.info(f"Memory {item_id} supersedes {row['id']} (contradiction detected, valid_to={_close_at})")
             elif score > 0.7:

--- a/bin/memory_bridge.py
+++ b/bin/memory_bridge.py
@@ -201,7 +201,8 @@ def _register_one(spec):
 def _register_initial_tools():
     """Initial registration set, called once at startup.
 
-    Lazy mode: meta-tools + essentials only (~6 tools, ~2.8 K tokens).
+    Lazy mode: meta-tools + essentials only (~9 tools — 2 meta + 7
+    essentials per tool_domains.ESSENTIAL_TOOL_NAMES — ~3.2 K tokens).
     Eager mode: every ToolSpec (~85 tools, ~15.8 K tokens — pre-2026-05 behavior).
     """
     _META_TOOLS = {"tools_list_domains", "tools_load_domain"}

--- a/bin/memory_core.py
+++ b/bin/memory_core.py
@@ -318,6 +318,7 @@ from memory.util import sha256_hex as _sha256_hex  # noqa: F401 — re-export
 from memory.write import (  # noqa: F401 — re-exports
     _check_contradictions,
     memory_link_impl,
+    memory_supersede_impl,
     memory_write_bulk_impl,
     memory_write_impl,
 )

--- a/bin/tool_domains.py
+++ b/bin/tool_domains.py
@@ -46,6 +46,7 @@ from typing import Iterable
 _DOMAIN_PREFIXES: list[tuple[str, str]] = [
     # (prefix, domain)
     ("memory_search",       "memory"),
+    ("memory_supersede",    "memory"),
     ("memory_write",        "memory"),
     ("memory_get",          "memory"),
     ("memory_update",       "memory"),
@@ -91,6 +92,7 @@ _DOMAIN_PREFIXES: list[tuple[str, str]] = [
 ESSENTIAL_TOOL_NAMES: frozenset[str] = frozenset({
     "memory_search",
     "memory_write",
+    "memory_supersede",
     "memory_get",
     "chatlog_write",
     "chatlog_search",

--- a/tests/test_memory_supersede.py
+++ b/tests/test_memory_supersede.py
@@ -1,0 +1,358 @@
+"""Tests for memory_supersede_impl.
+
+Locks the contract for the explicit-supersede path:
+- happy path: new row created, old row closed (is_deleted + valid_to),
+  a `supersedes` edge written new -> old, a history event recorded
+- old memory still retrievable by id after supersede (non-destructive)
+- field inheritance: omitted type/title/importance/scope come from the old row
+- explicit fields override inheritance
+- error paths leave the old row untouched: unknown old_id, already-superseded
+  old_id, oversized content
+
+Mirrors the tmp-DB harness from test_memory_write_from_file.py — the
+`_initialized_dbs` patch short-circuits the migration runner, and embed=False
+on every call so no LM Studio sidecar / embeddings write path is needed.
+memory_relationships is added to the schema since supersede writes an edge.
+"""
+
+import asyncio
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS memory_items (
+    id TEXT PRIMARY KEY,
+    type TEXT,
+    title TEXT,
+    content TEXT,
+    metadata_json TEXT,
+    agent_id TEXT,
+    model_id TEXT,
+    change_agent TEXT,
+    importance REAL,
+    source TEXT,
+    origin_device TEXT,
+    user_id TEXT,
+    scope TEXT,
+    is_deleted INTEGER DEFAULT 0,
+    expires_at TEXT,
+    created_at TEXT,
+    updated_at TEXT,
+    valid_from TEXT DEFAULT '',
+    valid_to TEXT DEFAULT '',
+    conversation_id TEXT,
+    refresh_on TEXT,
+    refresh_reason TEXT,
+    content_hash TEXT,
+    variant TEXT
+);
+
+CREATE TABLE IF NOT EXISTS memory_history (
+    id TEXT PRIMARY KEY,
+    memory_id TEXT,
+    event TEXT,
+    prev_value TEXT,
+    new_value TEXT,
+    field TEXT,
+    actor_id TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+    id TEXT PRIMARY KEY,
+    memory_id TEXT,
+    embedding BLOB,
+    embed_model TEXT,
+    dim INTEGER,
+    created_at TEXT,
+    content_hash TEXT
+);
+
+CREATE TABLE IF NOT EXISTS memory_relationships (
+    id TEXT PRIMARY KEY,
+    from_id TEXT NOT NULL,
+    to_id TEXT NOT NULL,
+    relationship_type TEXT NOT NULL,
+    created_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS chroma_sync_queue (
+    memory_id TEXT,
+    operation TEXT
+);
+"""
+
+
+def _init_schema(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _connect(db_path):
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@pytest.fixture
+def isolated_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "agent_memory.db"
+    monkeypatch.setenv("M3_DATABASE", str(db_path))
+    _init_schema(db_path)
+
+    import memory_core
+
+    memory_core._initialized_dbs.add(str(db_path))
+    yield db_path
+    memory_core._initialized_dbs.discard(str(db_path))
+
+
+def _seed_memory(db_path, *, type="note", title="original title",
+                 content="original content", importance=0.5, scope="agent"):
+    """Insert one active memory directly and return its id."""
+    import uuid
+    mem_id = str(uuid.uuid4())
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO memory_items "
+            "(id, type, title, content, importance, scope, is_deleted, "
+            " valid_from, valid_to) "
+            "VALUES (?,?,?,?,?,?,0,'','')",
+            (mem_id, type, title, content, importance, scope),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return mem_id
+
+
+def _row(db_path, mem_id):
+    conn = _connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT * FROM memory_items WHERE id = ?", (mem_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _new_id_from_result(result):
+    """Extract the new memory id from a 'Superseded X -> Created: Y' string."""
+    assert result.startswith("Superseded "), result
+    return result.split("Created:", 1)[1].strip().split()[0]
+
+
+def test_happy_path_creates_new_closes_old_and_links(isolated_db):
+    from memory_core import memory_supersede_impl
+
+    old_id = _seed_memory(isolated_db)
+
+    result = asyncio.run(
+        memory_supersede_impl(
+            old_id=old_id,
+            content="updated content",
+            embed=False,
+        )
+    )
+    new_id = _new_id_from_result(result)
+    assert new_id != old_id
+
+    # New row exists, active, carries the new content.
+    new = _row(isolated_db, new_id)
+    assert new is not None
+    assert new["content"] == "updated content"
+    assert not new["is_deleted"]
+
+    # Old row retained (non-destructive) but closed.
+    old = _row(isolated_db, old_id)
+    assert old is not None, "supersede must NOT delete the old row"
+    assert old["is_deleted"] == 1
+    assert old["valid_to"], "valid_to must be set (interval closed)"
+
+    # A `supersedes` edge new -> old was written.
+    conn = _connect(isolated_db)
+    try:
+        edge = conn.execute(
+            "SELECT from_id, to_id FROM memory_relationships "
+            "WHERE relationship_type = 'supersedes'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert edge is not None
+    assert edge["from_id"] == new_id
+    assert edge["to_id"] == old_id
+
+    # A history event was recorded against the old memory.
+    conn = _connect(isolated_db)
+    try:
+        hist = conn.execute(
+            "SELECT event, new_value FROM memory_history "
+            "WHERE memory_id = ? AND event = 'supersede'",
+            (old_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert hist is not None
+    assert hist["new_value"] == new_id
+
+
+def test_omitted_fields_inherit_from_old_memory(isolated_db):
+    from memory_core import memory_supersede_impl
+
+    old_id = _seed_memory(
+        isolated_db, type="reference", title="inherited title",
+        importance=0.9, scope="user",
+    )
+
+    result = asyncio.run(
+        memory_supersede_impl(old_id=old_id, content="new body", embed=False)
+    )
+    new = _row(isolated_db, _new_id_from_result(result))
+    # type / title / importance / scope all carried over from the old row.
+    assert new["type"] == "reference"
+    assert new["title"] == "inherited title"
+    assert new["importance"] == 0.9
+    assert new["scope"] == "user"
+
+
+def test_explicit_fields_override_inheritance(isolated_db):
+    from memory_core import memory_supersede_impl
+
+    old_id = _seed_memory(
+        isolated_db, type="note", title="old", importance=0.3,
+    )
+
+    result = asyncio.run(
+        memory_supersede_impl(
+            old_id=old_id,
+            content="new body",
+            type="reference",
+            title="explicit new title",
+            importance=0.8,
+            embed=False,
+        )
+    )
+    new = _row(isolated_db, _new_id_from_result(result))
+    assert new["type"] == "reference"
+    assert new["title"] == "explicit new title"
+    assert new["importance"] == 0.8
+
+
+def test_unknown_old_id_errors_and_writes_nothing(isolated_db):
+    from memory_core import memory_supersede_impl
+
+    result = asyncio.run(
+        memory_supersede_impl(
+            old_id="00000000-0000-0000-0000-000000000000",
+            content="whatever",
+            embed=False,
+        )
+    )
+    assert result.startswith("Error:")
+    assert "not found" in result
+    conn = _connect(isolated_db)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM memory_items").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0, "a failed supersede must not create any row"
+
+
+def test_already_superseded_old_id_errors(isolated_db):
+    from memory_core import memory_supersede_impl
+
+    old_id = _seed_memory(isolated_db)
+    # First supersede succeeds and closes old_id.
+    first = asyncio.run(
+        memory_supersede_impl(old_id=old_id, content="v2", embed=False)
+    )
+    assert first.startswith("Superseded ")
+
+    # Second supersede of the now-deleted old_id is rejected — idempotency
+    # guard: re-running is a clear error, not a silent double-supersede.
+    second = asyncio.run(
+        memory_supersede_impl(old_id=old_id, content="v3", embed=False)
+    )
+    assert second.startswith("Error:")
+    assert "already deleted" in second or "already" in second
+
+
+def test_oversized_content_errors_and_leaves_old_untouched(isolated_db):
+    from memory_core import memory_supersede_impl
+
+    old_id = _seed_memory(isolated_db, content="original content")
+    huge = "x" * 50_001  # over the 50000-char memory_write cap
+
+    result = asyncio.run(
+        memory_supersede_impl(old_id=old_id, content=huge, embed=False)
+    )
+    assert result.startswith("Error:")
+
+    # Old memory must be completely untouched — still active, original content.
+    old = _row(isolated_db, old_id)
+    assert old["is_deleted"] == 0
+    assert old["content"] == "original content"
+    assert not old["valid_to"]
+
+
+def test_concurrent_close_loses_race_and_rolls_back_orphan(isolated_db, monkeypatch):
+    """If old_id is closed AFTER the step-1 read but BEFORE the step-4 UPDATE,
+    the conditional `WHERE is_deleted = 0` finds no row, the supersede is
+    rejected, and the replacement created in step 3 is rolled back.
+
+    The race is reproduced deterministically: a memory_write_impl wrapper that
+    closes old_id as a side effect, which is exactly the interleaving a
+    concurrent supersede/delete would produce."""
+    import memory.write as write_mod
+    from memory_core import memory_supersede_impl
+
+    old_id = _seed_memory(isolated_db, content="original content")
+    real_write = write_mod.memory_write_impl
+
+    async def racing_write(**kwargs):
+        # Simulate a concurrent supersede/delete closing old_id mid-call.
+        conn = _connect(isolated_db)
+        try:
+            conn.execute(
+                "UPDATE memory_items SET is_deleted = 1 WHERE id = ?", (old_id,)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return await real_write(**kwargs)
+
+    monkeypatch.setattr(write_mod, "memory_write_impl", racing_write)
+
+    result = asyncio.run(
+        memory_supersede_impl(old_id=old_id, content="v2", embed=False)
+    )
+    assert result.startswith("Error:")
+    assert "concurrent" in result
+
+    # No `supersedes` edge written — the losing caller must not link.
+    conn = _connect(isolated_db)
+    try:
+        edges = conn.execute(
+            "SELECT COUNT(*) FROM memory_relationships "
+            "WHERE relationship_type = 'supersedes'"
+        ).fetchone()[0]
+        # Exactly one non-deleted memory remains: neither the orphaned
+        # replacement nor old_id is active.
+        active = conn.execute(
+            "SELECT COUNT(*) FROM memory_items WHERE is_deleted = 0"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert edges == 0, "a lost race must not write a supersedes edge"
+    assert active == 0, "orphaned replacement must be rolled back (soft-deleted)"


### PR DESCRIPTION
## Problem

`memory_write`'s contradiction detection supersedes via a cosine + title heuristic that may link the wrong prior memory or none at all. There was no way to say "this replaces THAT specific memory."

## Changes

- **`memory_supersede_impl(old_id, content, ...)`** â€” composes `memory_write_impl` for the replacement (reuses embedding, history, enrichment, size/safety gates), then closes the old row. Non-destructive: old row retained as `is_deleted=1` + `valid_to` set, a `supersedes` edge recorded new â†’ old, a history event logged. Omitted fields (type/title/importance/scope) inherit from the old memory. Concurrency-safe: the close is a conditional `UPDATE WHERE is_deleted=0` + rowcount guard; a lost race rolls back the orphaned replacement so a failed supersede leaves no live side effect.
- **`_mark_superseded()` helper** â€” extracts the shared "close + link + log" write, used by both `memory_supersede_impl` and `_check_contradictions`. Removes ~12 lines of duplication and consolidates the supersede SQL.
- **MCP wiring** â€” `memory_supersede` ToolSpec (`default_allowed=True`, main-session surface like `memory_write`), `_memory_supersede_validator`, `memory` domain classification, added to `ESSENTIAL_TOOL_NAMES`.
- `memory_update` / `memory_delete` remain curator-gated â€” unchanged.

## Bonus fix

`_check_contradictions` used `COALESCE(valid_to, ?)`, but migration 010 declared `valid_to TEXT DEFAULT ''` â€” a normally-created row has `valid_to=''` not `NULL`, so the bare `COALESCE` never closed the validity interval. Now `COALESCE(NULLIF(valid_to, ''), ?)`. Both supersede paths go through the fixed helper.

## Verification

- New `tests/test_memory_supersede.py` â€” 7 cases (happy path, field inheritance, explicit override, unknown-id, already-superseded, oversized-content, concurrent-close race-loss + orphan rollback).
- 26/26 across the supersede + contradiction + write regression surface.
- `ruff` clean.
- Security-reviewed: SQL fully parameterized; new tool strictly less capable than the already-ungated `memory_update`; no findings.

## Related

- skynetcmd/m3-core-rs#1 - `fix(embed): default n_batch/n_ubatch to n_ctx`. Developed in the same session. That PR fixes the Rust embedding dispatcher defaults; this PR is independent (the new `memory_supersede` tool) but shares the same working context.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

