### PR TITLE
fix(embed): default to BGE-M3, not the retired qwen3-embedding

### DIFF
--- a/bin/llm_failover.py
+++ b/bin/llm_failover.py
@@ -329,8 +329,13 @@ async def get_best_embed(client: httpx.AsyncClient, token: str) -> Optional[tupl
             else:
                 other_models.append(model_id)
 
-        # Prefer embedding model from this endpoint
+        # Prefer embedding model from this endpoint. When the endpoint
+        # advertises several embed models, pick BGE-M3 — it is m3-memory's
+        # canonical embedder; a blind `[0]` could otherwise select a retired
+        # model (e.g. qwen3-embedding), producing vectors that are
+        # semantically incomparable to the rest of the store.
         if embed_models:
+            embed_models.sort(key=lambda m: 0 if "bge-m3" in m.lower() else 1)
             _EMBED_ENDPOINT_CACHE = (endpoint, embed_models[0])
             return _EMBED_ENDPOINT_CACHE
 

--- a/bin/memory/config.py
+++ b/bin/memory/config.py
@@ -92,7 +92,11 @@ FILES_DB_PROMPT_ON_FIRST_USE: bool = os.environ.get(
 # ──────────────────────────────────────────────────────────────────────────────
 # Embedding model + transport
 # ──────────────────────────────────────────────────────────────────────────────
-EMBED_MODEL: str = os.environ.get("EMBED_MODEL", "qwen3-embedding")
+# BGE-M3 (1024-dim) is the canonical embedder for m3-memory. The store's
+# dominant embeddings are `text-embedding-bge-m3`; Qwen embedding is retired.
+# Mixing models in one store produces semantically incomparable vectors, so
+# the default must name BGE-M3 — an operator can still override via EMBED_MODEL.
+EMBED_MODEL: str = os.environ.get("EMBED_MODEL", "text-embedding-bge-m3")
 EMBED_DIM: int = int(os.environ.get("EMBED_DIM", "1024"))
 EMBED_TIMEOUT_READ: float = 30.0
 ORIGIN_DEVICE: str = os.environ.get("ORIGIN_DEVICE", platform.node())


### PR DESCRIPTION
## Problem

New memories were being embedded with `qwen3-embedding` instead of **BGE-M3** — m3-memory's canonical 1024-dim embedder. Mixing embedding models in one store produces semantically incomparable vectors (the store's dominant tag is `text-embedding-bge-m3`).

Two stale spots:

1. **`config.py`** — `EMBED_MODEL` defaulted to the literal `"qwen3-embedding"`.
2. **`llm_failover.py::get_best_embed`** — when an endpoint advertised several embedding models it picked `embed_models[0]` blindly. Non-deterministic, and on a server hosting *both* Qwen-embedding and BGE-M3 it could (and did) select Qwen.

## Changes

- `config.py` — `EMBED_MODEL` default → `text-embedding-bge-m3`. This is only the cascade's fallback label; operators can still override via the `EMBED_MODEL` env var.
- `llm_failover.py` — `get_best_embed` now sorts `embed_models` so BGE-M3 sorts first before taking `[0]`. Deterministic, prefers the canonical embedder.

## How it surfaced

A `memory_supersede` call (the new tool from #10) embedded a new memory with `qwen3-embedding:0.6b`. That specific row was re-embedded to BGE-M3 manually; this PR stops it recurring for *every* new memory.

## Note on the running server

`get_best_embed` caches its discovery result process-globally, so a live MCP server keeps its current choice until restarted — this fix takes effect on the next server start (after merge + local checkout pull, since the server runs the dev sibling bridge from the local `m3-memory` checkout).

## Verification

- `ruff` + `py_compile` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)