### PR TITLE
feat(setup): per-OS guidance when the always-on embedder install fails

### DIFF
--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -232,11 +232,30 @@ def _step_cpu_sovereign_embedder() -> bool:
         _ok("sovereign CPU embedder registered and running on port 8082")
         return True
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        _warn(
-            f"CPU embedder install failed: {e}. "
-            "m3 still works (Python-side embed fallback); retry with "
-            "`m3 embedder install` once you've resolved the issue."
-        )
+        _warn(f"CPU embedder install did not complete: {e}")
+        # m3 still works without it (the embed cascade falls through to the
+        # Python/HTTP tier) — so this is non-fatal. But print clear, per-OS
+        # instructions for getting the always-on embedder, because the most
+        # common cause is OS-specific (Windows needs elevation; mac/Linux may
+        # need the m3-embed-server binary or a linger setting).
+        print()
+        print("  To get the always-on CPU embedder, follow the steps for your OS:")
+        if sys.platform == "win32":
+            print("    Windows — the embedder registers as a Windows Service, which")
+            print("    needs Administrator rights. Open an *Administrator* terminal and run:")
+            print("        m3 embedder install")
+        elif sys.platform == "darwin":
+            print("    macOS — the embedder installs as a launchd user agent (no sudo).")
+            print("    Re-run, and if it still fails the m3-embed-server binary is")
+            print("    likely missing — install the Rust core, then retry:")
+            print("        m3 embedder install")
+        else:
+            print("    Linux — the embedder installs as a `systemd --user` unit (no sudo).")
+            print("    Re-run `m3 embedder install`. A `--user` service stops at logout;")
+            print("    to keep it running across logout / on a headless box also run:")
+            print("        loginctl enable-linger \"$USER\"")
+        print()
+        print("  Until then, m3 still embeds via its Python/HTTP fallback tier.")
         return True  # non-fatal
 
 


### PR DESCRIPTION
## Problem

The setup wizard's CPU-embedder install step printed a generic `"retry once you've resolved the issue"` on failure — unhelpful, since the most common cause is OS-specific:
- **Windows** — registering the service needs Administrator elevation
- **macOS/Linux** — may need the `m3-embed-server` binary, or (Linux) a linger setting to survive logout

## Change

`_step_cpu_sovereign_embedder()` now prints clear, actionable **per-OS** instructions for getting the always-on `:8082` CPU embedder:

- **Windows** — run `m3 embedder install` from an Administrator terminal
- **macOS** — launchd user agent (no sudo); install the Rust core if the `m3-embed-server` binary is missing
- **Linux** — `systemd --user` unit (no sudo); `loginctl enable-linger "$USER"` to keep it running across logout / headless

Still **non-fatal** — m3 keeps embedding via the Python/HTTP fallback tier, and the message says so.

## Related

- **skynetcmd/m3-core-rs#2** — the companion PR that makes `m3 embedder install` actually work on macOS (launchd) and Linux (systemd), not just Windows. This wizard message points users at that command; together they deliver the always-on embedder on all three OSes.

## Verification

- `python -m py_compile` clean.
- Change is confined to one function body; the per-OS branches are plain `print()` calls keyed on `sys.platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)