### PR TITLE
test(memory/graph): regression test for entity-graph seed stopword filter

### DIFF
--- a/tests/test_graph_seed_stopwords.py
+++ b/tests/test_graph_seed_stopwords.py
@@ -1,0 +1,90 @@
+"""Regression test for the entity-graph seed stopword filter (memory/graph.py).
+
+Locks the behavior added in PR #13 (dd6f1ed): sentence-initial Title-Case common
+words ("Can", "What", "How", "I", ...) that _ENTITY_MENTION_RE captures as if they
+were proper nouns must be dropped from the entity-graph seed candidate list before
+any entity lookup runs. Without this, seed "Can" LIKE-matches "Canada"/"Canva" and
+its BFS neighbors displace gold turns (measured -13.3pp at session-hit-rate@k=5 on
+single-session-preference questions; the filter restores that to 0pp).
+
+The fix was shipped with a pre-registered metric but no test gated it — this closes
+that §3/§11 gap. The test exercises the real _ENTITY_MENTION_RE + _QUERY_STARTER_
+STOPWORDS from memory.graph (no DB / embedder needed), replicating the exact Step-1
+seed-extraction loop so a regression in either the regex or the stoplist is caught.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
+
+from memory.graph import _ENTITY_MENTION_RE, _QUERY_STARTER_STOPWORDS  # noqa: E402
+
+
+def _extract_seeds(query: str) -> list[str]:
+    """Mirror of the Step-1 seed-extraction loop in _entity_graph_neighbor_ids.
+
+    Kept in lockstep with memory/graph.py: if that loop's filter condition changes,
+    update here too — the point is to assert the observable seed list, using the
+    real regex and stoplist objects (not copies) so drift in either is caught.
+    """
+    candidates: list[str] = []
+    seen_cands: set[str] = set()
+    for m in _ENTITY_MENTION_RE.finditer(query):
+        text = m.group(0).strip("\"'")
+        if text and text not in seen_cands and text not in _QUERY_STARTER_STOPWORDS:
+            seen_cands.add(text)
+            candidates.append(text)
+    return candidates
+
+
+# ── the stoplist itself ──────────────────────────────────────────────────────
+
+def test_stoplist_is_nonempty_frozenset():
+    assert isinstance(_QUERY_STARTER_STOPWORDS, frozenset)
+    assert len(_QUERY_STARTER_STOPWORDS) >= 40  # 43 at time of writing
+
+
+@pytest.mark.parametrize("word", ["Can", "What", "How", "Why", "Is", "Do", "I", "You", "Please", "Hello"])
+def test_common_query_starters_are_in_stoplist(word):
+    assert word in _QUERY_STARTER_STOPWORDS
+
+
+# ── observable filtering behavior on real queries ────────────────────────────
+
+@pytest.mark.parametrize(
+    "query, must_keep, must_drop",
+    [
+        # The canonical regression case: "Can" must not survive to match "Canada".
+        ("Can you recommend a show like Stranger Things",
+         ["Stranger Things"], ["Can"]),
+        # First-person + question starter dropped; real place kept.
+        ("What should I serve at my dinner party in Canada",
+         ["Canada"], ["What", "I"]),
+        # "How"/"I" dropped, product name kept.
+        ("How do I reset my Peloton",
+         ["Peloton"], ["How", "I"]),
+    ],
+)
+def test_starters_filtered_real_entities_survive(query, must_keep, must_drop):
+    seeds = _extract_seeds(query)
+    for kept in must_keep:
+        assert kept in seeds, f"expected entity {kept!r} in seeds: {seeds}"
+    for dropped in must_drop:
+        assert dropped not in seeds, f"stopword {dropped!r} leaked into seeds: {seeds}"
+
+
+def test_query_of_only_starters_yields_no_seeds():
+    # A purely conversational opener should produce zero entity-graph seeds,
+    # so the BFS short-circuits instead of chasing spurious neighbors.
+    assert _extract_seeds("Can you help me") == []
+
+
+def test_proper_noun_not_in_stoplist_is_kept():
+    # Sanity: a genuine Title-Case entity that is NOT a starter must survive.
+    seeds = _extract_seeds("Tell me about Barcelona")
+    assert "Barcelona" in seeds
+    assert "Tell" not in seeds  # "Tell" is a stoplisted imperative starter


### PR DESCRIPTION
## Summary

Adds the missing regression test for the entity-graph seed **stopword filter** (shipped in #13 / `dd6f1ed`). That fix landed with a pre-registered metric but **no test gated it** — a §3/§11 (robustness / bench-discipline) behavior-baseline gap per `docs/DESIGN_PHILOSOPHIES.md`. This closes it.

## Why it matters

The fix prevents sentence-initial Title-Case common words ("Can", "What", "How", "I") from being captured as entity-graph seeds, where "Can" LIKE-matched "Canada"/"Canva" and pulled spurious BFS neighbors into the top-k. Measured impact (from #13): **−13.3pp → 0pp** at session-hit-rate@k=5 on single-session-preference questions, +1.4pp @k=3 overall. Nothing locked that behavior until now.

## What the test does

Exercises the **real** `_ENTITY_MENTION_RE` + `_QUERY_STARTER_STOPWORDS` from `memory.graph` (no DB / embedder), replicating the Step-1 seed-extraction loop, and asserts:
- common query starters (Can/What/How/I/…) are in the stoplist;
- `"Can you recommend a show like Stranger Things"` → seeds keep `Stranger Things`, drop `Can` (the canonical false-match regression);
- a query of only starters yields zero seeds (BFS short-circuits);
- a genuine Title-Case entity **not** in the stoplist survives.

## Testing

- **16 tests, pass.** No DB, no network — fast (§8).
- **Mutation-verified**: emptying the stoplist turns the suite red, so it genuinely gates the fix (§3).
- Runs clean alongside `test_entity_graph.py` (52 passed together); `ruff` clean (§13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)