### PR TITLE
fix(ci): cap numpy <2.5 (mypy 3.11 stub) + tier4 transport mock + lint

### DIFF
--- a/bin/m3_entities_gliner.py
+++ b/bin/m3_entities_gliner.py
@@ -126,7 +126,7 @@ def _load_gliner(cfg: _Cfg):
         try:
             import torch
             if not torch.cuda.is_available():
-                print(f"[gliner] WARN: cuda requested but not available; falling back to cpu", flush=True)
+                print("[gliner] WARN: cuda requested but not available; falling back to cpu", flush=True)
                 cfg.device = "cpu"
         except Exception as e:
             print(f"[gliner] WARN: torch import failed ({e}); falling back to cpu", flush=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,9 @@ dependencies = [
     "chromadb-client>=1.5.8,<2",
     "cryptography>=48.0.1,<49",
     "keyring>=25.7.0,<26",
-    "numpy>=2.4.4,<3",
+    # Cap <2.5: numpy 2.5.0's stub uses PEP 695 `type` syntax that mypy rejects
+    # under python_version 3.11 (our floor). See requirements.txt for the full note.
+    "numpy>=2.4.4,<2.5",
     "python-dotenv>=1.2.2,<2",
     "PyYAML>=6.0.3,<7",
     "psutil>=7.2.2,<8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,12 @@ psutil>=7.2.2,<8
 pyobjc-framework-CoreWLAN; sys_platform == 'darwin'
 
 # --- Intelligence & Vector ---
-numpy>=2.4.4,<3
+# Cap <2.5: numpy 2.5.0's bundled stub (numpy/__init__.pyi) uses the PEP 695
+# `type` statement, which mypy rejects when targeting python_version 3.11 (our
+# supported floor, set in pyproject [tool.mypy]). The error halts the whole
+# mypy CI job before any bin/ file is checked. Lift once we drop 3.11 support
+# or numpy ships a 3.11-compatible stub. See CI "Type Check (Mypy)".
+numpy>=2.4.4,<2.5
 scipy>=1.17.1,<2
 tqdm>=4.67.3,<5
 # Fast fuzzy string matching for entity coalescing (token-order-aware, ~3-4x

--- a/tests/test_entity_resolution_tuning.py
+++ b/tests/test_entity_resolution_tuning.py
@@ -90,15 +90,23 @@ async def test_cosine_threshold_resolution_tuning(monkeypatch, tmp_path):
     async def stub_embed(text: str):
         return embed_map.get(text, ([0.0, 1.0], "stub"))
 
-    # _resolve_entity_async embeds via memory.embed._embed_canonical_cached,
-    # which calls the BARE name `_embed` resolved in memory.embed's own globals
-    # (i.e. memory.embed._embed) — NOT memory_core._embed. Patching only the
-    # memory_core re-export left the real path calling the actual embedder, which
-    # returns None in CI (no backend) -> no cosine -> no merge -> the test failed
-    # there while passing locally (warm cache / live embedder). Patch the embed
-    # module directly and clear the name-embedding cache so the stub is always hit.
+    # _resolve_entity_async (tier-3 cosine) gets every name vector — the query
+    # AND each candidate — through `_embed_canonical_cached`. Patch THAT, not the
+    # lower-level `_embed`: the cached helper short-circuits on
+    # _ENTITY_NAME_EMBED_CACHE and on the migration-032 entity_embeddings DB store
+    # (a candidate vector written at _create_entity time), so a real (null-in-CI)
+    # embedder could still leak in via those paths. `entity.py` binds the name at
+    # import (`from .embed import _embed_canonical_cached`), so patch its OWN
+    # namespace (where the resolver looks it up), not just memory.embed's.
+    # Returns list[float] | None (not the (vec, model) tuple `_embed` returns).
+    async def stub_canonical(name: str):
+        vec, _model = await stub_embed(name)
+        return vec
+
     import memory.embed as me_embed
-    monkeypatch.setattr(me_embed, "_embed", stub_embed)
+    monkeypatch.setattr(me, "_embed_canonical_cached", stub_canonical)
+    monkeypatch.setattr(me_embed, "_embed_canonical_cached", stub_canonical)
+    monkeypatch.setattr(me_embed, "_embed", stub_embed)  # belt-and-suspenders
     me_embed._ENTITY_NAME_EMBED_CACHE.clear()
 
     # 1. With a high cosine threshold (e.g. 0.95), they should NOT merge (0.90 < 0.95)

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -68,14 +68,21 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
 
     # Mock embedded and CPU fallback to fail
     monkeypatch.setattr("memory.embed._get_embedded_embedder", lambda: None)
-    # Disable the embed circuit breakers (mirrors test_tier4_fallback_skipped).
-    # Without this, the cascade's breaker logic still probes the real local HTTP
-    # tier (127.0.0.1:8082) before honoring the mocked client, so in a backend-
-    # less env (CI) tier 2 raises a live EmbedFallbackError instead of falling
-    # straight through to the mocked cloud client — the test then never reaches
-    # tier 4 and fails. Zeroing the thresholds forces the deterministic path.
-    monkeypatch.setattr(config, "EMBED_BREAKER_CPU_FALLBACK_THRESHOLD", 0)
-    monkeypatch.setattr(config, "EMBED_BREAKER_PRIMARY_THRESHOLD", 0)
+    # NULL the embed circuit-breaker globals so every tier is unconditionally
+    # allowed (the cascade gates each tier on `_X_BREAKER is None or
+    # _X_BREAKER.allow_request()`). This is the real fix for the CI failure:
+    # the breakers are built ONCE at module import from config thresholds, so
+    # patching the config values is too late — the already-constructed breaker
+    # objects are unaffected. If a breaker was left OPEN by an earlier test/embed
+    # call in the session, the tier short-circuits WITHOUT calling
+    # _get_embed_client, the cascade returns None before tier 4, and the mocked
+    # cloud client is never reached. (Diagnosed via a CI assertion: the patched
+    # getter was never called.) Setting the globals to None forces every tier
+    # open so the cascade flows through the mocked client to tier 4.
+    import memory.embed as _me
+    for _bk in ("_EMBEDDED_BREAKER", "_CPU_FALLBACK_BREAKER",
+                "_PRIMARY_BREAKER", "_CLOUD_BREAKER"):
+        monkeypatch.setattr(_me, _bk, None)
 
     # Mock best LLM failover to fail
     async def mock_get_best_embed(*args, **kwargs):
@@ -108,19 +115,20 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
     def _fake_get_client():
         get_client_calls.append(1)
         return client_mock
-    monkeypatch.setattr("memory.embed._get_embed_client", _fake_get_client)
-    # Also neutralize the process-wide cached real client so nothing can reuse a
+    monkeypatch.setattr(_me, "_get_embed_client", _fake_get_client)
+    # Neutralize the process-wide cached real client so nothing can reuse a
     # stale loop-bound AsyncClient that bypasses the patched getter.
-    import memory.embed as _me
     monkeypatch.setattr(_me, "_EMBED_CLIENT", None, raising=False)
 
     # Let's request an embedding with sensitive data
     vec, model = await _embed("My secret key is sk-proj-12345678901234567890 and email is test@domain.com")
 
-    # DIAGNOSTIC: surface whether the patched getter was actually used in CI.
+    # Regression guard: tier 4 must have gone through the mocked client getter.
+    # If this is empty the cascade short-circuited before any HTTP tier (the
+    # original CI failure mode), so a bare `vec is None` check would mask it.
     assert get_client_calls, (
-        "memory.embed._get_embed_client was never called via the patched name — "
-        "tier 4 reached a real client some other way"
+        "embed cascade short-circuited before reaching a client tier — "
+        "a breaker was left open (see breaker-nulling above)"
     )
     assert vec == [0.1, 0.2, 0.3, 0.4]
     assert len(posted_payloads) == 1

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -120,15 +120,28 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
     # stale loop-bound AsyncClient that bypasses the patched getter.
     monkeypatch.setattr(_me, "_EMBED_CLIENT", None, raising=False)
 
+    # DIAGNOSTIC: a real httpx client reaching enclave.test means tier 4 used a
+    # binding OTHER than the patched _me._get_embed_client. Trip-wire the real
+    # httpx.AsyncClient.post so CI reports exactly that (instead of a silent DNS
+    # error), and surface whether the cached client global was non-None.
+    import httpx as _httpx_mod
+    real_post_calls = []
+    _orig_async_post = _httpx_mod.AsyncClient.post
+
+    async def _spy_post(self, url, *a, **k):
+        real_post_calls.append(str(url))
+        return await _orig_async_post(self, url, *a, **k)
+    monkeypatch.setattr(_httpx_mod.AsyncClient, "post", _spy_post)
+
     # Let's request an embedding with sensitive data
     vec, model = await _embed("My secret key is sk-proj-12345678901234567890 and email is test@domain.com")
 
-    # Regression guard: tier 4 must have gone through the mocked client getter.
-    # If this is empty the cascade short-circuited before any HTTP tier (the
-    # original CI failure mode), so a bare `vec is None` check would mask it.
+    # Surface the diagnostic state if the mock path was bypassed.
     assert get_client_calls, (
-        "embed cascade short-circuited before reaching a client tier — "
-        "a breaker was left open (see breaker-nulling above)"
+        f"cascade reached a client tier but NOT via the patched getter. "
+        f"real httpx.AsyncClient.post calls={real_post_calls!r}; "
+        f"_me._EMBED_CLIENT after={_me._EMBED_CLIENT!r}; "
+        f"_me._get_embed_client is patched={_me._get_embed_client is _fake_get_client}"
     )
     assert vec == [0.1, 0.2, 0.3, 0.4]
     assert len(posted_payloads) == 1

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -103,11 +103,25 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
 
     client_mock = MagicMock()
     client_mock.post = mock_post
-    monkeypatch.setattr("memory.embed._get_embed_client", lambda: client_mock)
+    get_client_calls = []
+
+    def _fake_get_client():
+        get_client_calls.append(1)
+        return client_mock
+    monkeypatch.setattr("memory.embed._get_embed_client", _fake_get_client)
+    # Also neutralize the process-wide cached real client so nothing can reuse a
+    # stale loop-bound AsyncClient that bypasses the patched getter.
+    import memory.embed as _me
+    monkeypatch.setattr(_me, "_EMBED_CLIENT", None, raising=False)
 
     # Let's request an embedding with sensitive data
     vec, model = await _embed("My secret key is sk-proj-12345678901234567890 and email is test@domain.com")
 
+    # DIAGNOSTIC: surface whether the patched getter was actually used in CI.
+    assert get_client_calls, (
+        "memory.embed._get_embed_client was never called via the patched name — "
+        "tier 4 reached a real client some other way"
+    )
     assert vec == [0.1, 0.2, 0.3, 0.4]
     assert len(posted_payloads) == 1
     # Verify PII was redacted!

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -92,57 +92,36 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
     # Mock keyring lookup to return a token
     monkeypatch.setattr("auth_utils.safe_keyring_get_password", lambda s, u: "keyring-token")
 
-    # Mock HTTP client responses
+    # Mock at the httpx.AsyncClient.post CLASS level — not via _get_embed_client.
+    # A CI diagnostic proved every tier reaches a *real* httpx.AsyncClient
+    # (httpx.AsyncClient.post fired for both 127.0.0.1:8082 and enclave.test) even
+    # though _get_embed_client was patched, so patching the getter is not enough:
+    # intercept the actual transport so the local tiers fail and tier 4 returns
+    # the dummy embedding, regardless of how the client is resolved.
     posted_payloads = []
     posted_headers = []
     posted_urls = []
 
-    async def mock_post(url, json, headers=None, **kwargs):
-        if "enclave.test" in url:
-            posted_urls.append(url)
+    async def _fake_async_post(self, url, json=None, headers=None, **kwargs):
+        if "enclave.test" in str(url):
+            posted_urls.append(str(url))
             posted_payloads.append(json)
             posted_headers.append(headers)
-            # Return dummy embedding
             resp = MagicMock()
             resp.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3, 0.4]}]}
+            resp.raise_for_status = lambda: None
             return resp
         raise RuntimeError("Local HTTP down")
 
-    client_mock = MagicMock()
-    client_mock.post = mock_post
-    get_client_calls = []
-
-    def _fake_get_client():
-        get_client_calls.append(1)
-        return client_mock
-    monkeypatch.setattr(_me, "_get_embed_client", _fake_get_client)
-    # Neutralize the process-wide cached real client so nothing can reuse a
-    # stale loop-bound AsyncClient that bypasses the patched getter.
-    monkeypatch.setattr(_me, "_EMBED_CLIENT", None, raising=False)
-
-    # DIAGNOSTIC: a real httpx client reaching enclave.test means tier 4 used a
-    # binding OTHER than the patched _me._get_embed_client. Trip-wire the real
-    # httpx.AsyncClient.post so CI reports exactly that (instead of a silent DNS
-    # error), and surface whether the cached client global was non-None.
     import httpx as _httpx_mod
-    real_post_calls = []
-    _orig_async_post = _httpx_mod.AsyncClient.post
-
-    async def _spy_post(self, url, *a, **k):
-        real_post_calls.append(str(url))
-        return await _orig_async_post(self, url, *a, **k)
-    monkeypatch.setattr(_httpx_mod.AsyncClient, "post", _spy_post)
+    monkeypatch.setattr(_httpx_mod.AsyncClient, "post", _fake_async_post)
+    # Also neutralize the process-wide cached client so a stale one isn't reused.
+    monkeypatch.setattr(_me, "_EMBED_CLIENT", None, raising=False)
 
     # Let's request an embedding with sensitive data
     vec, model = await _embed("My secret key is sk-proj-12345678901234567890 and email is test@domain.com")
 
-    # Surface the diagnostic state if the mock path was bypassed.
-    assert get_client_calls, (
-        f"cascade reached a client tier but NOT via the patched getter. "
-        f"real httpx.AsyncClient.post calls={real_post_calls!r}; "
-        f"_me._EMBED_CLIENT after={_me._EMBED_CLIENT!r}; "
-        f"_me._get_embed_client is patched={_me._get_embed_client is _fake_get_client}"
-    )
+    # Tier 4 returned the dummy embedding via the class-level transport mock.
     assert vec == [0.1, 0.2, 0.3, 0.4]
     assert len(posted_payloads) == 1
     # Verify PII was redacted!

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -68,6 +68,14 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
 
     # Mock embedded and CPU fallback to fail
     monkeypatch.setattr("memory.embed._get_embedded_embedder", lambda: None)
+    # Disable the embed circuit breakers (mirrors test_tier4_fallback_skipped).
+    # Without this, the cascade's breaker logic still probes the real local HTTP
+    # tier (127.0.0.1:8082) before honoring the mocked client, so in a backend-
+    # less env (CI) tier 2 raises a live EmbedFallbackError instead of falling
+    # straight through to the mocked cloud client — the test then never reaches
+    # tier 4 and fails. Zeroing the thresholds forces the deterministic path.
+    monkeypatch.setattr(config, "EMBED_BREAKER_CPU_FALLBACK_THRESHOLD", 0)
+    monkeypatch.setattr(config, "EMBED_BREAKER_PRIMARY_THRESHOLD", 0)
 
     # Mock best LLM failover to fail
     async def mock_get_best_embed(*args, **kwargs):


### PR DESCRIPTION
Re-created after `main` was force-reset (concurrent session); rebased onto current `main`. Previously green as #57 before the reset.

## What this fixes

**1. Mypy CI broken repo-wide** — `numpy/__init__.pyi:737: Type statement is only supported in Python 3.12 and greater`. numpy 2.5.0's stub uses PEP 695 `type` syntax that mypy rejects under our `python_version = "3.11"` floor, halting the job before any `bin/` file is checked. **Fix:** cap `numpy>=2.4.4,<2.5` in both `requirements.txt` and `pyproject.toml` (chosen over bumping the mypy target, which would abandon type-checking against the supported 3.11 floor).

**2. Lint CI broken repo-wide** — pre-existing `ruff F541` (extraneous f-prefix) in `m3_entities_gliner.py`; the whole-tree lint reds out every PR. One-char fix, no behavior change.

**3. Two env-dependent tests failing only in CI** — `test_tier4_cloud` and `test_cosine_threshold_resolution_tuning` relied on a live local embed server (127.0.0.1:8082) / LLM to rescue incomplete mocks; in CI those ports are dead.
- **cosine-resolution:** patch `_embed_canonical_cached` in `memory.entity`'s namespace (where the resolver binds it), not the lower-level `_embed` — the cached helper short-circuits on the name cache + migration-032 DB store, so patching only `_embed` let a real (null-in-CI) embedder leak in.
- **tier4:** a CI diagnostic proved every tier reaches a *real* `httpx.AsyncClient` even with `_get_embed_client` patched. **Fix:** mock `httpx.AsyncClient.post` at the **class level** (the proven transport layer) so the local tiers fail and tier 4 returns the dummy embedding regardless of how the client is resolved.

## Verification
numpy specifier admits 2.4.x / excludes 2.5.0; mypy passes on `bin/`; tier4 + cosine tests pass with Rust disabled (CI's condition). Was fully green in CI pre-reset.