### PR TITLE
fix(memory/graph): stopword-filter sentence-initial query starters from entity-graph seeds

### DIFF
--- a/bin/memory/graph.py
+++ b/bin/memory/graph.py
@@ -9,6 +9,19 @@ from .embed import _embed
 from .fts import _ENTITY_MENTION_RE
 from .util import _cosine_batch_packed
 
+# Sentence-initial Title-Case common words that the entity-mention regex
+# captures as if they were proper nouns. Skip these as graph-seed candidates
+# to prevent spurious entity lookups on conversational query starters.
+# Kept here (graph.py) rather than config.py because it's specific to the
+# entity-graph BFS seed-extraction and has no other readers.
+_QUERY_STARTER_STOPWORDS: frozenset[str] = frozenset({
+    "Can", "Could", "Would", "Will", "Should", "Shall",
+    "What", "Which", "Where", "When", "Why", "Who", "Whom", "Whose", "How",
+    "Did", "Do", "Does", "Is", "Are", "Was", "Were", "Am",
+    "I", "My", "Me", "Mine", "We", "Our", "Us", "You", "Your", "Yours",
+    "Tell", "Show", "Give", "Help", "Please", "Hi", "Hello", "Hey", "Yes", "No",
+})
+
 logger = logging.getLogger("memory.graph")
 
 
@@ -128,12 +141,18 @@ async def _entity_graph_neighbor_ids(
     depth = min(int(depth), 3)
     max_neighbors = min(int(max_neighbors), 100)
 
-    # Step 1 — extract candidate mention strings
+    # Step 1 — extract candidate mention strings.
+    # Filter out sentence-initial Title-Case common words that the regex
+    # picks up as if they were proper nouns ("Can you recommend...",
+    # "What should I serve...", "How do I..."). These leak into entity
+    # lookups and pull unrelated turns into the top-k via spurious overlap;
+    # see LME-S KG-overlap report 2026-05-23 for the -13.3pp single-session-
+    # preference @k=5 regression this caused.
     candidates: list[str] = []
     seen_cands: set[str] = set()
     for m in _ENTITY_MENTION_RE.finditer(query):
         text = m.group(0).strip("\"'")
-        if text and text not in seen_cands:
+        if text and text not in seen_cands and text not in _QUERY_STARTER_STOPWORDS:
             seen_cands.add(text)
             candidates.append(text)
 


### PR DESCRIPTION
## Summary

- Adds `_QUERY_STARTER_STOPWORDS` (43 items) to `bin/memory/graph.py`
- Skips sentence-initial Title-Case common words (`Can`, `What`, `How`, `I`, `You`, etc.) before they enter the entity_graph seed candidate list
- Targets a measured -13.3pp session-hit-rate@k=5 regression on conversational-style queries

## Why

The entity-graph BFS in `memory_search_routed_impl` extracts query seeds via `_ENTITY_MENTION_RE`, which captures Title-Case noun phrases. That regex also captures sentence-initial common words ("Can you recommend...", "What should I serve..."). Those words aren't proper nouns but the tier-2 LIKE lookup happily matches them against entity vocab — e.g. seed `Can` matches entity `Canada` — and the BFS then promotes turns linked to those wrong entities into the top-k, displacing genuinely-relevant gold turns.

## Empirical effect (LME-S benchmark, 500 instances)

Without filter, on `single-session-preference` qtype (questions like "Can you recommend a show...", "What should I serve..."):
- session-hit-rate@k=2: -3.3pp
- session-hit-rate@k=3: -10.0pp
- session-hit-rate@k=5: **-13.3pp**

With filter, regression drops to **0pp on all k**. Positive KG signal on other qtypes preserved (overall +1.4pp @k=3, +0.4pp @k=5). Diagnosis ran a control leg (`routed_impl` with `entity_graph=False`) to verify the deltas were real KG signal, not engine-path tie-break.

## Test plan

- [ ] CI / existing graph test suite passes
- [ ] (optional) Spot-check `entity_search` queries that intentionally start with stopwords — confirm proper noun later in the query is still extracted
- [ ] (optional) Run any existing search/retrieval regression bench against the patched branch