### PR TITLE
fix(install): cross-platform install hardening + m3-core-rs 3.6.6 + curate UUID-integrity

### DIFF
--- a/.antigravity-plugin/agents/curate-chatlog.md
+++ b/.antigravity-plugin/agents/curate-chatlog.md
@@ -22,6 +22,20 @@ You are a **subagent**. You can't pause for user input — every spawn produces 
 
 This is non-negotiable. Don't pretend you can wait for confirmation; you can't.
 
+## UUID integrity (read this before you propose any plan)
+
+**The single most dangerous failure mode of this agent is hallucinating UUID tails.** Documented in production with the sister agent `m3:curate-memory` (2026-06-07 session): the agent saw a short prefix in a status output, then later emitted a "full UUID" by extending that prefix with a plausible-looking tail it invented. The hallucinated full UUID happened to collide with the first 8 chars of a real, unrelated chatlog row — so the destructive op silently mutated the WRONG row instead of erroring as not-found. The chatlog store has the same exposure: DEDUP and PRUNE write paths trust the ids you emit.
+
+Hard rules — these apply in BOTH modes:
+
+1. **Every ID in your plan MUST be copy-pasted verbatim from a tool result in the current session.** Source-of-truth tools: `chatlog_search` (returns full row UUIDs in its result), and any direct sqlite query you ran. Heartbeats, summaries, and human-readable scratch space use short prefixes (8 chars) — those are display strings, NOT data.
+2. **Never type a UUID from short-term memory.** If you cannot point at the exact tool call whose output contained the ID verbatim, you are hallucinating. Drop the op.
+3. **Never reconstruct a UUID from a prefix.** A 36-char UUID has 128 bits of entropy; the first 8 chars are display-only.
+4. **Verification step before you emit the apply prompt:** scan the apply-prompt block you are about to send. For each ID in DEDUP / PROMOTE / PRUNE, confirm it appears character-for-character in the JSON / SQL result of a prior tool call in this conversation. If you cannot find it, **delete that op from the plan** — do not emit it. Emit `[curate-chatlog] phase=plan_integrity_drop n=<n>` after this scan, even if n=0, so the user sees you did it.
+5. **APPLY mode:** before constructing the `plan` dict, verify each ID in the invocation prompt appears in the PLAN spawn's output that the user pasted. If the invocation prompt references an ID that is NOT in the embedded PLAN block, refuse to act on it — record it under `errors` and skip the op.
+
+These rules cost almost nothing to follow (you already have the tool outputs in context) and are the only thing standing between "clean curation" and "silently corrupted chatlog store."
+
 ## Tool usage
 
 You have BOTH `mcp__memory__*` and `mcp__plugin_m3_m3__*` registered. Prefer `mcp__plugin_m3_m3__*` (current plugin namespace); fall back to `mcp__memory__*` if the plugin form errors.
@@ -143,9 +157,11 @@ If you find yourself writing a query without `type='chat_log'`, stop and add it.
    === END APPLY PROMPT ===
    ```
 
-   Include exact IDs (full UUIDs, not prefixes) so the apply spawn can act literally.
+   Include exact IDs (full UUIDs, not prefixes) so the apply spawn can act literally. See the UUID integrity section above: every UUID in this block MUST be copy-pasted verbatim from a prior tool result, NEVER reconstructed from a prefix.
 
-6. **Exit.** Do not pretend to wait for confirmation.
+6. **Emit `[curate-chatlog] phase=plan_integrity_drop n=<n>`** after the apply-prompt block, where n is the number of ops you dropped during the UUID integrity scan. Emit even when n=0 so the user sees you performed the check.
+
+7. **Exit.** Do not pretend to wait for confirmation.
 
 ## APPLY mode
 

--- a/.antigravity-plugin/agents/curate-memory.md
+++ b/.antigravity-plugin/agents/curate-memory.md
@@ -20,6 +20,20 @@ You are a **subagent**. You can't pause for user input — every spawn produces 
 
 This is non-negotiable. Don't pretend you can wait for confirmation; you can't.
 
+## UUID integrity (read this before you propose any plan)
+
+**The single most dangerous failure mode of this agent is hallucinating UUID tails.** It has happened in production (2026-06-07 session): the agent saw a short prefix in a status output (`b8662939...`), then later emitted a "full UUID" by extending that prefix with a plausible-looking tail it invented. The hallucinated full UUID **happened to collide with the first 8 chars of a real, unrelated memory** — so the destructive op silently mutated the WRONG memory instead of erroring as not-found.
+
+Hard rules — these apply in BOTH modes:
+
+1. **Every ID in your plan MUST be copy-pasted verbatim from a tool result in the current session.** Source-of-truth tools: `memory_dedup` (returns `groups[].a` and `groups[].b` as full UUIDs), `memory_search` (returns `id` as full UUID), `memory_get` (the same).
+2. **Never type a UUID from short-term memory.** If you cannot point at the exact tool call whose output contained the ID verbatim, you are hallucinating. Drop the op.
+3. **Never reconstruct a UUID from a prefix.** Heartbeats, summaries, and human-readable logs in your scratch space use short prefixes (8 chars). Those are display strings, NOT data. Treat them as opaque labels — never feed them back into a plan.
+4. **Verification step before you emit the apply prompt:** scan the apply-prompt block you are about to send. For each ID in DELETE / SUPERSEDE / CONSOLIDATE / LINK, confirm it appears character-for-character in the JSON result of a prior tool call in this conversation. If you cannot find it, **delete that op from the plan** — do not emit it. Emit `[curate-memory] phase=plan_integrity_drop n=<n>` after this scan, even if n=0, so the user sees you did it.
+5. **APPLY mode:** before constructing the `plan` dict, verify each ID in the invocation prompt appears in the PLAN spawn's output that the user pasted. If the invocation prompt references an ID that is NOT in the embedded PLAN block, refuse to act on it — record it under `errors` and skip the op.
+
+These rules cost almost nothing to follow (you already have the tool outputs in context) and are the only thing standing between "clean curation" and "silently corrupted memory store."
+
 ## Tool usage
 
 You have BOTH `mcp__memory__*` and `mcp__plugin_m3_m3__*` registered. Prefer the `mcp__plugin_m3_m3__*` form (current plugin namespace); fall back to `mcp__memory__*` if the plugin form errors. Both call the same backend.
@@ -119,7 +133,7 @@ Run this sequence in order. Stop as soon as you have enough signal — don't pad
 
 8. **Heartbeat: `clustering_done` with `n_clusters=<n>`.**
 
-4. **Output the apply-prompt.** End your message with this exact structured block:
+9. **Output the apply-prompt.** End your message with this exact structured block:
 
    ```
    === APPLY PROMPT (copy this back as the next invocation) ===
@@ -135,9 +149,11 @@ Run this sequence in order. Stop as soon as you have enough signal — don't pad
    === END APPLY PROMPT ===
    ```
 
-   Make the IDs full UUIDs (not truncated prefixes) — the apply spawn parses them literally.
+   Make the IDs full UUIDs (not truncated prefixes) — the apply spawn parses them literally. See the UUID integrity section above: every UUID in this block MUST be copy-pasted verbatim from a prior tool result, NEVER reconstructed from a prefix.
 
-5. **Exit.** Do not pretend to wait for confirmation.
+10. **Emit `[curate-memory] phase=plan_integrity_drop n=<n>`** after the apply-prompt block, where n is the number of ops you dropped during the UUID integrity scan. Emit even when n=0 so the user sees you performed the check.
+
+11. **Exit.** Do not pretend to wait for confirmation.
 
 ## APPLY mode
 
@@ -171,4 +187,4 @@ APPLY is **one tool call**. The MCP tool `curate_memory_apply(plan=...)` takes t
 
 ## When to hand back
 
-After APPLY mode runs (success or failure), exit with the report. After PLAN mode, exit with the apply-prompt block. The parent agent (or user decides what to do next.
+After APPLY mode runs (success or failure), exit with the report. After PLAN mode, exit with the apply-prompt block. The parent agent (or user) decides what to do next.

--- a/agents/curate-chatlog.md
+++ b/agents/curate-chatlog.md
@@ -22,6 +22,20 @@ You are a **subagent**. You can't pause for user input — every spawn produces 
 
 This is non-negotiable. Don't pretend you can wait for confirmation; you can't.
 
+## UUID integrity (read this before you propose any plan)
+
+**The single most dangerous failure mode of this agent is hallucinating UUID tails.** Documented in production with the sister agent `m3:curate-memory` (2026-06-07 session): the agent saw a short prefix in a status output, then later emitted a "full UUID" by extending that prefix with a plausible-looking tail it invented. The hallucinated full UUID happened to collide with the first 8 chars of a real, unrelated chatlog row — so the destructive op silently mutated the WRONG row instead of erroring as not-found. The chatlog store has the same exposure: DEDUP and PRUNE write paths trust the ids you emit.
+
+Hard rules — these apply in BOTH modes:
+
+1. **Every ID in your plan MUST be copy-pasted verbatim from a tool result in the current session.** Source-of-truth tools: `chatlog_search` (returns full row UUIDs in its result), and any direct sqlite query you ran. Heartbeats, summaries, and human-readable scratch space use short prefixes (8 chars) — those are display strings, NOT data.
+2. **Never type a UUID from short-term memory.** If you cannot point at the exact tool call whose output contained the ID verbatim, you are hallucinating. Drop the op.
+3. **Never reconstruct a UUID from a prefix.** A 36-char UUID has 128 bits of entropy; the first 8 chars are display-only.
+4. **Verification step before you emit the apply prompt:** scan the apply-prompt block you are about to send. For each ID in DEDUP / PROMOTE / PRUNE, confirm it appears character-for-character in the JSON / SQL result of a prior tool call in this conversation. If you cannot find it, **delete that op from the plan** — do not emit it. Emit `[curate-chatlog] phase=plan_integrity_drop n=<n>` after this scan, even if n=0, so the user sees you did it.
+5. **APPLY mode:** before constructing the `plan` dict, verify each ID in the invocation prompt appears in the PLAN spawn's output that the user pasted. If the invocation prompt references an ID that is NOT in the embedded PLAN block, refuse to act on it — record it under `errors` and skip the op.
+
+These rules cost almost nothing to follow (you already have the tool outputs in context) and are the only thing standing between "clean curation" and "silently corrupted chatlog store."
+
 ## Tool usage
 
 You have BOTH `mcp__memory__*` and `mcp__plugin_m3_m3__*` registered. Prefer `mcp__plugin_m3_m3__*` (current plugin namespace); fall back to `mcp__memory__*` if the plugin form errors.
@@ -143,9 +157,11 @@ If you find yourself writing a query without `type='chat_log'`, stop and add it.
    === END APPLY PROMPT ===
    ```
 
-   Include exact IDs (full UUIDs, not prefixes) so the apply spawn can act literally.
+   Include exact IDs (full UUIDs, not prefixes) so the apply spawn can act literally. See the UUID integrity section above: every UUID in this block MUST be copy-pasted verbatim from a prior tool result, NEVER reconstructed from a prefix.
 
-6. **Exit.** Do not pretend to wait for confirmation.
+6. **Emit `[curate-chatlog] phase=plan_integrity_drop n=<n>`** after the apply-prompt block, where n is the number of ops you dropped during the UUID integrity scan. Emit even when n=0 so the user sees you performed the check.
+
+7. **Exit.** Do not pretend to wait for confirmation.
 
 ## APPLY mode
 

--- a/agents/curate-memory.md
+++ b/agents/curate-memory.md
@@ -20,6 +20,20 @@ You are a **subagent**. You can't pause for user input — every spawn produces 
 
 This is non-negotiable. Don't pretend you can wait for confirmation; you can't.
 
+## UUID integrity (read this before you propose any plan)
+
+**The single most dangerous failure mode of this agent is hallucinating UUID tails.** It has happened in production (2026-06-07 session): the agent saw a short prefix in a status output (`b8662939...`), then later emitted a "full UUID" by extending that prefix with a plausible-looking tail it invented. The hallucinated full UUID **happened to collide with the first 8 chars of a real, unrelated memory** — so the destructive op silently mutated the WRONG memory instead of erroring as not-found.
+
+Hard rules — these apply in BOTH modes:
+
+1. **Every ID in your plan MUST be copy-pasted verbatim from a tool result in the current session.** Source-of-truth tools: `memory_dedup` (returns `groups[].a` and `groups[].b` as full UUIDs), `memory_search` (returns `id` as full UUID), `memory_get` (the same).
+2. **Never type a UUID from short-term memory.** If you cannot point at the exact tool call whose output contained the ID verbatim, you are hallucinating. Drop the op.
+3. **Never reconstruct a UUID from a prefix.** Heartbeats, summaries, and human-readable logs in your scratch space use short prefixes (8 chars). Those are display strings, NOT data. Treat them as opaque labels — never feed them back into a plan.
+4. **Verification step before you emit the apply prompt:** scan the apply-prompt block you are about to send. For each ID in DELETE / SUPERSEDE / CONSOLIDATE / LINK, confirm it appears character-for-character in the JSON result of a prior tool call in this conversation. If you cannot find it, **delete that op from the plan** — do not emit it. Emit `[curate-memory] phase=plan_integrity_drop n=<n>` after this scan, even if n=0, so the user sees you did it.
+5. **APPLY mode:** before constructing the `plan` dict, verify each ID in the invocation prompt appears in the PLAN spawn's output that the user pasted. If the invocation prompt references an ID that is NOT in the embedded PLAN block, refuse to act on it — record it under `errors` and skip the op.
+
+These rules cost almost nothing to follow (you already have the tool outputs in context) and are the only thing standing between "clean curation" and "silently corrupted memory store."
+
 ## Tool usage
 
 You have BOTH `mcp__memory__*` and `mcp__plugin_m3_m3__*` registered. Prefer the `mcp__plugin_m3_m3__*` form (current plugin namespace); fall back to `mcp__memory__*` if the plugin form errors. Both call the same backend.
@@ -119,7 +133,7 @@ Run this sequence in order. Stop as soon as you have enough signal — don't pad
 
 8. **Heartbeat: `clustering_done` with `n_clusters=<n>`.**
 
-4. **Output the apply-prompt.** End your message with this exact structured block:
+9. **Output the apply-prompt.** End your message with this exact structured block:
 
    ```
    === APPLY PROMPT (copy this back as the next invocation) ===
@@ -135,9 +149,11 @@ Run this sequence in order. Stop as soon as you have enough signal — don't pad
    === END APPLY PROMPT ===
    ```
 
-   Make the IDs full UUIDs (not truncated prefixes) — the apply spawn parses them literally.
+   Make the IDs full UUIDs (not truncated prefixes) — the apply spawn parses them literally. See the UUID integrity section above: every UUID in this block MUST be copy-pasted verbatim from a prior tool result, NEVER reconstructed from a prefix.
 
-5. **Exit.** Do not pretend to wait for confirmation.
+10. **Emit `[curate-memory] phase=plan_integrity_drop n=<n>`** after the apply-prompt block, where n is the number of ops you dropped during the UUID integrity scan. Emit even when n=0 so the user sees you performed the check.
+
+11. **Exit.** Do not pretend to wait for confirmation.
 
 ## APPLY mode
 

--- a/install_os.py
+++ b/install_os.py
@@ -143,8 +143,23 @@ def install_node_manager():
             run_cmd(["bash", "-c", "curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell"])
             print("  -> fnm installed. Please follow the terminal instructions to add it to your shell.")
 
-def setup_oxidation(pip_exe):
-    """Prompts the user to install Project Oxidation (Rust compute core)."""
+def setup_oxidation():
+    """Prompts the user to install Project Oxidation (Rust compute core).
+
+    Delegates to m3_memory.rust_core_install, which:
+      - Auto-detects the right backend (Metal on macOS, CUDA/Vulkan/CPU on
+        Linux+Windows) and picks the matching prebuilt PyPI wheel
+        (m3-core-rs-<os>-<backend>).
+      - Falls back to a source build with the correct Cargo features
+        (--features embedded-metal / embedded-cuda / embedded-vulkan) if no
+        prebuilt wheel matches this platform/Python.
+      - Installs into the *current* Python (sys.executable — the pipx venv
+        where mcp-memory itself runs), NOT a sibling repo/.venv that
+        mcp-memory can't see.
+
+    The non-interactive code path (env M3_INSTALL_OXIDATION=1/0) lets
+    install.sh / install.ps1 drive this unattended.
+    """
     print("\n" + "="*50)
     print("🦀 PROJECT OXIDATION: HIGH-PERFORMANCE RUST CORE")
     print("="*50)
@@ -153,28 +168,58 @@ def setup_oxidation(pip_exe):
     print("  - Massive speedups: 1.3x to 520x (AVERAGE 85x BENEFIT) on hot paths.")
     print("  - Instantaneous vector math & cosine similarity.")
     print("  - Ultra-fast hybrid search ranking and chatlog redaction.")
-    print("\n[NOTE] This requires a one-time setup of Rust/C++ build tools.")
-    print("The performance gains will apply to every subsequent M3 interaction.")
+    print("\n[NOTE] Prebuilt wheels are tried first (no toolchain needed).")
+    print("Source fallback requires Rust + a C/C++ compiler.")
 
-    choice = input("\nWould you like to install Project Oxidation now? [y/N]: ").strip().lower()
+    # Non-interactive override for install.sh / install.ps1.
+    env_choice = os.environ.get("M3_INSTALL_OXIDATION", "").strip().lower()
+    if env_choice in ("0", "false", "no", "n"):
+        choice = "n"
+    elif env_choice in ("1", "true", "yes", "y"):
+        choice = "y"
+    else:
+        try:
+            choice = input(
+                "\nWould you like to install Project Oxidation now? [y/N]: "
+            ).strip().lower()
+        except EOFError:
+            # Piped stdin exhausted (e.g. `printf '\n' | install-m3`).
+            # Default to skip — caller can run `m3 embedder install-gpu` later.
+            choice = "n"
+
     if choice in ("y", "yes"):
-        system = _os_name()
-        if system == "Windows":
+        if _os_name() == "Windows":
             print("\n[*] Checking for Windows C++ Build Tools...")
             script = os.path.join(BASE_DIR, "install_oxidation_buildtools.ps1")
             if os.path.exists(script):
-                print("  -> Please run this script in an ADMINISTRATOR PowerShell to install build tools:")
-                print(f"     powershell -ExecutionPolicy Bypass -File {script}")
-                input("\nPress Enter AFTER you have run the build tools script (or to attempt install anyway)...")
+                print("  -> If the source-fallback build fails, run this script in an")
+                print("     ADMINISTRATOR PowerShell first:")
+                print(f"       powershell -ExecutionPolicy Bypass -File {script}")
 
-        print("\n[*] Installing m3-core-rs from git...")
-        run_cmd([pip_exe, "install",
-                 "m3-core-rs @ git+https://github.com/skynetcmd/m3-core-rs.git@v0.9.0#subdirectory=crates/m3-core-py"])
-        print("✅ Project Oxidation installed successfully!")
+        print("\n[*] Installing m3-core-rs (prebuilt wheel preferred)...")
+        try:
+            # Local import: m3_memory is importable here because install_os.py
+            # is launched under the same interpreter that runs mcp-memory (the
+            # pipx venv). This avoids the historical bug where setup_oxidation
+            # installed into repo/.venv/bin/pip, leaving the pipx-installed
+            # mcp-memory unable to import m3_core_rs.
+            from m3_memory.rust_core_install import install_rust_core
+        except ImportError as e:
+            print(f"  ⚠️  m3_memory.rust_core_install not importable ({e}).")
+            print("     Skipping Oxidation. Install later via: m3 embedder install-gpu")
+            return
+
+        rc = install_rust_core()
+        if rc == 0:
+            print("✅ Project Oxidation installed successfully!")
+        else:
+            print(f"⚠️  Project Oxidation install returned exit {rc}.")
+            print("    The CPU embedder still serves embeddings (Tier-2 HTTP).")
+            print("    Retry later: m3 embedder install-gpu")
     else:
         print(
-            "Skipping Project Oxidation. You can install it later via:\n"
-            "  pip install 'm3-core-rs @ git+https://github.com/skynetcmd/m3-core-rs.git@v0.9.0#subdirectory=crates/m3-core-py'"
+            "Skipping Project Oxidation. Install it later via:\n"
+            "  m3 embedder install-gpu"
         )
 
 def main():
@@ -218,7 +263,9 @@ def main():
         run_cmd([pip_exe, "install", "fastmcp", "httpx", "numpy", "keyring", "cryptography", "psycopg2-binary"])
 
     # 4. Project Oxidation (Rust Core)
-    setup_oxidation(pip_exe)
+    # No pip_exe arg — setup_oxidation installs into the current interpreter
+    # (the pipx venv where mcp-memory runs), not into repo/.venv.
+    setup_oxidation()
 
     # 5. Initialize local SQLite Database Schema
     print("\n[5/6] Initializing local Agent Memory schema...")

--- a/install_os.py
+++ b/install_os.py
@@ -209,13 +209,21 @@ def setup_oxidation():
             print("     Skipping Oxidation. Install later via: m3 embedder install-gpu")
             return
 
-        rc = install_rust_core()
+        # allow_source_fallback=False: the curl-install.sh flow should not
+        # silently launch a multi-minute Rust+cmake build that surprises the
+        # user. If both prebuilt paths miss, install_rust_core prints a
+        # multi-line recommendation (prereqs + manual command). The user can
+        # then opt in deliberately via `m3 embedder install-gpu`.
+        rc = install_rust_core(allow_source_fallback=False)
         if rc == 0:
             print("✅ Project Oxidation installed successfully!")
         else:
-            print(f"⚠️  Project Oxidation install returned exit {rc}.")
-            print("    The CPU embedder still serves embeddings (Tier-2 HTTP).")
-            print("    Retry later: m3 embedder install-gpu")
+            # install_rust_core already printed the recommendation. Keep
+            # this terse — repeating it would just push the helpful info
+            # off the user's screen.
+            print(f"\n⚠️  Project Oxidation prebuilt unavailable (exit {rc}).")
+            print("    Embeddings still work via the tier-2 HTTP fallback.")
+            print("    See above for source-build steps if you want native speed.")
     else:
         print(
             "Skipping Project Oxidation. Install it later via:\n"

--- a/m3_memory/rust_core_install.py
+++ b/m3_memory/rust_core_install.py
@@ -30,10 +30,10 @@ from typing import Optional
 from m3_memory._platform import os_name as _os_name
 
 # Release this m3-memory build expects. Bump in lockstep with the m3-core-rs
-# release tag (v2026.05.30 == 3.5.30). Used as the version pin for both the
+# release tag (v2026.06.07 == 3.6.6). Used as the version pin for both the
 # prebuilt PyPI install and the source-build fallback.
-M3_CORE_RS_VERSION = "3.5.30"
-M3_CORE_RS_GIT_TAG = "v2026.05.30"
+M3_CORE_RS_VERSION = "3.6.6"
+M3_CORE_RS_GIT_TAG = "v2026.06.07"
 
 # Cargo features per backend, mirroring build_wheel.py's _MATRIX (the source
 # fallback passes these to maturin via pip's config-settings).
@@ -257,31 +257,249 @@ def install_prebuilt(choice: BackendChoice, *, version: str = M3_CORE_RS_VERSION
     )
 
 
+def _find_executable(candidates: list[str]) -> Optional[str]:
+    """Return the first executable from candidates that exists and runs.
+
+    A binary that exists but isn't executable by the current user is
+    treated as absent (same end-user symptom: the build can't invoke it).
+    """
+    for cmd in candidates:
+        path = shutil.which(cmd)
+        if path:
+            try:
+                subprocess.run([path, "--version"], capture_output=True, timeout=5)
+                return path
+            except (PermissionError, OSError):
+                pass  # binary exists but not executable for this user
+    return None
+
+
+def _find_cargo() -> Optional[str]:
+    """Locate cargo, including rustup-installed toolchains not on PATH.
+
+    The friction case (2026-06-07): user had rustup-installed Rust but
+    ~/.cargo/bin wasn't sourced, so `shutil.which("cargo")` returned None
+    even though cargo was at ~/.rustup/toolchains/<triple>/bin/cargo. The
+    source-build then failed mid-compile with a cryptic error after pip
+    had already pulled all deps. Probing rustup's toolchain dirs catches
+    this and lets us report a clean missing-prereq error up front.
+    """
+    found = _find_executable(["cargo"])
+    if found:
+        return found
+
+    # ~/.cargo/bin is rustup's "current toolchain" symlink dir
+    candidate = os.path.expanduser("~/.cargo/bin/cargo")
+    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+
+    # Toolchain-specific dirs (rustup default install w/o PATH wiring)
+    rustup_home = os.path.expanduser(os.environ.get("RUSTUP_HOME", "~/.rustup"))
+    toolchains_dir = os.path.join(rustup_home, "toolchains")
+    if os.path.isdir(toolchains_dir):
+        try:
+            for toolchain in os.listdir(toolchains_dir):
+                candidate = os.path.join(toolchains_dir, toolchain, "bin", "cargo")
+                if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                    return candidate
+        except OSError:
+            pass
+    return None
+
+
 def _check_build_tools() -> list[str]:
     """Return a list of missing build tools needed for a source build.
 
-    Checks for cmake and a C++ compiler. Both must be executable by the
-    current user — a binary that exists but isn't executable is reported
-    as missing (same symptom as absent).
+    Checks for cmake, a C++ compiler, and the Rust toolchain (cargo). All
+    must be executable by the current user — a binary that exists but
+    isn't executable is reported as missing (same symptom as absent).
+
+    Rust check probes rustup's toolchain dirs in addition to PATH — see
+    _find_cargo for the rationale.
     """
     missing = []
-    for tool, candidates in [
-        ("cmake",   ["cmake"]),
-        ("C++ compiler", ["c++", "g++", "clang++"]),
-    ]:
-        found = False
-        for cmd in candidates:
-            path = shutil.which(cmd)
-            if path:
-                try:
-                    subprocess.run([path, "--version"], capture_output=True, timeout=5)
-                    found = True
-                    break
-                except (PermissionError, OSError):
-                    pass  # binary exists but not executable for this user
-        if not found:
-            missing.append(tool)
+    if not _find_executable(["cmake"]):
+        missing.append("cmake")
+    if not _find_executable(["c++", "g++", "clang++"]):
+        missing.append("C++ compiler")
+    if not _find_cargo():
+        missing.append("Rust (cargo)")
     return missing
+
+
+def _print_manual_build_recommendation(
+    choice: BackendChoice, *, pypi_rc: int, release_rc: int
+) -> None:
+    """Print a multi-line, actionable recommendation when both prebuilt
+    paths missed and the caller has disabled auto-source-build.
+
+    Two audiences read this:
+      - The curl-install.sh user who saw "Project Oxidation" prompt say yes.
+        For them, the wheel isn't critical — tier-2 HTTP keeps embeddings
+        working. They need to know that (so they don't think they're broken)
+        AND how to opt into the optional build if they want the speed.
+      - Operators triaging a CI/non-interactive deploy. They need the exact
+        repro: package name, version, and the explicit command to run.
+    """
+    feats = ",".join(choice.features) if choice.features else "(none)"
+    install_rust_cmd = (
+        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+    )
+    print(
+        f"\n[rust-core] No prebuilt wheel available for {choice.package} "
+        f"{M3_CORE_RS_VERSION} on this Python.\n"
+        f"            PyPI returned exit {pypi_rc}; "
+        f"GitHub Release returned exit {release_rc}.\n"
+        f"\n"
+        f"            Embeddings still work without it: the tier-2 HTTP\n"
+        f"            embedder (m3-embed-server on port 8082) serves every\n"
+        f"            request. The native wheel just makes embeddings\n"
+        f"            5-10x faster (in-process Rust vs HTTP round-trip).\n"
+        f"\n"
+        f"            To install the native wheel by compiling from source:\n"
+        f"\n"
+        f"            1. Install prerequisites:\n"
+        f"                 macOS:          xcode-select --install && brew install cmake\n"
+        f"                 Debian/Ubuntu:  sudo apt install cmake build-essential\n"
+        f"                 Fedora/RHEL:    sudo dnf install cmake gcc-c++\n"
+        f"                 Arch:           sudo pacman -S cmake base-devel\n"
+        f"                 Windows:        install Visual Studio Build Tools (C++ workload)\n"
+        f"\n"
+        f"            2. Install the Rust toolchain (if not already present):\n"
+        f"                 {install_rust_cmd}\n"
+        f"                 source \"$HOME/.cargo/env\"\n"
+        f"\n"
+        f"            3. Run the source-build path explicitly:\n"
+        f"                 m3 embedder install-gpu\n"
+        f"\n"
+        f"            (Will build {choice.package} from "
+        f"{M3_CORE_RS_GIT_TAG} with features: {feats}.)\n",
+        file=sys.stderr,
+    )
+
+
+# GitHub Release fallback — owner/repo for the published-wheels release.
+# Kept module-level so tests can monkeypatch and so a fork can override
+# without touching the install logic.
+M3_CORE_RS_GH_REPO = "skynetcmd/m3-core-rs"
+
+
+def install_from_github_release(
+    choice: BackendChoice, *,
+    version: str = M3_CORE_RS_VERSION,
+    git_tag: str = M3_CORE_RS_GIT_TAG,
+    repo: str = M3_CORE_RS_GH_REPO,
+) -> int:
+    """Try to install the matching prebuilt wheel from the GitHub Release.
+
+    Sits between install_prebuilt (PyPI) and install_from_source. The
+    GitHub Release is the canonical home for wheels too large for PyPI's
+    100 MiB cap (Linux CUDA static build is 464 MB) and a defensive
+    fallback for every other backend when PyPI is missing the right
+    version. Public release only — unauthenticated GitHub API; draft
+    releases are invisible here by design.
+
+    Wheel naming convention (set by m3-core-rs/crates/m3-core-py/build_wheel.py):
+        m3_core_rs_<os>_<backend>-<version>-cp<py>-cp<py>-<platform_tag>.whl
+    The platform tag varies per backend (manylinux_2_17 for Linux CPU,
+    bare linux_x86_64 for Linux CUDA static, macosx_*_arm64, win_amd64, ...).
+    We match by the deterministic prefix — `m3_core_rs_<os>_<backend>-<ver>-cp<py>-`
+    — and pick the single asset that starts with it. If multiple match,
+    pick the first (sorted) so the choice is deterministic across runs.
+
+    Returns 0 on success, non-zero on any failure (API miss, no asset,
+    download failure, pip rejection). On non-zero the caller falls through
+    to install_from_source.
+    """
+    import json
+    import tempfile
+    import urllib.error
+    import urllib.request
+
+    py_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    asset_prefix = f"m3_core_rs_{choice.os_tok}_{choice.backend}-{version}-{py_tag}-"
+
+    print(f"[rust-core] looking for GitHub Release asset matching "
+          f"{asset_prefix}*.whl  (repo={repo}, tag={git_tag})")
+
+    api_url = f"https://api.github.com/repos/{repo}/releases/tags/{git_tag}"
+    try:
+        req = urllib.request.Request(
+            api_url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "m3-memory-installer",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            release = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"[rust-core] release {git_tag} not found on GitHub "
+                  f"(may be draft or not yet published); skipping Release fallback",
+                  file=sys.stderr)
+        else:
+            print(f"[rust-core] GitHub API HTTP {e.code} fetching {git_tag}; "
+                  f"skipping Release fallback", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        print(f"[rust-core] GitHub API fetch failed ({type(e).__name__}: {e}); "
+              f"skipping Release fallback", file=sys.stderr)
+        return 1
+
+    assets = release.get("assets") or []
+    matches = sorted(
+        (a for a in assets if str(a.get("name", "")).startswith(asset_prefix)),
+        key=lambda a: a["name"],
+    )
+    if not matches:
+        print(f"[rust-core] no Release asset matches {asset_prefix}*.whl "
+              f"({len(assets)} assets in {git_tag})", file=sys.stderr)
+        return 1
+
+    asset = matches[0]
+    wheel_url = asset["browser_download_url"]
+    wheel_name = asset["name"]
+    wheel_size = asset.get("size", 0)
+    print(f"[rust-core] downloading {wheel_name} "
+          f"({wheel_size / (1024*1024):.1f} MiB)...")
+
+    tmp_path: Optional[str] = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".whl", delete=False) as tmp:
+            tmp_path = tmp.name
+            chunk_size = 1024 * 1024  # 1 MiB
+            downloaded = 0
+            next_progress = 10 * 1024 * 1024  # progress dot every 10 MiB
+            try:
+                with urllib.request.urlopen(wheel_url, timeout=300) as resp:
+                    while True:
+                        chunk = resp.read(chunk_size)
+                        if not chunk:
+                            break
+                        tmp.write(chunk)
+                        downloaded += len(chunk)
+                        if downloaded >= next_progress:
+                            print(f"[rust-core]   ... "
+                                  f"{downloaded / (1024*1024):.0f} MiB",
+                                  file=sys.stderr)
+                            next_progress += 10 * 1024 * 1024
+            except (urllib.error.URLError, OSError) as e:
+                print(f"[rust-core] wheel download failed "
+                      f"({type(e).__name__}: {e})", file=sys.stderr)
+                return 1
+        print(f"[rust-core] downloaded {downloaded / (1024*1024):.1f} MiB; "
+              f"installing via pip...")
+        return _pip_install_with_pep668_fallback(
+            "install", "--force-reinstall", "--no-deps", tmp_path,
+        )
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def install_from_source(choice: BackendChoice, *,
@@ -300,13 +518,20 @@ def install_from_source(choice: BackendChoice, *,
     if missing:
         print(
             f"[rust-core] source build requires: {', '.join(missing)}\n"
-            "  On Debian/Ubuntu:  sudo apt install cmake build-essential\n"
-            "  On Fedora/RHEL:    sudo dnf install cmake gcc-c++\n"
-            "  On Arch:           sudo pacman -S cmake base-devel\n"
-            "  If cmake/c++ exists but gives 'Permission denied', the binary\n"
-            "  is not executable by this user — ask an admin to fix permissions\n"
-            "  or install the package for this user's distro.\n"
-            "  CPU embedding (Tier-1/Tier-2) works without this.",
+            "  cmake + C++:\n"
+            "    Debian/Ubuntu:  sudo apt install cmake build-essential\n"
+            "    Fedora/RHEL:    sudo dnf install cmake gcc-c++\n"
+            "    Arch:           sudo pacman -S cmake base-devel\n"
+            "    macOS:          xcode-select --install && brew install cmake\n"
+            "  Rust toolchain:\n"
+            "    All platforms:  curl --proto '=https' --tlsv1.2 -sSf "
+            "https://sh.rustup.rs | sh -s -- -y\n"
+            "    Then source the env: source \"$HOME/.cargo/env\"\n"
+            "  If cmake/c++/cargo exists but gives 'Permission denied', the\n"
+            "  binary is not executable by this user — ask an admin to fix\n"
+            "  permissions or install the package for this user's distro.\n"
+            "  Embeddings still work without this: Tier-2 HTTP fallback serves\n"
+            "  every embed request (no native build needed).",
             file=sys.stderr,
         )
         return 1
@@ -361,22 +586,36 @@ def install_rust_core(os_tok: Optional[str] = None, *,
               f"{choice.os_tok}-{choice.backend}", file=sys.stderr)
         return 2
 
+    # Three-tier install cascade:
+    #   1. PyPI prebuilt — fastest path, no toolchain.
+    #   2. GitHub Release prebuilt — defensive fallback for size-capped builds
+    #      (Linux CUDA wheel is 464 MB, can never go on PyPI) and for any
+    #      backend where PyPI is missing this version.
+    #   3. Source build — last resort, needs Rust + cmake + C++ + backend SDK.
     rc = install_prebuilt(choice)
     if rc == 0:
-        print(f"[rust-core] installed {choice.package} {M3_CORE_RS_VERSION}")
+        print(f"[rust-core] installed {choice.package} {M3_CORE_RS_VERSION} "
+              f"(PyPI prebuilt)")
+        return 0
+
+    print(f"[rust-core] PyPI prebuilt unavailable for {choice.package} "
+          f"(pip exit {rc}); trying GitHub Release fallback.", file=sys.stderr)
+    rc_gh = install_from_github_release(choice)
+    if rc_gh == 0:
+        print(f"[rust-core] installed {choice.package} {M3_CORE_RS_VERSION} "
+              f"(GitHub Release)")
         return 0
 
     if not allow_source_fallback:
-        print(f"[rust-core] no prebuilt wheel for {choice.package} on this "
-              f"platform/Python (pip exit {rc}); source fallback disabled.",
-              file=sys.stderr)
-        return rc
+        _print_manual_build_recommendation(choice, pypi_rc=rc, release_rc=rc_gh)
+        return rc_gh
 
-    print(f"[rust-core] no prebuilt wheel for {choice.package} "
-          f"(pip exit {rc}); falling back to source build.", file=sys.stderr)
-    rc = install_from_source(choice)
-    if rc != 0:
-        print(f"[rust-core] source build failed (exit {rc}). The CPU embedder "
-              f"still serves embeddings; see docs/EMBED_DEPLOYMENT.md.",
+    print(f"[rust-core] no prebuilt wheel available for {choice.package} "
+          f"(PyPI={rc}, Release={rc_gh}); falling back to source build.",
+          file=sys.stderr)
+    rc_src = install_from_source(choice)
+    if rc_src != 0:
+        print(f"[rust-core] source build failed (exit {rc_src}). The CPU "
+              f"embedder still serves embeddings; see docs/EMBED_DEPLOYMENT.md.",
               file=sys.stderr)
-    return rc
+    return rc_src

--- a/m3_memory/rust_core_install.py
+++ b/m3_memory/rust_core_install.py
@@ -465,41 +465,50 @@ def install_from_github_release(
     print(f"[rust-core] downloading {wheel_name} "
           f"({wheel_size / (1024*1024):.1f} MiB)...")
 
-    tmp_path: Optional[str] = None
+    # Download into a temp DIR, keeping the original filename: pip parses
+    # the wheel filename per PEP 427 to identify the package, so the file
+    # must be named e.g. m3_core_rs_macos_metal-3.6.6-cp314-cp314-macosx_11_0_arm64.whl
+    # — a random NamedTemporaryFile path like /tmp/tmpXXXX.whl is rejected
+    # by pip with "Invalid wheel filename (wrong number of parts)".
+    tmp_dir = tempfile.mkdtemp(prefix="m3-core-rs-")
+    wheel_path = os.path.join(tmp_dir, wheel_name)
     try:
-        with tempfile.NamedTemporaryFile(suffix=".whl", delete=False) as tmp:
-            tmp_path = tmp.name
-            chunk_size = 1024 * 1024  # 1 MiB
-            downloaded = 0
-            next_progress = 10 * 1024 * 1024  # progress dot every 10 MiB
-            try:
-                with urllib.request.urlopen(wheel_url, timeout=300) as resp:
-                    while True:
-                        chunk = resp.read(chunk_size)
-                        if not chunk:
-                            break
-                        tmp.write(chunk)
-                        downloaded += len(chunk)
-                        if downloaded >= next_progress:
-                            print(f"[rust-core]   ... "
-                                  f"{downloaded / (1024*1024):.0f} MiB",
-                                  file=sys.stderr)
-                            next_progress += 10 * 1024 * 1024
-            except (urllib.error.URLError, OSError) as e:
-                print(f"[rust-core] wheel download failed "
-                      f"({type(e).__name__}: {e})", file=sys.stderr)
-                return 1
+        downloaded = 0
+        try:
+            with urllib.request.urlopen(wheel_url, timeout=300) as resp, \
+                 open(wheel_path, "wb") as out:
+                chunk_size = 1024 * 1024            # 1 MiB
+                next_progress = 10 * 1024 * 1024    # heartbeat every 10 MiB
+                while True:
+                    chunk = resp.read(chunk_size)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    downloaded += len(chunk)
+                    if downloaded >= next_progress:
+                        print(f"[rust-core]   ... "
+                              f"{downloaded / (1024*1024):.0f} MiB",
+                              file=sys.stderr)
+                        next_progress += 10 * 1024 * 1024
+        except (urllib.error.URLError, OSError) as e:
+            print(f"[rust-core] wheel download failed "
+                  f"({type(e).__name__}: {e})", file=sys.stderr)
+            return 1
+
+        if downloaded == 0:
+            print(f"[rust-core] wheel download yielded 0 bytes", file=sys.stderr)
+            return 1
+
         print(f"[rust-core] downloaded {downloaded / (1024*1024):.1f} MiB; "
               f"installing via pip...")
         return _pip_install_with_pep668_fallback(
-            "install", "--force-reinstall", "--no-deps", tmp_path,
+            "install", "--force-reinstall", "--no-deps", wheel_path,
         )
     finally:
-        if tmp_path:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+        try:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        except OSError:
+            pass
 
 
 def install_from_source(choice: BackendChoice, *,

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -438,8 +438,10 @@ def _step_preflight(plan: SetupPlan, args: argparse.Namespace) -> bool:
                 os.environ["M3_EMBED_GGUF"] = discovered
                 plan.embed_gguf = discovered
                 _ok(f"  M3_EMBED_GGUF set for this session: {discovered}")
-                _say("  (to persist: add to your shell rc OR "
-                     "let the wizard's m3-embed-server install pin it)")
+                # Persist so every new shell and every MCP server spawn picks
+                # it up automatically. Without this, tier-1 falls back to
+                # tier-2 the next time anything reads the env.
+                _persist_embed_gguf(discovered, non_interactive=args.non_interactive)
     else:
         _say("  no BGE-M3 GGUF auto-discovered; tier-2 (:8082) will serve all embeds")
         _say("  (set M3_EMBED_GGUF later to enable tier-1; see EMBEDDER_ARCHITECTURE.md)")
@@ -484,15 +486,176 @@ def _kill_process_windows(pid: int) -> bool:
         return False
 
 
+def _persist_embed_gguf(gguf_path: str, *, non_interactive: bool) -> None:
+    """Persist M3_EMBED_GGUF so new shells + spawned MCP servers see it.
+
+    Two surfaces, both idempotent and cross-platform:
+
+      1. Shell env — so `mcp-memory doctor` and other CLI invocations see
+         the var without the wizard's process being in scope:
+           - Unix (macOS / Linux): append `export M3_EMBED_GGUF=...` to
+             ~/.zshrc on zsh, ~/.bashrc on bash, ~/.profile fallback.
+           - Windows: `setx M3_EMBED_GGUF <path>` writes to the user env
+             (HKCU\\Environment), so new cmd / PowerShell sessions inherit
+             it. setx does NOT update the current process or other open
+             shells — that's fine, the wizard's own os.environ is already set.
+
+      2. The 'memory' MCP server entry's `env` block in
+         ~/.claude/settings.json and ~/.gemini/settings.json. MCP servers
+         are spawned by Claude Code / Gemini CLI as subprocesses that DO NOT
+         inherit the user's interactive shell env on macOS (launchd) or
+         Windows (GUI process tree). Without this, the shell rc alone never
+         reaches them. Same code path on all 3 platforms — Path.home()
+         resolves correctly on each.
+
+    Failure on any surface is reported as a warning but does not abort:
+    the GGUF is still set in *this* process, which is enough for the
+    rest of setup. Best-effort across surfaces matches the wizard's
+    overall posture (post-install steps print warnings, don't crash).
+    """
+    _persist_embed_gguf_shell(gguf_path, non_interactive=non_interactive)
+    _persist_embed_gguf_mcp(gguf_path)
+
+
+def _persist_embed_gguf_shell(gguf_path: str, *, non_interactive: bool) -> None:
+    """Persist M3_EMBED_GGUF for new shell sessions (per-platform mechanism)."""
+    if sys.platform == "win32":
+        # Windows: setx writes to HKCU\Environment. Persists across reboot;
+        # new cmd / PowerShell sessions see it. The current process and
+        # other already-open shells are unaffected (by design).
+        if not non_interactive and not _ask_yes_no(
+            "  Persist M3_EMBED_GGUF to your Windows user environment (setx)?",
+            default=True,
+        ):
+            _warn(f"    skipped — set it later: setx M3_EMBED_GGUF \"{gguf_path}\"")
+            return
+        try:
+            result = subprocess.run(
+                ["setx", "M3_EMBED_GGUF", gguf_path],
+                capture_output=True, text=True, timeout=10,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            _warn(f"    setx failed ({e}); set it later: setx M3_EMBED_GGUF \"{gguf_path}\"")
+            return
+        if result.returncode == 0:
+            _ok(f"    persisted M3_EMBED_GGUF via setx (new shells will see it)")
+        else:
+            stderr = (result.stderr or result.stdout or "").strip()
+            _warn(f"    setx exited {result.returncode}: {stderr}")
+        return
+
+    # Unix: append `export M3_EMBED_GGUF=...` to the appropriate shell rc.
+    rc_path = _pick_unix_shell_rc()
+
+    if not non_interactive and not _ask_yes_no(
+        f"  Persist M3_EMBED_GGUF to {rc_path}?", default=True
+    ):
+        _warn(f"    skipped — set it later: echo 'export M3_EMBED_GGUF={gguf_path}' >> {rc_path}")
+        return
+
+    try:
+        existing = rc_path.read_text(encoding="utf-8") if rc_path.exists() else ""
+    except OSError as e:
+        _warn(f"    could not read {rc_path} ({e}); skipping shell rc persistence")
+        return
+
+    if "M3_EMBED_GGUF" in existing:
+        _ok(f"    M3_EMBED_GGUF already present in {rc_path}")
+        return
+
+    block = (
+        "\n# Added by m3 setup — tier-1 in-process BGE-M3 embedder\n"
+        f'export M3_EMBED_GGUF="{gguf_path}"\n'
+    )
+    try:
+        with rc_path.open("a", encoding="utf-8") as f:
+            f.write(block)
+        _ok(f"    persisted M3_EMBED_GGUF -> {rc_path}")
+    except OSError as e:
+        _warn(f"    failed to write {rc_path} ({e})")
+
+
+def _pick_unix_shell_rc() -> Path:
+    """Pick the shell rc file most likely to be read on this Unix system.
+
+    Order:
+      1. ~/.zshrc if SHELL points at zsh (macOS default since Catalina)
+      2. ~/.bashrc if SHELL points at bash (most Linux distros)
+      3. First existing among (~/.zshrc, ~/.bashrc, ~/.bash_profile, ~/.profile)
+      4. Default to ~/.zshrc (covers fresh macOS Spotlight users)
+    """
+    home = Path.home()
+    shell = os.environ.get("SHELL", "")
+    if "zsh" in shell:
+        return home / ".zshrc"
+    if "bash" in shell:
+        return home / ".bashrc"
+    for candidate in (home / ".zshrc", home / ".bashrc",
+                      home / ".bash_profile", home / ".profile"):
+        if candidate.exists():
+            return candidate
+    return home / ".zshrc"
+
+
+def _persist_embed_gguf_mcp(gguf_path: str) -> None:
+    """Patch the 'memory' MCP server entry's env block on every platform.
+
+    MCP servers are spawned by Claude Code / Gemini CLI as subprocesses; on
+    macOS (launchd) and Windows (GUI process tree) they do not inherit the
+    user's interactive shell env. Setting the env on the MCP server entry
+    itself is the only reliable way the spawned server sees M3_EMBED_GGUF.
+
+    Same code on all 3 platforms — Path.home() resolves to ~/, %USERPROFILE%,
+    or /home/<user> as appropriate.
+    """
+    for label, settings_path in (
+        ("Claude Code", Path.home() / ".claude" / "settings.json"),
+        ("Gemini CLI",  Path.home() / ".gemini" / "settings.json"),
+    ):
+        if not settings_path.is_file():
+            continue
+        try:
+            cfg = json.loads(settings_path.read_text(encoding="utf-8")) or {}
+        except (OSError, json.JSONDecodeError) as e:
+            _warn(f"    {settings_path} is unreadable ({e}); skipping {label} env wiring")
+            continue
+        mcp = cfg.get("mcpServers")
+        if not isinstance(mcp, dict) or "memory" not in mcp:
+            # Memory MCP not yet registered — per-agent wiring step (later
+            # in setup) will create it. We don't pre-create here to avoid
+            # racing the wiring step's idempotency check.
+            continue
+        server = mcp["memory"]
+        env = server.setdefault("env", {})
+        if env.get("M3_EMBED_GGUF") == gguf_path:
+            _ok(f"    M3_EMBED_GGUF already set on {label} memory MCP entry")
+            continue
+        env["M3_EMBED_GGUF"] = gguf_path
+        try:
+            settings_path.write_text(
+                json.dumps(cfg, indent=2) + "\n", encoding="utf-8"
+            )
+            _ok(f"    set M3_EMBED_GGUF on {label} memory MCP entry ({settings_path})")
+        except OSError as e:
+            _warn(f"    failed to write {settings_path} ({e})")
+
+
 def _discover_bge_m3_gguf() -> str | None:
     """Mirror of m3-embed-server's discovery cascade (B5). Probes the same
     paths so the wizard's auto-discovery matches what `m3-embed-server`
     will pick up at install time.
+
+    Cross-platform notes:
+      - ~/.lmstudio/models works on macOS and Windows (LM Studio's default
+        on both — Path.home() handles the home-dir resolution per-OS).
+      - ~/Library/Application Support/LM Studio/models is macOS-specific.
+      - ~/.cache/lm-studio/models is LM Studio's Linux default (XDG cache).
     """
     home = Path.home()
     candidate_dirs = [
         home / ".lmstudio" / "models",
         home / "Library" / "Application Support" / "LM Studio" / "models",
+        home / ".cache" / "lm-studio" / "models",   # Linux LM Studio default (XDG)
         home / ".cache" / "m3" / "models",
         home / ".m3-memory" / "_assets" / "embedder",
         home / "models",
@@ -509,10 +672,16 @@ def _discover_bge_m3_gguf() -> str | None:
 
 
 def _step_install_m3(plan: SetupPlan) -> bool:
-    """Run install-m3 with the wizard's chosen capture-mode."""
+    """Run install-m3 with the wizard's chosen capture-mode.
+
+    Always passes --force so re-running `m3 setup` (or `install.sh`) upgrades
+    in place instead of aborting with "repo already exists". install_m3()
+    preserves user data (chatlog DB, .json/.jsonl state) across --force, so
+    this is non-destructive for upgrades and a no-op for fresh installs.
+    """
     _say("Step 1/5: fetching m3-memory system payload (install-m3)")
     cmd = [sys.executable, "-m", "m3_memory.cli", "install-m3",
-           "--non-interactive", "--capture-mode", plan.capture_mode]
+           "--non-interactive", "--force", "--capture-mode", plan.capture_mode]
     if plan.endpoint:
         cmd += ["--endpoint", plan.endpoint]
     if plan.cognitive_loop:

--- a/tests/test_rust_core_install.py
+++ b/tests/test_rust_core_install.py
@@ -138,34 +138,242 @@ def test_install_from_source_cpu_no_features(monkeypatch):
     assert "--config-settings" not in captured["argv"]
 
 
-def test_install_rust_core_prebuilt_success_no_fallback(monkeypatch):
+def test_install_rust_core_prebuilt_success_skips_fallbacks(monkeypatch):
+    """PyPI prebuilt succeeds — neither GitHub Release nor source attempted."""
     calls = []
-    monkeypatch.setattr(rci, "install_prebuilt", lambda c, **k: calls.append("prebuilt") or 0)
-    monkeypatch.setattr(rci, "install_from_source", lambda c, **k: calls.append("source") or 0)
+    monkeypatch.setattr(rci, "install_prebuilt",
+                        lambda c, **k: calls.append("prebuilt") or 0)
+    monkeypatch.setattr(rci, "install_from_github_release",
+                        lambda c, **k: calls.append("github") or 0)
+    monkeypatch.setattr(rci, "install_from_source",
+                        lambda c, **k: calls.append("source") or 0)
     monkeypatch.setattr(rci, "detect_backend",
                         lambda os_tok=None: rci.BackendChoice("linux", "cuda", "t"))
     rc = rci.install_rust_core()
     assert rc == 0
-    assert calls == ["prebuilt"]  # source NOT attempted
+    assert calls == ["prebuilt"]
 
 
-def test_install_rust_core_falls_back_to_source(monkeypatch):
+def test_install_rust_core_falls_back_pypi_to_github(monkeypatch):
+    """PyPI fails -> GitHub Release succeeds -> source NOT attempted.
+
+    Locks in the 3-tier order: PyPI -> GitHub Release -> source.
+    """
     calls = []
-    monkeypatch.setattr(rci, "install_prebuilt", lambda c, **k: calls.append("prebuilt") or 1)
-    monkeypatch.setattr(rci, "install_from_source", lambda c, **k: calls.append("source") or 0)
+    monkeypatch.setattr(rci, "install_prebuilt",
+                        lambda c, **k: calls.append("prebuilt") or 1)
+    monkeypatch.setattr(rci, "install_from_github_release",
+                        lambda c, **k: calls.append("github") or 0)
+    monkeypatch.setattr(rci, "install_from_source",
+                        lambda c, **k: calls.append("source") or 0)
+    monkeypatch.setattr(rci, "detect_backend",
+                        lambda os_tok=None: rci.BackendChoice("macos", "metal", "t"))
+    rc = rci.install_rust_core()
+    assert rc == 0
+    assert calls == ["prebuilt", "github"]
+
+
+def test_install_rust_core_falls_back_all_three_tiers(monkeypatch):
+    """PyPI + GitHub Release both fail -> source build attempted."""
+    calls = []
+    monkeypatch.setattr(rci, "install_prebuilt",
+                        lambda c, **k: calls.append("prebuilt") or 1)
+    monkeypatch.setattr(rci, "install_from_github_release",
+                        lambda c, **k: calls.append("github") or 1)
+    monkeypatch.setattr(rci, "install_from_source",
+                        lambda c, **k: calls.append("source") or 0)
     monkeypatch.setattr(rci, "detect_backend",
                         lambda os_tok=None: rci.BackendChoice("linux", "cuda", "t"))
     rc = rci.install_rust_core()
     assert rc == 0
-    assert calls == ["prebuilt", "source"]
+    assert calls == ["prebuilt", "github", "source"]
 
 
-def test_install_rust_core_no_fallback_when_disabled(monkeypatch):
+def test_install_rust_core_no_source_fallback_when_disabled(monkeypatch):
+    """allow_source_fallback=False -> PyPI + GitHub Release attempted, then
+    recommendation printed and source build NOT triggered. The curl install.sh
+    flow passes False so users aren't surprised by a multi-minute Rust build.
+    """
     calls = []
-    monkeypatch.setattr(rci, "install_prebuilt", lambda c, **k: calls.append("prebuilt") or 1)
-    monkeypatch.setattr(rci, "install_from_source", lambda c, **k: calls.append("source") or 0)
+    monkeypatch.setattr(rci, "install_prebuilt",
+                        lambda c, **k: calls.append("prebuilt") or 1)
+    monkeypatch.setattr(rci, "install_from_github_release",
+                        lambda c, **k: calls.append("github") or 1)
+    monkeypatch.setattr(rci, "install_from_source",
+                        lambda c, **k: calls.append("source") or 0)
     monkeypatch.setattr(rci, "detect_backend",
-                        lambda os_tok=None: rci.BackendChoice("linux", "cuda", "t"))
+                        lambda os_tok=None: rci.BackendChoice("macos", "metal", "t"))
     rc = rci.install_rust_core(allow_source_fallback=False)
+    assert rc != 0
+    assert calls == ["prebuilt", "github"]  # source NOT attempted
+
+
+# ── GitHub Release fallback ────────────────────────────────────────────────────
+
+
+class _FakeRespCtx:
+    """Mimics urlopen()'s context-manager + .read() interface."""
+    def __init__(self, payload: bytes, chunks: int = 0):
+        self._payload = payload
+        self._chunks = chunks
+        self._offset = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            data = self._payload[self._offset:]
+            self._offset = len(self._payload)
+            return data
+        data = self._payload[self._offset:self._offset + size]
+        self._offset += len(data)
+        return data
+
+
+def _gh_release_payload(asset_names: list[str]) -> bytes:
+    """Build a minimal GitHub release JSON with the named assets."""
+    import json as _json
+    return _json.dumps({
+        "tag_name": "v2026.06.07",
+        "assets": [
+            {
+                "name": name,
+                "size": 1024,
+                "browser_download_url": f"https://example.com/{name}",
+            }
+            for name in asset_names
+        ],
+    }).encode("utf-8")
+
+
+def test_github_release_finds_and_installs_matching_asset(monkeypatch):
+    """Picks the m3_core_rs_<os>_<backend>-<ver>-<py>-*.whl that matches
+    the current Python and pip-installs the downloaded file.
+    """
+    py_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    matching_name = f"m3_core_rs_macos_metal-3.6.6-{py_tag}-{py_tag}-macosx_11_0_arm64.whl"
+    payload = _gh_release_payload([
+        f"m3_core_rs_macos_metal-3.6.6-cp310-cp310-macosx_11_0_arm64.whl",  # wrong py
+        matching_name,                                                       # match
+        f"m3_core_rs_linux_cuda-3.6.6-{py_tag}-{py_tag}-linux_x86_64.whl",   # wrong os
+    ])
+
+    urlopen_calls = []
+    fake_wheel = b"PK\x03\x04" + b"fake wheel" * 100  # ZIP-ish header so it looks plausible
+
+    def fake_urlopen(req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else req
+        urlopen_calls.append(url)
+        if "api.github.com" in url:
+            return _FakeRespCtx(payload)
+        return _FakeRespCtx(fake_wheel)
+
+    # install_from_github_release imports urllib lazily — patch the global
+    # module so the lazy import in the function picks up our fake.
+    import urllib.request as _ur
+    monkeypatch.setattr(_ur, "urlopen", fake_urlopen)
+
+    pip_argv = []
+    monkeypatch.setattr(rci, "_pip_install_with_pep668_fallback",
+                        lambda *a: pip_argv.append(a) or 0)
+
+    choice = rci.BackendChoice("macos", "metal", "test")
+    rc = rci.install_from_github_release(choice)
+    assert rc == 0
+
+    # We made two HTTPS calls: GH API for the release, then wheel download
+    assert any("api.github.com" in u for u in urlopen_calls)
+    assert any(matching_name in u for u in urlopen_calls)
+
+    # pip got our temp wheel path
+    assert len(pip_argv) == 1
+    args = pip_argv[0]
+    assert args[0] == "install"
+    assert "--force-reinstall" in args
+    assert "--no-deps" in args
+    assert args[-1].endswith(".whl")
+
+
+def test_github_release_404_returns_nonzero(monkeypatch):
+    """Draft / missing release -> 1 (caller falls through). Don't raise."""
+    import urllib.request as _ur
+    import urllib.error as _ue
+
+    def fake_urlopen(req, timeout=None):
+        raise _ue.HTTPError(
+            url="https://api.github.com/...", code=404, msg="Not Found",
+            hdrs=None, fp=None,
+        )
+
+    monkeypatch.setattr(_ur, "urlopen", fake_urlopen)
+    choice = rci.BackendChoice("macos", "metal", "test")
+    rc = rci.install_from_github_release(choice)
     assert rc == 1
-    assert calls == ["prebuilt"]  # no source build
+
+
+def test_github_release_no_matching_asset_returns_nonzero(monkeypatch):
+    """API succeeds but no asset starts with the expected prefix."""
+    import urllib.request as _ur
+    py_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    payload = _gh_release_payload([
+        f"m3_core_rs_linux_cpu-3.6.6-{py_tag}-{py_tag}-manylinux2014.whl",
+        # No macos_metal asset
+    ])
+
+    monkeypatch.setattr(_ur, "urlopen",
+                        lambda req, timeout=None: _FakeRespCtx(payload))
+
+    choice = rci.BackendChoice("macos", "metal", "test")
+    rc = rci.install_from_github_release(choice)
+    assert rc == 1
+
+
+def test_github_release_network_error_returns_nonzero(monkeypatch):
+    """OSError / URLError on API request -> 1 (don't raise)."""
+    import urllib.request as _ur
+
+    def boom(req, timeout=None):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(_ur, "urlopen", boom)
+    choice = rci.BackendChoice("macos", "metal", "test")
+    rc = rci.install_from_github_release(choice)
+    assert rc == 1
+
+
+# ── build-tool preflight (cargo via rustup toolchains) ─────────────────────────
+
+
+def test_check_build_tools_includes_rust(monkeypatch):
+    """Source build needs Rust — _check_build_tools must catch missing cargo."""
+    # No cmake, no C++, no cargo, no rustup dirs.
+    monkeypatch.setattr(rci.shutil, "which", lambda x: None)
+    monkeypatch.setattr(rci.os.path, "isfile", lambda p: False)
+    monkeypatch.setattr(rci.os.path, "isdir", lambda p: False)
+    missing = rci._check_build_tools()
+    assert "Rust (cargo)" in missing
+
+
+def test_find_cargo_via_rustup_toolchain(monkeypatch, tmp_path):
+    """cargo not on PATH but rustup toolchain dir holds it -> found."""
+    # No cargo on PATH and no ~/.cargo/bin/cargo
+    monkeypatch.setattr(rci.shutil, "which", lambda x: None)
+
+    rustup_home = tmp_path / "rustup"
+    toolchain_bin = rustup_home / "toolchains" / "stable-aarch64-apple-darwin" / "bin"
+    toolchain_bin.mkdir(parents=True)
+    cargo_path = toolchain_bin / "cargo"
+    cargo_path.write_text("#!/bin/sh\necho cargo\n", encoding="utf-8")
+    cargo_path.chmod(0o755)
+
+    monkeypatch.setenv("RUSTUP_HOME", str(rustup_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "home-without-cargo"))  # no ~/.cargo
+
+    found = rci._find_cargo()
+    assert found is not None
+    assert "cargo" in found
+    assert "toolchains" in found

--- a/tests/test_setup_wizard_preflight.py
+++ b/tests/test_setup_wizard_preflight.py
@@ -427,3 +427,266 @@ def test_gather_plan_interactive_decouple_and_fips(monkeypatch):
     assert any("FIPS" in c for c in calls)
 
 
+# ────────────────────────────────────────────────────────────────────────
+# _step_install_m3 — must pass --force (macOS install hardening)
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_step_install_m3_passes_force(monkeypatch):
+    """Wizard must pass --force to install-m3 so re-running `m3 setup` (and
+    install.sh) upgrades in place instead of aborting with `repo already
+    exists`. install_m3() preserves user data on --force, so this is safe
+    and a no-op on fresh installs.
+    """
+    captured: list = []
+
+    class _FakeProc:
+        returncode = 0
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(cmd)
+        return _FakeProc()
+
+    monkeypatch.setattr(setup_wizard, "_run", fake_run)
+
+    plan = setup_wizard.SetupPlan()
+    plan.capture_mode = "both"
+    assert setup_wizard._step_install_m3(plan) is True
+
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert "install-m3" in cmd
+    assert "--force" in cmd, (
+        f"_step_install_m3 must pass --force; got: {cmd}"
+    )
+    assert "--non-interactive" in cmd
+    assert "--capture-mode" in cmd
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _persist_embed_gguf — Fix #7: M3_EMBED_GGUF persistence
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_persist_embed_gguf_writes_zshrc(monkeypatch, tmp_path):
+    """Non-interactive run writes the export to ~/.zshrc (zsh shell)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".zshrc").write_text("# existing rc\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.setattr(sys, "platform", "darwin")  # not win32
+
+    setup_wizard._persist_embed_gguf("/path/to/bge-m3.gguf", non_interactive=True)
+
+    content = (home / ".zshrc").read_text(encoding="utf-8")
+    assert "M3_EMBED_GGUF" in content
+    assert '"/path/to/bge-m3.gguf"' in content
+    # Original content is preserved
+    assert "# existing rc" in content
+
+
+def test_persist_embed_gguf_idempotent(monkeypatch, tmp_path):
+    """Re-running doesn't append a second export line."""
+    home = tmp_path / "home"
+    home.mkdir()
+    rc = home / ".zshrc"
+    rc.write_text(
+        '# already set\nexport M3_EMBED_GGUF="/old/path.gguf"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    setup_wizard._persist_embed_gguf("/new/path.gguf", non_interactive=True)
+
+    content = rc.read_text(encoding="utf-8")
+    assert content.count("M3_EMBED_GGUF") == 1, (
+        "Expected exactly one M3_EMBED_GGUF entry; got duplicate writes"
+    )
+    # Pre-existing path is left untouched (user already configured it)
+    assert "/old/path.gguf" in content
+
+
+def test_persist_embed_gguf_patches_claude_settings(monkeypatch, tmp_path):
+    """Adds env.M3_EMBED_GGUF to the 'memory' MCP entry in claude settings."""
+    import json
+
+    home = tmp_path / "home"
+    home.mkdir()
+    claude_dir = home / ".claude"
+    claude_dir.mkdir()
+    settings = claude_dir / "settings.json"
+    settings.write_text(json.dumps({
+        "mcpServers": {"memory": {"command": "mcp-memory"}},
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    setup_wizard._persist_embed_gguf("/path/to/bge-m3.gguf", non_interactive=True)
+
+    cfg = json.loads(settings.read_text(encoding="utf-8"))
+    mem = cfg["mcpServers"]["memory"]
+    assert mem.get("env", {}).get("M3_EMBED_GGUF") == "/path/to/bge-m3.gguf", (
+        f"Expected env wired on memory MCP entry; got: {mem}"
+    )
+
+
+def test_persist_embed_gguf_skips_settings_without_memory_entry(monkeypatch, tmp_path):
+    """If settings.json has no 'memory' entry yet, we don't pre-create it —
+    the per-agent wiring step later in setup is responsible for that."""
+    import json
+
+    home = tmp_path / "home"
+    home.mkdir()
+    claude_dir = home / ".claude"
+    claude_dir.mkdir()
+    settings = claude_dir / "settings.json"
+    settings.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    setup_wizard._persist_embed_gguf("/path/to/bge-m3.gguf", non_interactive=True)
+
+    cfg = json.loads(settings.read_text(encoding="utf-8"))
+    # No memory entry was conjured up out of nothing
+    assert "memory" not in cfg.get("mcpServers", {})
+
+
+def test_persist_embed_gguf_uses_setx_on_windows(monkeypatch, tmp_path):
+    """Windows uses `setx` instead of writing a shell rc — setx is the
+    canonical way to persist user env vars across reboot."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    captured: list = []
+
+    class _FakeResult:
+        returncode = 0
+        stdout = "SUCCESS: Specified value was saved."
+        stderr = ""
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(cmd)
+        return _FakeResult()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    setup_wizard._persist_embed_gguf("C:\\path\\bge-m3.gguf", non_interactive=True)
+
+    # Exactly one setx call with the right env var and path
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[0] == "setx"
+    assert cmd[1] == "M3_EMBED_GGUF"
+    assert cmd[2] == "C:\\path\\bge-m3.gguf"
+
+    # No Unix rc files were created (we did NOT fall through to the Unix path)
+    assert not (home / ".zshrc").exists()
+    assert not (home / ".bashrc").exists()
+
+
+def test_persist_embed_gguf_patches_mcp_settings_on_windows(monkeypatch, tmp_path):
+    """The MCP settings.json env wiring must run on Windows too — Claude
+    Code on Windows reads %USERPROFILE%\\.claude\\settings.json, and the
+    spawned MCP server doesn't inherit the user env from the GUI process."""
+    import json
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    settings = home / ".claude" / "settings.json"
+    settings.write_text(json.dumps({
+        "mcpServers": {"memory": {"command": "mcp-memory"}},
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(sys, "platform", "win32")
+    # Stub setx so the shell-env step doesn't try to execute a real binary.
+    monkeypatch.setattr(subprocess, "run",
+                        lambda *a, **kw: mock.Mock(returncode=0, stdout="", stderr=""))
+
+    setup_wizard._persist_embed_gguf("C:\\path\\bge-m3.gguf", non_interactive=True)
+
+    cfg = json.loads(settings.read_text(encoding="utf-8"))
+    mem = cfg["mcpServers"]["memory"]
+    assert mem.get("env", {}).get("M3_EMBED_GGUF") == "C:\\path\\bge-m3.gguf"
+
+
+def test_persist_embed_gguf_setx_failure_is_non_fatal(monkeypatch, tmp_path):
+    """A setx crash on Windows warns but does not abort — the GGUF is still
+    set in the current process, and that's enough for the rest of setup."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    def boom(*a, **kw):
+        raise OSError("setx not found")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    # Should not raise
+    setup_wizard._persist_embed_gguf("C:\\path\\bge-m3.gguf", non_interactive=True)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _pick_unix_shell_rc — Linux/macOS shell rc selection
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_pick_unix_shell_rc_prefers_zsh_when_shell_env_zsh(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    assert setup_wizard._pick_unix_shell_rc() == home / ".zshrc"
+
+
+def test_pick_unix_shell_rc_prefers_bashrc_when_shell_env_bash(monkeypatch, tmp_path):
+    """Linux default (bash) lands on ~/.bashrc — distinct from macOS default."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    assert setup_wizard._pick_unix_shell_rc() == home / ".bashrc"
+
+
+def test_pick_unix_shell_rc_falls_back_to_existing_file(monkeypatch, tmp_path):
+    """Unknown SHELL — pick whichever rc actually exists."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".profile").write_text("# ksh", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("SHELL", "/usr/local/bin/ksh")
+    assert setup_wizard._pick_unix_shell_rc() == home / ".profile"
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _discover_bge_m3_gguf — Linux LM Studio default path
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_discover_finds_gguf_in_linux_lmstudio_cache(monkeypatch, tmp_path):
+    """LM Studio on Linux stores models under ~/.cache/lm-studio/models —
+    the discovery cascade must include that path."""
+    home = tmp_path / "home"
+    linux_lm = home / ".cache" / "lm-studio" / "models"
+    linux_lm.mkdir(parents=True)
+    target = linux_lm / "bge-m3-Q4_K_M.gguf"
+    target.write_bytes(b"fake")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    found = setup_wizard._discover_bge_m3_gguf()
+    assert found is not None
+    assert Path(found) == target
+
+


### PR DESCRIPTION
## Summary

End-to-end hardening of the m3-memory install path on all 3 platforms,
plus the m3-core-rs 3.6.6 wheel cascade and a defensive fix for the
2026-06-07 curate-memory UUID-tail hallucination incident.

3 commits:

| SHA | Title |
|-----|-------|
| `0635190` | fix(setup): auto-force upgrade, pipx-aware oxidation, persist GGUF |
| `669fd7a` | fix(install): 3.6.6 + 3-tier wheel cascade + curate UUID-integrity |
| `f72eb82` | fix(install): preserve wheel filename for pip PEP 427 parsing |

## What changes (per fix)

### 1. `install.sh` re-runs no longer abort
`setup_wizard._step_install_m3` now passes `--force` to `install-m3`.
Without it, every re-run of the canonical installer (or `m3 setup`) on
an existing install aborts with "repo already exists". `install_m3()`
already preserves user data (`.db`, `.json`, `.jsonl`) across `--force`,
so the flag is safe on upgrades and a no-op on fresh installs.

Applies on macOS, Linux, and Windows identically.

### 2. Oxidation step installs the wheel into the right venv with right features
`install_os.setup_oxidation` no longer pip-installs into `repo/.venv` with
a stale hardcoded git tag. Delegates to `rust_core_install.install_rust_core()`,
which:
- Auto-detects backend (Metal / CUDA / Vulkan / CPU)
- Installs the matching prebuilt wheel from PyPI when available
- Falls back to the GitHub Release wheel (new — see §4)
- Falls back to source build only when the caller opted in
- Installs into `sys.executable` (the pipx venv `mcp-memory` runs in)

Linux CUDA / Vulkan users on the curl-install.sh path were silently
getting CPU-only source builds — now they get the matching prebuilt.

### 3. `M3_EMBED_GGUF` is persisted on every platform
`setup_wizard._persist_embed_gguf` (new) writes the auto-discovered GGUF
path to:
- Shell env: `~/.zshrc` / `~/.bashrc` / `.profile` fallback on Unix;
  `setx M3_EMBED_GGUF <path>` on Windows (HKCU\Environment).
- The `memory` MCP server entry's `env` block in `~/.claude/settings.json`
  and `~/.gemini/settings.json` on every platform — MCP servers spawned
  by Claude Code don't inherit the user's interactive shell env on
  macOS (launchd) or Windows (GUI process tree).

Adjacent: `_discover_bge_m3_gguf` now also probes
`~/.cache/lm-studio/models` (LM Studio's XDG-compliant Linux default).

### 4. 3-tier wheel install cascade
`install_rust_core` now tries, in order:
1. **PyPI prebuilt** — fastest path, no toolchain needed.
2. **GitHub Release prebuilt** (new) — lists release assets via API,
   matches `m3_core_rs_<os>_<backend>-<version>-cp<py>-*.whl`,
   downloads (chunked with progress), pip-installs. Defensive for
   every backend, **required** for Linux CUDA (464 MiB wheel cannot
   go on PyPI — 100 MiB cap).
3. **Source build** — only when caller opts in via `allow_source_fallback=True`.
   The CLI command `m3 embedder install-gpu` keeps this default. The
   curl-`install.sh` Oxidation prompt switches to `allow_source_fallback=False`
   and prints a multi-line per-OS recommendation (cmake + Rust install
   commands + the `m3 embedder install-gpu` opt-in line) when both
   prebuilt tiers miss.

`_check_build_tools` now includes Rust toolchain (was missing — silent
failure cause); `_find_cargo()` probes `~/.rustup/toolchains/*/bin/cargo`
to catch the rustup-installed-but-not-on-PATH case from the 2026-06-07
install transcript.

### 5. m3-core-rs version pin: 3.5.30 → 3.6.6 / v2026.05.30 → v2026.06.07
The 28 wheels are published at https://github.com/skynetcmd/m3-core-rs/releases/tag/v2026.06.07
(7 backends × cp311–314, released 2026-06-08).

### 6. curate-memory / curate-chatlog UUID-tail hallucination defense
2026-06-07 incident: curate-memory reconstructed UUID tails from short
prefixes seen in its own status output. The hallucinated full UUID
collided with a real but unrelated memory's first 8 chars, so the
supersede operation mutated the **wrong** memory instead of erroring
as not-found.

New "UUID integrity" section in both agent prompts:
- Hard rule: copy verbatim from tool output, never reconstruct from prefix
- Verification step: scan each plan ID against prior tool results, drop
  ops whose IDs aren't found
- Mandatory `phase=plan_integrity_drop n=<n>` heartbeat (even at n=0)
- APPLY-mode refusal for IDs not present in the embedded PLAN block

Same fix applied to curate-chatlog (same latent risk). `.antigravity-plugin/`
mirrors synced.

## Live testing

- ✅ macOS Metal cp314 wheel installs cleanly from the published v2026.06.07
  release via `install_from_github_release` end-to-end
- ✅ `backend_label()` returns `metal`, `EmbeddedEmbedder` present after install
- ✅ Pre-push leak scan: clean
- ✅ Pre-push tool-catalog drift gate: skipped (no catalog/doc paths in push)

## Test plan

- [ ] Run `pytest tests/test_setup_wizard_preflight.py tests/test_installer.py tests/test_rust_core_install.py` — should be 80 passed / 3 skipped
- [ ] On a clean macOS Apple Silicon: `curl ... install.sh | bash`, accept Oxidation prompt → tier-1 metal works
- [ ] On a clean Linux + CUDA box: same flow → install_from_github_release downloads the 464 MB CUDA wheel
- [ ] On Windows: `setx M3_EMBED_GGUF ...` writes to user env after wizard run
- [ ] Smoke-test linux-cuda wheel on real NVIDIA hardware (deferred per maintainer call)

## Notes for reviewers

- Files: 10 total (3 setup/install + 1 rust core + 1 test + 4 agent prompt + 1 install_os)
- +1090 / -92 LOC
- No backwards-incompatible changes to public API surface
- The curate-* prompt changes only ship via the plugin cache; existing
  in-flight curate sessions are unaffected until plugin reload