### PR TITLE
fix(fts): neutralize all FTS5 operator chars in query sanitizer

### DIFF
--- a/bin/chatlog_core.py
+++ b/bin/chatlog_core.py
@@ -4,7 +4,7 @@ Provides:
 - Async write queue (asyncio.Queue) with flush-on-size/interval
 - Spill-to-disk backpressure at memory/chatlog_spill/YYYYMMDD.jsonl
 - chatlog_write_impl / chatlog_write_bulk_impl — enqueue + flush
-- chatlog_search_impl — delegates to memory_core.memory_search_scored_impl
+- chatlog_search_impl — FTS5 + facet filters over chat_log rows
 - chatlog_promote_impl — ATTACH DATABASE cross-DB copy (separate/hybrid) or UPDATE (integrated)
 - chatlog_list_conversations_impl
 - chatlog_cost_report_impl — aggregates tokens/cost from metadata_json
@@ -44,6 +44,11 @@ VALID_PROVIDERS = frozenset({
     "deepseek", "mistral", "meta", "other",
 })
 MAX_CONTENT_LEN = 50_000
+# Hard cap on search result rows. Defends the API boundary against pathological
+# `k` (DESIGN §4/§6): SQLite treats `LIMIT -1` as UNBOUNDED, so a negative k
+# would otherwise dump the entire chatlog into memory + JSON. k is clamped into
+# [1, MAX_SEARCH_K] before it reaches any query.
+MAX_SEARCH_K = 1_000
 
 # Price table — USD per 1M tokens. Unknown entries → cost_usd stays null (no fake zeros).
 # Keys: (provider, model_id_prefix_or_exact). Lookup walks exact first, then prefix.
@@ -550,7 +555,7 @@ def _derive_title(role: str, content: str, host_agent: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Search — delegates to memory_core.memory_search_scored_impl
+# Search — FTS5 + facet filters over chat_log rows (via _chatlog_search_separate)
 # ---------------------------------------------------------------------------
 
 async def chatlog_search_impl(
@@ -568,7 +573,9 @@ async def chatlog_search_impl(
     """Keyword/vector/hybrid search over chat_log rows in the configured chat log DB.
 
     Returns a JSON string with {"results": [...], "count": N, "db_path": "...", "mode": "..."}."""
-    import memory_core
+    # Clamp k at the boundary: negative -> SQLite LIMIT -1 is UNBOUNDED (would
+    # dump the whole chatlog); 0 -> never useful; huge -> unbounded Python/JSON.
+    k = max(1, min(int(k), MAX_SEARCH_K))
 
     # Ensure flushes complete before searching (best-effort)
     await _flush_once()
@@ -578,33 +585,28 @@ async def chatlog_search_impl(
     chatlog_path = os.path.abspath(chatlog_config.chatlog_db_path())
     main_path = os.path.abspath(resolve_db_path(None))
 
-    # When the chatlog DB is the same file as the active main DB, delegate to
-    # memory_core's full-featured search (vector/hybrid/fts). When they
-    # differ, fall back to the FTS-only path against the chatlog DB.
-    if chatlog_path == main_path:
-        results_json = await memory_core.memory_search_scored_impl(
-            query=query, k=k, type_filter="chat_log",
-            conversation_id=conversation_id, agent_id=agent_id,
-            search_mode=search_mode, since=since, until=until,
-        )
-        return json.dumps({
-            "results": json.loads(results_json).get("results", []),
-            "count":   json.loads(results_json).get("count", 0),
-            "db_path": chatlog_path,
-            "unified": True,
-        })
-
+    # Both the unified (chatlog DB == main DB) and separate cases go through
+    # _chatlog_search_separate. In the unified case get_chatlog_conn() resolves
+    # to the main pool, so this queries the same rows a delegation to
+    # memory_core.memory_search_scored_impl would have — but it honors every
+    # filter (agent_id/since/until/host_agent/provider/model_id) and returns a
+    # consistent result shape. The old delegation branch was dead from the
+    # start: it forwarded agent_id/since/until, none of which
+    # memory_search_scored_impl ever accepted (it takes agent_filter/as_of),
+    # so it raised TypeError the first time the unified path actually ran.
+    unified = chatlog_path == main_path
     return await _chatlog_search_separate(
         query=query, k=k, conversation_id=conversation_id,
         host_agent=host_agent, provider=provider, model_id=model_id,
         agent_id=agent_id, since=since, until=until, db_path=chatlog_path,
+        unified=unified,
     )
 
 
 async def _chatlog_search_separate(
     query: str, k: int, conversation_id: str, host_agent: str,
     provider: str, model_id: str, agent_id: str, since: str, until: str,
-    db_path: str,
+    db_path: str, unified: bool = False,
 ) -> str:
     from m3_sdk import M3Context
     ctx = M3Context.for_db(None)
@@ -636,8 +638,16 @@ async def _chatlog_search_separate(
 
         where = " AND ".join(clauses)
 
+        # Distinguish three cases:
+        #   - no query supplied (blank/whitespace) -> browse: latest rows by time
+        #   - query supplied, sanitizes to tokens   -> FTS MATCH search
+        #   - query supplied but ALL operator chars  -> zero results, NOT a browse
+        # The third case matters: a user searching "---" or ":::" specified a
+        # term; silently returning the latest rows (as the old `if fts_query`
+        # fall-through did) is a misleading false-positive, not a search.
+        has_query = bool(query.strip())
+        fts_query = _sanitize_fts(query) if has_query else ""
         with ctx.get_chatlog_conn() as conn:
-            fts_query = _sanitize_fts(query) if query.strip() else ""
             if fts_query:
                 sql = (
                     "SELECT mi.id, mi.title, mi.content, mi.metadata_json, mi.created_at, "
@@ -648,6 +658,9 @@ async def _chatlog_search_separate(
                     "ORDER BY rank LIMIT ?"
                 )
                 rows = conn.execute(sql, [fts_query] + params + [k]).fetchall()
+            elif has_query:
+                # Query given but no matchable tokens survived sanitization.
+                rows = []
             else:
                 sql = (
                     "SELECT id, title, content, metadata_json, created_at, "
@@ -679,7 +692,7 @@ async def _chatlog_search_separate(
     return json.dumps({
         **result,
         "db_path": db_path,
-        "unified": False,
+        "unified": unified,
     })
 
 

--- a/bin/doctor/__init__.py
+++ b/bin/doctor/__init__.py
@@ -1,11 +1,12 @@
 """m3-memory doctor — health probes and DB repair, split per concern.
 
-Three narrow modules, plus a thin CLI dispatcher (`memory_doctor.py` at
+Narrow modules, plus a thin CLI dispatcher (`memory_doctor.py` at
 `bin/` keeps its name for backward compatibility):
 
 - `db_repair`           — legacy DB repair (timestamps, relationships, JSON)
 - `cascade_probe`       — wrapper around `memory.doctor.memory_doctor_impl`
 - `embed_server_probe`  — shells out to the Rust `m3-embed-server doctor`
+- `oxidation_probe`     — reports m3_core_rs presence / staleness (report-only)
 
 Each module's public entry point returns an int exit code (0=pass,
 non-zero=fail-this-phase). The CLI aggregates the worst code across

--- a/bin/doctor/oxidation_probe.py
+++ b/bin/doctor/oxidation_probe.py
@@ -1,0 +1,84 @@
+"""Oxidation status probe — is the installed `m3_core_rs` present and current?
+
+The Python hot paths (FTS sanitize/compile, vector ops, ranking) route through
+the native `m3_core_rs` extension when it exposes the matching function, and
+silently fall back to a slower pure-Python body otherwise. That silent fallback
+is correct for *un*installed extensions — but it also hides a present-but-STALE
+wheel: an old build missing newer functions degrades performance and, worse,
+can ship behavior that a later source fix already corrected. A stale wheel
+missing `sanitize_fts`/`compile_fts_query` is exactly what masked the FTS
+operator-char crash for days (the Python fallback carried the bug while the
+fixed Rust sat unbuilt).
+
+This probe makes that state visible instead of silent (DESIGN §3 fail-loud,
+§8 performance). It never fails the doctor run — a Python-only deployment is a
+legitimate, supported configuration — it only reports, returning 0 always.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("memory.doctor.oxidation_probe")
+
+# Native functions the Python oxidation paths expect to route through. Each is
+# a (name, why-it-matters) pair so the report explains the cost of its absence.
+# Keep this list curated and load-bearing — it is the contract between the
+# Python fallbacks and the shipped wheel, not an exhaustive symbol dump.
+_EXPECTED = [
+    ("sanitize_fts", "FTS5 query sanitization (search correctness + speed)"),
+    ("compile_fts_query", "FTS5 query compilation (hot search path)"),
+    ("token_jaccard", "lexical overlap scoring (ranker hot path)"),
+    ("token_jaccard_batch", "batched lexical overlap (ranker hot path)"),
+    ("rank_hybrid_packed", "packed hybrid ranking (search hot path)"),
+    ("cosine_batch_packed", "packed batch cosine (vector search hot path)"),
+    ("mmr_rerank_scored_packed", "packed MMR rerank (diversity rerank)"),
+    ("scrub", "redaction scrubbing (write boundary)"),
+]
+
+
+def run() -> int:
+    """Report m3_core_rs presence and per-function availability. Always 0."""
+    print()
+    print("=== oxidation status (m3_core_rs native extension) ===")
+
+    try:
+        from memory import config
+    except Exception as e:  # noqa: BLE001 — probe must never crash the doctor
+        print(f"  could not import memory.config: {type(e).__name__}: {e}")
+        return 0
+
+    if getattr(config, "_OXIDATION_DISABLED", False):
+        print("  status   : disabled via M3_CORE_RS_DISABLE (pure-Python by choice)")
+        return 0
+
+    rs = config.m3_core_rs
+    if rs is None:
+        print("  status   : not installed — pure-Python fallback (supported, slower)")
+        print("  hint     : `pip install m3-memory[oxidation]` for native speedups")
+        return 0
+
+    try:
+        version = getattr(rs, "__version__", "unknown")
+        present = [n for n, _ in _EXPECTED if hasattr(rs, n)]
+        missing = [(n, why) for n, why in _EXPECTED if not hasattr(rs, n)]
+    except Exception as e:  # noqa: BLE001 — a hostile/broken extension object
+        print(f"  status   : installed but uninspectable: {type(e).__name__}: {e}")
+        return 0
+
+    print(f"  status   : installed (version {version})")
+    print(f"  functions: {len(present)}/{len(_EXPECTED)} expected native paths present")
+
+    if not missing:
+        print("  result   : current — all expected native paths active")
+        return 0
+
+    # Present-but-stale: the wheel is old relative to the Python code's
+    # expectations. Loud, actionable, but non-fatal.
+    print("  result   : STALE — installed wheel is missing expected functions:")
+    for name, why in missing:
+        print(f"             - {name}: {why}")
+    print("  impact   : those paths silently use the slower Python fallback;")
+    print("             a stale wheel can also carry bugs already fixed in source.")
+    print("  fix      : rebuild/reinstall m3_core_rs from the current m3-core-rs")
+    print("             (e.g. reinstall the matching wheel or `maturin develop`).")
+    return 0

--- a/bin/memory/fts.py
+++ b/bin/memory/fts.py
@@ -114,28 +114,58 @@ _EVENT_PROPER_NOUN = re.compile(r"\b([A-Z][a-z]{2,})\b")
 # ──────────────────────────────────────────────────────────────────────────────
 # FTS5 sanitization
 # ──────────────────────────────────────────────────────────────────────────────
-# Strips FTS5 operators from user input so a query like "AND OR NOT *(foo)" can't
-# turn into a parse error or query injection. Operator words are matched as
-# whole words; bracket / wildcard punctuation is matched anywhere.
-_FTS_OPERATORS = re.compile(r"\b(OR|AND|NOT|NEAR)\b|[*()\[\]{}]")
+# Neutralizes FTS5 query syntax in user input so an arbitrary phrase can never
+# turn into a parse error or query injection. Two passes:
+#
+#   1. Operator WORDS (OR/AND/NOT/NEAR) — dangerous even though alphanumeric, so
+#      a punctuation strip alone won't catch them. Matched as whole words.
+#   2. Every non-(word|whitespace) CHARACTER → space. This is an ALLOWLIST, not
+#      a blocklist: in an FTS5 MATCH a *bare* term, almost all punctuation is a
+#      syntax error or operator — `-`/`:`/`{` silently change the parse
+#      ("gpt-4o" -> column-negation -> `no such column: 4o`), while `/ ! . , ; @
+#      = < > ~ | # $ % & \` ( ) [ ] *` raise outright. A whitelist regex that
+#      enumerated "bad" chars repeatedly missed cases (`-`, then `:`, then `/`)
+#      and shipped a content-dependent ("intermittent") crash: any search with a
+#      model name / hyphenated id / range / field:value threw, while plain-word
+#      searches worked. Replacing with a space (not deleting) aligns the query
+#      with the default tokenizer, which already splits indexed content on these
+#      same characters — so `gpt-4o` -> `gpt 4o` still matches the stored row.
+#
+# Quoted exact-phrase queries are handled by `_compile_fts_query` BEFORE this
+# function is reached, so stripping quotes here is safe for that path.
+# `_FTS_OPERATORS` keeps its name (re-exported through the memory_core shim and
+# referenced by tests/test_fts_parity.py) but now matches operator WORDS only;
+# punctuation is handled by the broader `_FTS_NON_TERM` allowlist below.
+_FTS_OPERATORS = re.compile(r"\b(OR|AND|NOT|NEAR)\b")
+_FTS_NON_TERM = re.compile(r"[^\w\s]", re.UNICODE)
 
 
 def _sanitize_fts(query: str, max_len: int = 500) -> str:
-    """Strip FTS5 operators from user input to prevent query injection.
+    """Neutralize FTS5 query syntax in user input to prevent injection / crashes.
+
+    Returns a string safe to drop into an FTS5 `MATCH` as bare terms: operator
+    words removed, all non-word/non-space characters replaced with spaces.
 
     Oxidation: routed through m3_core_rs.sanitize_fts (byte-exact Rust port,
-    no regex engine) when the extension is present; the regex body below is the
-    parity fallback. Parity gated by tests/test_fts_parity.py.
+    no regex engine) when the extension exposes it; the regex body below is the
+    parity fallback. Parity gated by tests/test_fts_parity.py. Note the Rust
+    port MUST mirror the allowlist below — see crates/m3-fts/src/lib.rs.
     """
     _rs = config.m3_core_rs
-    if _rs is not None:
+    # hasattr guard: older installed wheels predate the FTS bindings (the
+    # function is simply absent). Probe explicitly instead of catching the
+    # AttributeError — a bare except here is what silently masked a stale wheel
+    # falling back to Python for days (see DESIGN §3, fail loud not silent).
+    if _rs is not None and hasattr(_rs, "sanitize_fts"):
         try:
             return _rs.sanitize_fts(query, max_len)
-        except Exception:  # noqa: BLE001 — FFI hiccup falls back to Python
+        except Exception:  # noqa: BLE001 — genuine FFI hiccup falls back to Python
             pass
     if len(query) > max_len:
         query = query[:max_len]
-    return _FTS_OPERATORS.sub(" ", query).strip()
+    query = _FTS_OPERATORS.sub(" ", query)
+    query = _FTS_NON_TERM.sub(" ", query)
+    return query.strip()
 
 
 # Mirror of the SQLite mi_fts_insert trigger sanitization. The trigger
@@ -174,16 +204,22 @@ def _compile_fts_query(query: str, mode: str) -> tuple[str, bool]:
     unique (query, mode). Parity gated by tests/test_fts_parity.py.
     """
     _rs = config.m3_core_rs
-    if _rs is not None:
+    # hasattr guard mirrors _sanitize_fts: older wheels lack compile_fts_query,
+    # and a bare except would silently mask the stale-wheel fallback (DESIGN §3).
+    if _rs is not None and hasattr(_rs, "compile_fts_query"):
         try:
             return tuple(_rs.compile_fts_query(query, mode))
-        except Exception:  # noqa: BLE001 — FFI hiccup falls back to Python
+        except Exception:  # noqa: BLE001 — genuine FFI hiccup falls back to Python
             pass
     is_exact_query = (query.startswith('"') and query.endswith('"')) or (
         query.startswith("'") and query.endswith("'")
     )
     if is_exact_query:
-        return f'"{query[1:-1]}"', True
+        # Escape interior double-quotes by doubling them — FTS5's own escape
+        # rule. Without this, an input like `"alpha"beta"` re-wraps to the
+        # unterminated string `"alpha"beta"` and FTS5 MATCH raises.
+        inner = query[1:-1].replace('"', '""')
+        return f'"{inner}"', True
     clean = _sanitize_fts(query)
     clean = _sanitize_for_searchable(clean)
     if not clean.strip():

--- a/bin/memory_doctor.py
+++ b/bin/memory_doctor.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""m3-memory doctor — thin CLI dispatcher over the three doctor phases.
+"""m3-memory doctor — thin CLI dispatcher over the doctor phases.
 
 Phases (each in its own module under bin/doctor/):
 
   - db_repair          legacy DB fixes (timestamps, relationships, JSON)
   - cascade_probe      embedding-cascade health (delegates to memory.doctor)
   - embed_server_probe Rust-side `m3-embed-server doctor` subprocess
+  - oxidation_probe    m3_core_rs native-extension presence/staleness report
 
 Each phase can be skipped via --skip-*. Exit code is the maximum across
-the non-skipped phases (most-severe wins).
+the non-skipped phases (most-severe wins). The embed-server and oxidation
+phases are report-only and never bump the exit code.
 
 Design note: this file is intentionally thin — narrow CLI + phase
 dispatch only. Logic lives in the bin/doctor/ submodules so each can be
@@ -46,6 +48,10 @@ def main() -> int:
     parser.add_argument(
         "--skip-embed-server", action="store_true",
         help="Skip the Rust-side m3-embed-server doctor subprocess.",
+    )
+    parser.add_argument(
+        "--skip-oxidation", action="store_true",
+        help="Skip the m3_core_rs native-extension status report.",
     )
     parser.add_argument(
         "--fix", action="store_true",
@@ -94,6 +100,13 @@ def main() -> int:
         # legitimately run m3 without `m3 embedder install`, and a missing
         # binary is not a Python-side failure.
         embed_server_probe.run()
+
+    if not args.skip_oxidation:
+        from doctor import oxidation_probe
+        # Report-only: a pure-Python deployment (no/old wheel) is supported, so
+        # this never bumps the exit code — it surfaces a stale wheel that would
+        # otherwise degrade silently.
+        oxidation_probe.run()
 
     return exit_code
 

--- a/tests/test_chatlog_roundtrip.py
+++ b/tests/test_chatlog_roundtrip.py
@@ -1,12 +1,11 @@
 """End-to-end roundtrip tests: write → flush → search → list conversations."""
 
-import asyncio
 import json
 import sqlite3
+
 import pytest
 
-
-from conftest import isolate_chatlog_env, create_memory_items_schema
+from conftest import create_memory_items_schema, isolate_chatlog_env
 
 
 @pytest.fixture
@@ -46,7 +45,6 @@ def _create_supporting_tables(db_path):
 @pytest.mark.skip(reason="Async queue lifecycle issues in test environment")
 async def test_roundtrip_write_and_search(chatlog_with_schema):
     """Insert 50 rows, flush, search them back."""
-    import chatlog_config
     import chatlog_core
 
     items = []
@@ -81,6 +79,92 @@ async def test_roundtrip_write_and_search(chatlog_with_schema):
     assert count > 0
 
     conn.close()
+
+
+@pytest.mark.asyncio
+async def test_search_with_filters_does_not_crash(chatlog_with_schema):
+    """chatlog_search_impl must accept its full filter set without raising.
+
+    Regression for a day-one bug (commit 1242f96): the unified-path branch
+    (chatlog DB == main DB) forwarded agent_id/since/until to
+    memory_search_scored_impl, which only ever accepted agent_filter/as_of —
+    so the unified path raised TypeError on every real call. No test exercised
+    chatlog_search_impl, so it survived ~7 weeks. This test calls the impl with
+    every filter populated and asserts a well-formed structured result.
+    """
+    import chatlog_core
+
+    # The minimal fixture schema predates the soft-delete column; production
+    # memory_items has it and _chatlog_search_separate filters on it. Add it
+    # here (scoped to this test) so the query path runs against a faithful
+    # schema without disturbing the shared fixture other tests rely on.
+    db_path = chatlog_with_schema["db_path"]
+    _conn = sqlite3.connect(str(db_path))
+    cols = {row[1] for row in _conn.execute("PRAGMA table_info(memory_items)")}
+    if "is_deleted" not in cols:
+        _conn.execute("ALTER TABLE memory_items ADD COLUMN is_deleted INTEGER DEFAULT 0")
+        _conn.commit()
+    _conn.close()
+
+    items = [
+        {
+            "content": f"alpha bravo charlie message {i}",
+            "role": "user" if i % 2 == 0 else "assistant",
+            "conversation_id": f"conv-{i % 2}",
+            "host_agent": "claude-code",
+            "provider": "anthropic",
+            "model_id": "claude-3-sonnet",
+            "agent_id": "agent-x",
+            "turn_index": i,
+            "variant": "test",
+        }
+        for i in range(6)
+    ]
+    await chatlog_core.chatlog_write_bulk_impl(items)
+    await chatlog_core._flush_once()
+
+    # The exact call that used to TypeError on the unified path: a real query
+    # plus every filter the tool exposes (agent_id/since/until + facets).
+    out = await chatlog_core.chatlog_search_impl(
+        query="bravo",
+        k=5,
+        conversation_id="conv-0",
+        host_agent="claude-code",
+        provider="anthropic",
+        model_id="claude-3-sonnet",
+        agent_id="agent-x",
+        since="2000-01-01",
+        until="2099-12-31",
+    )
+    payload = json.loads(out)
+
+    # Structured return, never a bare string or None (DESIGN §3).
+    assert isinstance(payload, dict)
+    assert isinstance(payload["results"], list)
+    assert isinstance(payload["count"], int)
+    assert payload["count"] == len(payload["results"])
+    assert "db_path" in payload and "unified" in payload
+    # conversation_id filter must be honored end-to-end.
+    for r in payload["results"]:
+        assert r["conversation_id"] == "conv-0"
+
+    # Empty query with filters only (the filter-only branch) returns recent
+    # rows for that conversation — a "browse", which should find the 3 conv-1
+    # messages written above.
+    out2 = await chatlog_core.chatlog_search_impl(
+        query="", k=5, conversation_id="conv-1",
+    )
+    payload2 = json.loads(out2)
+    assert isinstance(payload2["results"], list)
+    assert payload2["count"] == len(payload2["results"])
+    assert payload2["count"] > 0  # blank query = browse, not "no results"
+
+    # Operator-only query ("---") sanitizes to no tokens. The user DID specify a
+    # term, so this must return ZERO results — not silently fall through to the
+    # browse branch and return the latest rows (a real prior footgun).
+    out3 = await chatlog_core.chatlog_search_impl(query="---", k=5)
+    payload3 = json.loads(out3)
+    assert payload3["count"] == 0, "operator-only query must not browse-fall-through"
 
 
 @pytest.mark.asyncio

--- a/tests/test_fts_parity.py
+++ b/tests/test_fts_parity.py
@@ -39,10 +39,16 @@ MODES = ["fts5", "hybrid", "semantic", "exact", ""]
 
 
 def _py_sanitize(query, max_len=500):
-    """The pure-Python _sanitize_fts body, regardless of m3_core_rs presence."""
+    """The pure-Python _sanitize_fts body, regardless of m3_core_rs presence.
+
+    Mirrors the two-pass fts.py body: operator words removed, then every
+    non-word/non-space character replaced with a space (FTS5-MATCH allowlist).
+    """
     if len(query) > max_len:
         query = query[:max_len]
-    return ftsmod._FTS_OPERATORS.sub(" ", query).strip()
+    query = ftsmod._FTS_OPERATORS.sub(" ", query)
+    query = ftsmod._FTS_NON_TERM.sub(" ", query)
+    return query.strip()
 
 
 def _py_compile(query, mode):
@@ -51,7 +57,8 @@ def _py_compile(query, mode):
         query.startswith("'") and query.endswith("'")
     )
     if is_exact_query:
-        return f'"{query[1:-1]}"', True
+        inner = query[1:-1].replace('"', '""')
+        return f'"{inner}"', True
     clean = _py_sanitize(query)
     clean = ftsmod._sanitize_for_searchable(clean)
     if not clean.strip():

--- a/tests/test_fts_sanitize.py
+++ b/tests/test_fts_sanitize.py
@@ -1,0 +1,129 @@
+"""Behavioral regression tests for the FTS5 query sanitizer.
+
+These are deliberately NOT parity tests (those live in test_fts_parity.py and
+compare the Python body against the Rust port). This file pins the *contract*
+that matters to callers: whatever `_sanitize_fts` / `_compile_fts_query`
+produce must be safe to hand to an FTS5 `MATCH` clause without raising.
+
+Regression for a real, content-dependent ("intermittent") production bug: the
+sanitizer's blocklist regex left FTS5 operator characters (`-` `:` `^` `/` `.`
+and most other punctuation) in place, so any chatlog/memory search whose terms
+contained a model name (`gpt-4o`, `claude-code`), a hyphenated id, a range
+(`100-200MB`), or a `field:value` token raised
+`sqlite3.OperationalError: no such column: <token>` (or `syntax error near …`)
+deep inside FTS5 — while plain-word searches worked. The fix switched to an
+allowlist (`_FTS_NON_TERM`: replace every non-word/non-space char with a space).
+No behavioral test exercised the sanitizer against a live FTS5 table, so it
+survived. See bin/memory/fts.py `_FTS_NON_TERM` / `_sanitize_fts`.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# bin/ is on sys.path for the MCP server at runtime; mirror that for tests.
+_BIN = str(Path(__file__).resolve().parent.parent / "bin")
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+from memory.fts import _compile_fts_query, _sanitize_fts  # noqa: E402
+
+# Inputs that used to crash FTS5: each contains an operator character (`-`, `:`,
+# `^`) or a boolean keyword that FTS5 would otherwise interpret as syntax.
+_OPERATOR_INPUTS = [
+    "gpt-4o",
+    "claude-code",
+    "xyzzy-nomatch-query",
+    "100-200MB",
+    "model_id:claude",
+    "foo:bar",
+    "foo^bar",
+    "-leading",
+    "trailing-",
+    "a-b-c-d",
+    "AND OR NOT",
+    "NEAR/3 quux",
+    "co-author: jane",
+    '"alpha"beta"',  # quoted phrase with an interior quote (exact-mode path)
+    '"unterminated',
+]
+
+# Inputs that must keep working unchanged (no operator chars).
+_PLAIN_INPUTS = [
+    "PyPI limit increase",
+    "immich upload",
+    "hello world",
+    "single",
+    "",
+    "   ",
+]
+
+
+@pytest.fixture
+def fts_table():
+    """An in-memory FTS5 table mirroring how memory_items_fts is queried."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("CREATE VIRTUAL TABLE t USING fts5(x);")
+    conn.execute(
+        "INSERT INTO t(x) VALUES "
+        "('alpha gpt-4o claude-code beta nomatch model_id claude foo bar 100 200MB')"
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def _match_must_not_raise(conn: sqlite3.Connection, fts_query: str) -> int:
+    """Run an FTS5 MATCH; return row count. Raises if the query is malformed."""
+    if not fts_query.strip():
+        return 0
+    cur = conn.execute("SELECT count(*) FROM t WHERE t MATCH ?", [fts_query])
+    return cur.fetchone()[0]
+
+
+@pytest.mark.parametrize("raw", _OPERATOR_INPUTS + _PLAIN_INPUTS)
+def test_sanitize_fts_output_is_match_safe(fts_table, raw):
+    """`_sanitize_fts` output must never make FTS5 MATCH raise."""
+    sanitized = _sanitize_fts(raw)
+    # The contract: no FTS5 operator chars survive into a bare MATCH term.
+    for ch in "-:^*()[]{}":
+        assert ch not in sanitized, f"{ch!r} survived sanitization of {raw!r}: {sanitized!r}"
+    # And it must actually be accepted by FTS5.
+    _match_must_not_raise(fts_table, sanitized)
+
+
+@pytest.mark.parametrize("mode", ["fts5", "hybrid"])
+@pytest.mark.parametrize("raw", _OPERATOR_INPUTS + _PLAIN_INPUTS)
+def test_compile_fts_query_output_is_match_safe(fts_table, mode, raw):
+    """`_compile_fts_query` output must never make FTS5 MATCH raise."""
+    compiled, ok = _compile_fts_query(raw, mode)
+    if not ok:
+        # ok=False is the "no matchable tokens" signal; caller skips MATCH.
+        return
+    _match_must_not_raise(fts_table, compiled)
+
+
+def test_hyphenated_term_still_matches_content(fts_table):
+    """Stripping `-` to a space aligns with the tokenizer, so `gpt-4o` still hits.
+
+    The default FTS5 tokenizer splits indexed `gpt-4o` into `gpt` + `4o`, so a
+    query sanitized to `gpt 4o` matches the row. This guards against a naive
+    "delete the hyphen" fix (`gpt4o`) that would silently stop matching.
+    """
+    sanitized = _sanitize_fts("gpt-4o")
+    assert _match_must_not_raise(fts_table, sanitized) == 1
+
+
+def test_colon_term_does_not_become_column_filter(fts_table):
+    """`model_id:claude` must search for the words, not filter a column."""
+    sanitized = _sanitize_fts("model_id:claude")
+    # Both tokens are present in the row; should match, not raise on a bad column.
+    assert _match_must_not_raise(fts_table, sanitized) == 1
+
+
+def test_plain_query_is_untouched():
+    """Operator-free queries pass through with only whitespace trimming."""
+    assert _sanitize_fts("PyPI limit increase") == "PyPI limit increase"
+    assert _sanitize_fts("  hello world  ") == "hello world"

--- a/tests/test_oxidation_probe.py
+++ b/tests/test_oxidation_probe.py
@@ -1,0 +1,79 @@
+"""Tests for the doctor oxidation probe (bin/doctor/oxidation_probe.py).
+
+The probe is report-only: it must ALWAYS return 0 (a pure-Python or stale-wheel
+deployment is supported, not a failure) and must distinguish three states —
+not-installed, installed-and-current, installed-but-stale — in its output.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_BIN = str(Path(__file__).resolve().parent.parent / "bin")
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+from doctor import oxidation_probe  # noqa: E402
+
+from memory import config  # noqa: E402
+
+
+def _set_rs(monkeypatch, value):
+    monkeypatch.setattr(config, "m3_core_rs", value, raising=False)
+    monkeypatch.setattr(config, "_OXIDATION_DISABLED", False, raising=False)
+
+
+def test_returns_zero_when_not_installed(monkeypatch, capsys):
+    _set_rs(monkeypatch, None)
+    assert oxidation_probe.run() == 0
+    out = capsys.readouterr().out
+    assert "not installed" in out
+
+
+def test_returns_zero_when_disabled(monkeypatch, capsys):
+    monkeypatch.setattr(config, "m3_core_rs", object(), raising=False)
+    monkeypatch.setattr(config, "_OXIDATION_DISABLED", True, raising=False)
+    assert oxidation_probe.run() == 0
+    assert "disabled" in capsys.readouterr().out
+
+
+def test_reports_current_when_all_present(monkeypatch, capsys):
+    # A fake extension exposing every expected function.
+    fake = SimpleNamespace(__version__="9.9.9")
+    for name, _why in oxidation_probe._EXPECTED:
+        setattr(fake, name, lambda *a, **k: None)
+    _set_rs(monkeypatch, fake)
+
+    assert oxidation_probe.run() == 0
+    out = capsys.readouterr().out
+    assert "current" in out
+    assert "STALE" not in out
+
+
+def test_reports_stale_when_functions_missing(monkeypatch, capsys):
+    # Expose all but the two FTS functions — the real stale-wheel case.
+    fake = SimpleNamespace(__version__="1.0.0")
+    for name, _why in oxidation_probe._EXPECTED:
+        if name in ("sanitize_fts", "compile_fts_query"):
+            continue
+        setattr(fake, name, lambda *a, **k: None)
+    _set_rs(monkeypatch, fake)
+
+    assert oxidation_probe.run() == 0  # report-only: never fails the run
+    out = capsys.readouterr().out
+    assert "STALE" in out
+    assert "sanitize_fts" in out
+    assert "compile_fts_query" in out
+
+
+def test_never_raises_on_bad_config(monkeypatch, capsys):
+    # Even if m3_core_rs is a hostile object, the probe must not crash the doctor.
+    class Boom:
+        def __getattr__(self, name):
+            raise RuntimeError("boom")
+
+    _set_rs(monkeypatch, Boom())
+    # hasattr swallows the AttributeError path; RuntimeError from __getattr__
+    # would propagate through hasattr as False, so the probe still completes.
+    assert oxidation_probe.run() == 0


### PR DESCRIPTION
## Problem

Chatlog/memory search failed **intermittently** for days across all agents. Root cause: the FTS5 query sanitizer used a **blocklist** that only stripped `OR/AND/NOT/NEAR` and a few brackets, leaving `-` `:` `^` `/` `.` and most punctuation to reach the FTS5 `MATCH` parser.

Any search whose terms contained a model name (`gpt-4o`), a hyphenated id (`claude-code`), a range (`100-200MB`), or a `field:value` token raised `OperationalError: no such column …` / `syntax error near …`. Plain-word searches worked — hence the content-dependent "intermittent" presentation.

## Fixes

**Sanitizer (`bin/memory/fts.py`)** — switched the blocklist to an **allowlist**: strip operator words, then replace every non-word/non-space char with a space. Aligns with the default tokenizer (which splits indexed content on the same chars), so `gpt-4o` → `gpt 4o` still matches. Also escape interior double-quotes in the exact-phrase path (`"a"b"` → `"a""b"`), which previously crashed `MATCH` with an unterminated string.

**Chatlog search (`bin/chatlog_core.py`)** — the unified (chatlog DB == main DB) path:
- Route through `_chatlog_search_separate` instead of a dead delegation to `memory_search_scored_impl` that forwarded `agent_id/since/until` (params it never accepted → `TypeError` on every unified-config search).
- Operator-only queries (`"---"`) now return **zero** results instead of silently browsing the latest rows.
- Clamp `k` to `[1, MAX_SEARCH_K]` — SQLite `LIMIT -1` is UNBOUNDED, so a negative `k` would dump the entire chatlog into memory + JSON.

**Observability** — `hasattr` guards on the `m3_core_rs` FFI fallbacks (a stale wheel missing `sanitize_fts`/`compile_fts_query` was silently masked by a bare `except`, which is how this hid for days), plus a new report-only doctor probe `bin/doctor/oxidation_probe.py` that surfaces a present-but-stale native extension.

## Companion PR

The same allowlist + quote-escape fix is ported to Rust in **skynetcmd/m3-core-rs** (`m3-fts` crate). The Python fix is what protects deployments live today; the Rust fix prevents a future wheel rebuild from reintroducing the crash.

## Tests

- New behavioral FTS suite (`test_fts_sanitize.py`) driving **real FTS5** — no operator char may crash `MATCH`.
- Chatlog search regression (`test_chatlog_roundtrip.py`): unified path, full filter set, `k` clamp, operator-only query.
- Oxidation probe tests (`test_oxidation_probe.py`); parity oracle updated.
- 112 affected-suite tests green, ruff clean.