### PR TITLE
Fix chatlog migration path and online-migration lock against live MCP server

### DIFF
--- a/bin/chatlog_config.py
+++ b/bin/chatlog_config.py
@@ -77,7 +77,11 @@ MAIN_DB_PATH = os.environ.get("M3_DATABASE") or _resolve_engine_file("agent_memo
 STATE_FILE = _resolve_engine_file(".chatlog_state.json")
 SPILL_DIR = _resolve_engine_file("chatlog_spill")
 INGEST_CURSOR = _resolve_engine_file(".chatlog_ingest_cursor.json")
-CHATLOG_MIGRATIONS_DIR = _resolve_engine_file("chatlog_migrations")
+# Migration DDL ships WITH the code, not in the relocatable engine data root —
+# mirror the main runner (migrate_memory.MIGRATIONS_DIR = BASE_DIR/memory/migrations).
+# Using _resolve_engine_file here was a bug: it pointed at <engine>/chatlog_migrations,
+# which homecoming never populates, so the chatlog DB could never be bootstrapped.
+CHATLOG_MIGRATIONS_DIR = os.path.join(BASE_DIR, "memory", "chatlog_migrations")
 
 VALID_HOST_AGENTS: frozenset[str] = frozenset(("claude-code", "gemini-cli", "antigravity-cli", "opencode", "aider"))
 VALID_PROVIDERS: frozenset[str] = frozenset((

--- a/bin/migrate_memory.py
+++ b/bin/migrate_memory.py
@@ -669,8 +669,14 @@ def cmd_up(args):
         os.makedirs(os.path.dirname(target.db_path), exist_ok=True)
         conn = sqlite3.connect(target.db_path)
         try:
-            conn.execute("PRAGMA busy_timeout = 5000;")
-            conn.execute("PRAGMA locking_mode = EXCLUSIVE;")
+            conn.execute("PRAGMA busy_timeout = 30000;")
+            # Do NOT set locking_mode = EXCLUSIVE here. The m3 MCP memory server
+            # keeps agent_memory.db open continuously in WAL mode, so an EXCLUSIVE
+            # lock can never be granted — the migration fails with "database is
+            # locked" regardless of busy_timeout (and db._ensure_sync_tables then
+            # re-spawns it every sync, the lock-loop documented in 033). Normal WAL
+            # locking + a generous busy_timeout lets online migrations coexist with
+            # the live server.
         except sqlite3.Error as e:
             logger.warning(f"Could not set lock/timeout pragmas: {e}")
         try:
@@ -746,8 +752,14 @@ def cmd_down(args):
 
         conn = sqlite3.connect(target.db_path)
         try:
-            conn.execute("PRAGMA busy_timeout = 5000;")
-            conn.execute("PRAGMA locking_mode = EXCLUSIVE;")
+            conn.execute("PRAGMA busy_timeout = 30000;")
+            # Do NOT set locking_mode = EXCLUSIVE here. The m3 MCP memory server
+            # keeps agent_memory.db open continuously in WAL mode, so an EXCLUSIVE
+            # lock can never be granted — the migration fails with "database is
+            # locked" regardless of busy_timeout (and db._ensure_sync_tables then
+            # re-spawns it every sync, the lock-loop documented in 033). Normal WAL
+            # locking + a generous busy_timeout lets online migrations coexist with
+            # the live server.
         except sqlite3.Error as e:
             logger.warning(f"Could not set lock/timeout pragmas: {e}")
         try:


### PR DESCRIPTION
## Summary

Two related bugs that broke the hourly SQLite↔PostgreSQL/Chroma sync (`bin/sync_all.py`) on a live Homecoming install. Both surfaced as the sync silently exiting 0 while errors scrolled past in `logs/sync_all.log`.

### 1. Chatlog DB could never bootstrap (`bin/chatlog_config.py`)
`CHATLOG_MIGRATIONS_DIR` was resolved via `_resolve_engine_file()` → `<engine>/chatlog_migrations`, the relocatable data root, which Homecoming never populates. The actual migration SQL ships *with the code* in `repo/memory/chatlog_migrations/` — exactly like the main runner (`migrate_memory.MIGRATIONS_DIR = BASE_DIR/memory/migrations`).

Result: `migrate up` created only `schema_versions`, found zero migration files, and left the chatlog DB classified as `kind=unknown`. That made both `pg_sync` and `chroma_sync` refuse the chatlog target on every run.

**Fix:** source chatlog migrations from the repo (`BASE_DIR/memory/chatlog_migrations`), mirroring the main runner.

### 2. Online migrations deadlocked against the live server (`bin/migrate_memory.py`)
`cmd_up`/`cmd_down` set `PRAGMA locking_mode = EXCLUSIVE`. The MCP memory server keeps `agent_memory.db` open continuously in WAL mode, so an EXCLUSIVE lock can never be granted — migrations died at the first `CREATE TABLE` with `database is locked`, regardless of `busy_timeout`. Because the migration never applied, the version stayed behind and `db._ensure_sync_tables` re-spawned it every sync (the lock-loop documented in migration `033`).

**Fix:** drop the EXCLUSIVE pragma and raise `busy_timeout` 5s→30s. Normal WAL locking lets online migrations coexist with the live server.

## Verification
- Chatlog DB bootstraps to v4; first-ever `[chatlog]` warehouse sync pulled 62,696 embeddings + 10,494 relationships.
- Main `agent_memory.db` migrations 032/033 applied cleanly against the **live** DB (proof the EXCLUSIVE pragma was the blocker); `PRAGMA quick_check = ok`.
- Fresh `sync_all` run: exit 0, **no lock/migration errors, no tracebacks**; both `main` and `chatlog` Chroma targets sync; migration subprocess no longer spawned (fast-path short-circuits now that the DB is current).

## Notes
- No tool-catalog/doc paths touched — pre-push drift gate skips (verified in sync manually); leakage scan clean.