### PR TITLE
fix(governor): detect legacy Windows sync tasks by action + chatlog prune cap

### DIFF
--- a/bin/chatlog_ingest.py
+++ b/bin/chatlog_ingest.py
@@ -298,6 +298,13 @@ def _commit_cursor(items: list[dict], session_id: str, cursor: dict) -> None:
 def _make_agent_id(host_agent: str) -> str:
     user = os.environ.get("USER") or os.environ.get("USERNAME", "unknown")
     host = os.environ.get("COMPUTERNAME") or os.environ.get("HOSTNAME") or platform.node()
+    # Windows hostnames are case-insensitive and COMPUTERNAME is the canonical
+    # uppercase form. Ingestion under shells that don't inherit COMPUTERNAME
+    # (git-bash / WSL -> platform.node() returns mixed case, e.g. "HostPc") would
+    # otherwise fork the agent_id away from the canonical "HOSTPC". Normalize on
+    # Windows only; leave case-significant POSIX hostnames untouched.
+    if os.name == "nt":
+        host = host.upper()
     return f"{host_agent}:{user}@{host}"
 
 

--- a/bin/chatlog_prune.py
+++ b/bin/chatlog_prune.py
@@ -215,9 +215,22 @@ def run(db_path: str, args) -> dict:
                            WHEN title LIKE 'assistant@%' THEN 'assistant'
                            WHEN title LIKE 'system@%' THEN 'system'
                            WHEN title LIKE 'tool@%' THEN 'tool' ELSE '' END"""
+        # §4/§8: scope the scan to the ACTIONABLE window. Only rows aged past
+        # fresh_days are ever decayed/pruned (fresher noise is kept, see below),
+        # so there's no reason to pull the whole chat_log table into Python every
+        # run — that turns a large backlog into one unbounded monster pass. Filter
+        # by created_at (ISO-8601 sorts lexically) so the scan and the in-Python
+        # cluster build stay bounded to what we might act on. `created_at` is
+        # indexed on the chatlog DB; a missing index just degrades to a scan of
+        # the same rows we'd have read anyway.
+        fresh_cutoff = datetime.fromtimestamp(
+            now_ts - args.fresh_days * 86400.0, timezone.utc
+        ).isoformat()
         rows = conn.execute(f"""SELECT id, {role_sql} AS role, content, importance, created_at
                                 FROM memory_items
-                                WHERE type='chat_log' AND is_deleted=0""").fetchall()
+                                WHERE type='chat_log' AND is_deleted=0
+                                  AND created_at < ?
+                                ORDER BY created_at ASC""", (fresh_cutoff,)).fetchall()
         # PASS 1: build normalized-content cluster sizes (for repeat-status)
         cluster: dict[str, int] = {}
         norms: dict[str, str] = {}
@@ -226,8 +239,14 @@ def run(db_path: str, args) -> dict:
             norms[r["id"]] = n
             if n:
                 cluster[n] = cluster.get(n, 0) + 1
-        # PASS 2: classify + decide by age tier
-        decay_buf, prune_buf = [], []
+        # PASS 2: classify + decide by age tier. §8: bound the WRITE volume per
+        # run via max_actions so a huge backlog drains across cycles instead of
+        # one monster pass (rows are oldest-first, so we always make forward
+        # progress on the most-aged noise). max_actions <= 0 means "no cap".
+        max_actions = int(getattr(args, "max_actions", 0) or 0)
+        S["capped"] = False
+        decay_buf: list[tuple[Any, float]] = []
+        prune_buf: list[tuple[Any]] = []
         for r in rows:
             S["scanned"] += 1
             role = r["role"] or ""
@@ -240,6 +259,12 @@ def run(db_path: str, args) -> dict:
             if age < args.fresh_days:
                 S["kept_noise_recent"] += 1          # noise but recent -> keep
                 continue
+            if max_actions and (len(decay_buf) + len(prune_buf)) >= max_actions:
+                # Hit the per-run action cap. Stop accumulating; the remaining
+                # aged noise is handled next run. Surfaced (not silent) so a
+                # standing backlog is visible.
+                S["capped"] = True
+                break
             # Tightened guard: protected turns (durable signal, or substantial &
             # structured, or a generic turn longer than the trivia cutoff) are
             # never tombstoned — at most suppressed. Hard-noise bypasses this.
@@ -302,6 +327,10 @@ def main() -> int:
     ap.add_argument("--generic-delete-maxlen", type=int, default=300,
                     help="generic turns >= this length are never tombstoned (suppress-only)")
     ap.add_argument("--no-generic", action="store_true")
+    ap.add_argument("--max-actions", type=int, default=0,
+                    help="Max decay+prune writes per run (0 = no cap). Bounds a "
+                         "single pass so a large backlog drains across runs "
+                         "instead of one monster pass; oldest noise goes first.")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()

--- a/bin/chatlog_prune.py
+++ b/bin/chatlog_prune.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""chatlog_prune — aged noise pruning for chatlog turns.
+
+Builds on bin/chatlog_decay.py's philosophy (deterministic, age-graded) but
+adds (a) a PRUNE tier that soft-deletes aged noise, (b) a repeated-status
+request/response detector, and (c) an aged generic-low-value classifier.
+
+THREE AGE TIERS (all tunable):
+    age < FRESH_DAYS            -> keep untouched (recent noise may still have value)
+    FRESH_DAYS <= age < PRUNE   -> DECAY: lower importance + set valid_to (suppress)
+    age >= PRUNE_DAYS           -> PRUNE: soft-delete (is_deleted=1) so it leaves
+                                   retrieval and propagates fleet-wide as a tombstone
+
+Soft-delete only: nothing is hard-deleted or VACUUMed here, so it stays
+recoverable and rides the normal delta sync (is_deleted + updated_at bump).
+
+NOISE = ephemeral (PIDs/UUIDs/status/tmp/JSON one-liners)
+      | short user command (<=4 words, not a question/refusal)
+      | repeated-status (normalized content recurs >= STATUS_MIN_CLUSTER times
+        AND matches status request/response vocabulary)  [request AND response]
+      | generic-low (importance <= GENERIC_IMP_MAX, unpromoted chat_log,
+        not a question, no strong-signal markers)         [the bulk]
+
+KEEP guards (never noise): questions ('?'), explicit refusals, importance above
+a floor, assistant turns carrying decision/code markers.
+
+USAGE
+    python3 chatlog_prune.py --db <path> [--dry-run]            # default: dry-run
+    python3 chatlog_prune.py --db <path> --apply
+    options: --fresh-days 14 --prune-days 45 --status-min-cluster 5
+             --generic-imp-max 0.3 --no-generic
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+# ── Noise patterns (ported from chatlog_decay.py + extensions) ────────────────
+_PID_OR_UUID_RE = re.compile(
+    r"(?:\bPID\s*\d+|\bprocess[_\s]+id[\s:=]*\d+|\bport\s*\d{4,5}"
+    r"|\bbatches/[A-Za-z0-9_-]{12,}"
+    r"|\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
+    r"|/tmp/[A-Za-z0-9._/-]+|AppData[\\/]+Local[\\/]+Temp)",
+    re.IGNORECASE,
+)
+_STATUS_RE = re.compile(
+    r"\b(?:completion[:\s]+\d+\.?\d*\s*%|cost[:\s]+\$?\d+\.\d+"
+    r"|\d+\s*/\s*\d+\s+(?:in_?progress|done|pending|sessions)"
+    r"|workers?\s+alive[:\s]+\d+|slice\s+\d+\s+poll\s*#?\d+)",
+    re.IGNORECASE,
+)
+_SHORT_COMMAND_WORDS = frozenset({
+    "status", "start", "stop", "go", "yes", "y", "ok", "proceed", "continue",
+    "do it", "kick off", "run it", "fire", "fire it",
+})
+_REFUSAL_WORDS = frozenset({"no", "stop", "kill", "abort", "wait", "hold"})
+# status request/response vocabulary for the repeated-status detector
+_STATUS_REQ_RE = re.compile(
+    r"\b(status|progress|any\s+update|update\??|how('?s| is)\s+it\s+going"
+    r"|where\s+are\s+we|eta|done\s*\??|finished\s*\??|ready\s*\??)\b", re.I)
+_STATUS_RESP_RE = re.compile(
+    r"(\bstatus\b|\bprogress\b|\d+\s*%|\d+\s*/\s*\d+|\bremaining\b|\bso far\b"
+    r"|\bin[_\s]?progress\b|\bcompleted?\b|\bpending\b|\bworkers?\b|\beta\b)", re.I)
+# strong-signal markers that protect a generic turn from being pruned
+_SIGNAL_RE = re.compile(
+    r"```|\bdecid(e|ed|ing|sion)\b|\bbecause\b|\btherefore\b|\bremember\b"
+    r"|\bnever\b|\balways\b|\bIMPORTANT\b|\bnote that\b|\bgotcha\b|\bTODO\b", re.I)
+
+# Durable-knowledge signals (same family used by the promotion scan). A turn
+# carrying any of these is PROTECTED from soft-delete: it may be suppressed
+# (importance lowered) when aged, but never tombstoned — so unpromoted value
+# survives. These are the tightened guards.
+_DURABLE_RE = re.compile(
+    r"\b(we (decided|chose|went with|will use)|decision:|settled on|going with"
+    r"|the plan is to|production footgun|the rule is|canonical (form|way) is"
+    r"|from now on|going forward|always (use|do|prefer)|never (use|do)"
+    r"|by default|prefer \w+ (over|to)|hostname is|runs on port \d|listening on \d"
+    r"|configured (to|with)|the (endpoint|url|path|model|db|database) (is|=|:)"
+    r"|installed (at|in)|API key|lives (at|in) /|stored (at|in))\b", re.I)
+_STRUCT_RE = re.compile(r"(^|\n)\s*(#{1,3}\s|\*\s|-\s|\d+[.)]\s)", re.M)
+
+# Noise categories that are ALWAYS safe to soft-delete (unambiguous chatter).
+_HARD_NOISE = frozenset({"short_cmd", "repeat_status_req", "repeat_status_resp"})
+
+
+def _is_protected(content: str, generic_protect_len: int) -> bool:
+    """A turn worth keeping out of the tombstone bin (suppress-only)."""
+    if not content:
+        return False
+    if _DURABLE_RE.search(content) or _SIGNAL_RE.search(content):
+        return True
+    # substantial, structured explanation = likely reference value
+    if len(content) >= generic_protect_len and len(_STRUCT_RE.findall(content)) >= 2:
+        return True
+    return False
+
+
+def _norm_key(content: str) -> str:
+    """Normalized form for clustering: strip volatile tokens, lowercase, head."""
+    s = content[:400].lower()
+    s = _PID_OR_UUID_RE.sub(" ", s)
+    s = re.sub(r"[0-9a-f]{6,}", " ", s)          # hex blobs / hashes
+    s = re.sub(r"\d+", " ", s)                    # all digits
+    s = re.sub(r"[^a-z ]+", " ", s)               # punctuation
+    s = re.sub(r"\s+", " ", s).strip()
+    return s[:120]
+
+
+def _is_general_ephemeral(content: str) -> bool:
+    if not content:
+        return False
+    snip = content[:2000]
+    if _PID_OR_UUID_RE.search(snip) or _STATUS_RE.search(snip):
+        return True
+    stripped = snip.strip()
+    if len(stripped) <= 30 and (stripped.startswith("{") or stripped.lstrip("-+").isdigit()):
+        return True
+    return False
+
+
+def _is_short_user_command(role: str, content: str) -> bool:
+    if (role or "").lower() != "user" or not content:
+        return False
+    s = content.strip().lower()
+    if "?" in s or any(w in s.split() for w in _REFUSAL_WORDS):
+        return False
+    return len(s.split()) <= 4 or s in _SHORT_COMMAND_WORDS
+
+
+def _age_days(created_at: str | None, now_ts: float) -> float:
+    if not created_at:
+        return 0.0
+    s = created_at.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        try:
+            dt = datetime.strptime(s.split(".")[0], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+        except Exception:
+            return 0.0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return max(0.0, (now_ts - dt.timestamp()) / 86400.0)
+
+
+def _has_column(conn, table, col) -> bool:
+    return any(r[1] == col for r in conn.execute(f'pragma table_info("{table}")'))
+
+
+def classify(role: str, content: str, importance: float, norm: str,
+             cluster_size: int, args) -> tuple[str | None, str]:
+    """Return (noise_category | None, reason). None => keep."""
+    # KEEP guards first
+    if importance is not None and importance > args.keep_imp_floor:
+        return None, "keep:importance"
+    if content and "?" in content[:200]:
+        return None, "keep:question"
+    if _SIGNAL_RE.search(content or ""):
+        return None, "keep:signal"
+    # NOISE classes
+    if _is_general_ephemeral(content):
+        return "ephemeral", "pattern"
+    if _is_short_user_command(role, content):
+        return "short_cmd", "short"
+    # repeated status: recurring normalized form + status vocabulary, both sides
+    if cluster_size >= args.status_min_cluster and norm:
+        r = (role or "").lower()
+        if r == "user" and _STATUS_REQ_RE.search(content or ""):
+            return "repeat_status_req", f"cluster={cluster_size}"
+        if r in ("assistant", "tool", "") and _STATUS_RESP_RE.search(content or ""):
+            return "repeat_status_resp", f"cluster={cluster_size}"
+    # generic low-value (the bulk) — aged unpromoted default-importance chat
+    if not args.no_generic and (importance is None or importance <= args.generic_imp_max):
+        return "generic_low", "low-imp-unpromoted"
+    return None, "keep:default"
+
+
+def run(db_path: str, args) -> dict:
+    if not os.path.exists(db_path):
+        return {"error": f"DB not found: {db_path}"}
+    now_ts = time.time()
+    S: dict[str, Any] = {
+        "db": db_path, "apply": args.apply, "scanned": 0,
+        "fresh_kept": 0, "decay": {}, "prune": {}, "kept_noise_recent": 0,
+        "writes_decay": 0, "writes_prune": 0,
+        "prune_rows": 0, "prune_content_mb": 0.0, "errors": [],
+        "params": {"fresh_days": args.fresh_days, "prune_days": args.prune_days,
+                   "status_min_cluster": args.status_min_cluster,
+                   "generic_imp_max": args.generic_imp_max, "generic": not args.no_generic},
+    }
+    conn = sqlite3.connect(db_path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    # §10 DB hygiene: tune the connection (WAL autocheckpoint, journal_size_limit,
+    # mmap/cache) so an --apply run doesn't bloat the chatlog WAL. Best-effort —
+    # a missing helper or odd path must not abort a prune.
+    try:
+        import sys as _sys
+        _sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from sqlite_pragmas import apply_pragmas, checkpoint_truncate, profile_for_db
+        apply_pragmas(conn, profile_for_db(db_path))
+    except Exception:
+        checkpoint_truncate = None  # type: ignore[assignment]
+    try:
+        for col in ("id", "type", "title", "content", "importance", "created_at", "is_deleted"):
+            if not _has_column(conn, "memory_items", col):
+                return {"error": f"memory_items.{col} missing"}
+        has_valid_to = _has_column(conn, "memory_items", "valid_to")
+        role_sql = """CASE WHEN title LIKE 'user@%' THEN 'user'
+                           WHEN title LIKE 'assistant@%' THEN 'assistant'
+                           WHEN title LIKE 'system@%' THEN 'system'
+                           WHEN title LIKE 'tool@%' THEN 'tool' ELSE '' END"""
+        rows = conn.execute(f"""SELECT id, {role_sql} AS role, content, importance, created_at
+                                FROM memory_items
+                                WHERE type='chat_log' AND is_deleted=0""").fetchall()
+        # PASS 1: build normalized-content cluster sizes (for repeat-status)
+        cluster: dict[str, int] = {}
+        norms: dict[str, str] = {}
+        for r in rows:
+            n = _norm_key(r["content"] or "")
+            norms[r["id"]] = n
+            if n:
+                cluster[n] = cluster.get(n, 0) + 1
+        # PASS 2: classify + decide by age tier
+        decay_buf, prune_buf = [], []
+        for r in rows:
+            S["scanned"] += 1
+            role = r["role"] or ""
+            content = r["content"] or ""
+            imp = float(r["importance"]) if r["importance"] is not None else 0.3
+            age = _age_days(r["created_at"], now_ts)
+            cat, _ = classify(role, content, imp, norms[r["id"]], cluster.get(norms[r["id"]], 0), args)
+            if cat is None:
+                continue
+            if age < args.fresh_days:
+                S["kept_noise_recent"] += 1          # noise but recent -> keep
+                continue
+            # Tightened guard: protected turns (durable signal, or substantial &
+            # structured, or a generic turn longer than the trivia cutoff) are
+            # never tombstoned — at most suppressed. Hard-noise bypasses this.
+            protected = (cat not in _HARD_NOISE) and (
+                _is_protected(content, args.generic_protect_len)
+                or (cat == "generic_low" and len(content) >= args.generic_delete_maxlen))
+            if age < args.prune_days or protected:
+                # DECAY/SUPPRESS tier
+                tag = cat if age < args.prune_days else f"{cat}!protected"
+                S["decay"][tag] = S["decay"].get(tag, 0) + 1
+                new_imp = round(min(imp, 0.3) * 0.2, 4)
+                decay_buf.append((r["id"], new_imp))
+            else:
+                # PRUNE tier: soft-delete (high-confidence noise only)
+                S["prune"][cat] = S["prune"].get(cat, 0) + 1
+                S["prune_rows"] += 1
+                S["prune_content_mb"] += len(content) / 1048576.0
+                prune_buf.append((r["id"],))
+        S["prune_content_mb"] = round(S["prune_content_mb"], 1)
+        if args.apply:
+            ts = datetime.now(timezone.utc).isoformat()
+            conn.execute("BEGIN IMMEDIATE")
+            if has_valid_to:
+                conn.executemany(
+                    "UPDATE memory_items SET importance=?, valid_to=?, updated_at=? "
+                    "WHERE id=? AND type='chat_log'",
+                    [(ni, ts, ts, rid) for rid, ni in decay_buf])
+            else:
+                conn.executemany(
+                    "UPDATE memory_items SET importance=?, updated_at=? WHERE id=? AND type='chat_log'",
+                    [(ni, ts, rid) for rid, ni in decay_buf])
+            conn.executemany(
+                "UPDATE memory_items SET is_deleted=1, updated_at=? WHERE id=? AND type='chat_log'",
+                [(ts, rid) for (rid,) in prune_buf])
+            conn.commit()
+            S["writes_decay"], S["writes_prune"] = len(decay_buf), len(prune_buf)
+            # §10: truncate the WAL after a write batch so it doesn't grow unbounded.
+            if checkpoint_truncate is not None:
+                try:
+                    checkpoint_truncate(conn)
+                except Exception as exc:
+                    S["errors"].append(f"wal_checkpoint: {exc!r}")
+    except Exception as exc:
+        conn.rollback(); S["errors"].append(repr(exc))
+    finally:
+        conn.close()
+    return S
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Aged noise pruning for chatlog.")
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--fresh-days", type=float, default=14.0)
+    ap.add_argument("--prune-days", type=float, default=45.0)
+    ap.add_argument("--status-min-cluster", type=int, default=5)
+    ap.add_argument("--generic-imp-max", type=float, default=0.3)
+    ap.add_argument("--keep-imp-floor", type=float, default=0.4)
+    ap.add_argument("--generic-protect-len", type=int, default=300,
+                    help="generic turns >= this length (if structured) are suppress-only")
+    ap.add_argument("--generic-delete-maxlen", type=int, default=300,
+                    help="generic turns >= this length are never tombstoned (suppress-only)")
+    ap.add_argument("--no-generic", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    if args.apply and args.dry_run:
+        print("error: --apply and --dry-run are mutually exclusive", file=sys.stderr); return 2
+    import json
+    print(json.dumps(run(args.db, args), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/governor_migration.py
+++ b/bin/governor_migration.py
@@ -77,8 +77,21 @@ def detect_scheduled_tasks() -> dict[str, list[str]]:
     empty lists.
     """
     installed = _list_installed_task_names()
-    eligible = [t for t in GOVERNOR_ELIGIBLE if t in installed]
     not_migratable = [name for name, _ in NOT_MIGRATABLE if name in installed]
+    eligible = [t for t in GOVERNOR_ELIGIBLE if t in installed]
+    # Legacy / hand-named tasks (Windows, detected by action) are neither in
+    # GOVERNOR_ELIGIBLE nor NOT_MIGRATABLE — they carry their real task name. They
+    # ARE governor-eligible (an old sync task IS the thing the governor owns), so
+    # fold them into `eligible` so the CLI removes them by their actual name.
+    # Guard against a hand-named task colliding with a canonical name (already
+    # counted) or a not-migratable name (don't reclassify it for removal).
+    extra = [
+        n for n in sorted(installed)
+        if n not in GOVERNOR_ELIGIBLE
+        and n not in {nm for nm, _ in NOT_MIGRATABLE}
+        and n not in not_migratable
+    ]
+    eligible.extend(extra)
     return {"eligible": eligible, "not_migratable_present": not_migratable}
 
 
@@ -101,6 +114,10 @@ def _list_installed_task_names() -> set[str]:
                     names.add(name)
         except FileNotFoundError:
             pass
+        # Also catch legacy / hand-named tasks (e.g. the pre-bf110222
+        # `m3-memory-sync`) that the canonical-name query above misses. These are
+        # surfaced under their ACTUAL task name so removal targets the right task.
+        names |= detect_windows_legacy_action_tasks()
         return names
 
     # Unix: cron entries carry the invoked command, not the AgentOS_* name.
@@ -109,6 +126,67 @@ def _list_installed_task_names() -> set[str]:
         cron = r.stdout if r.returncode == 0 else ""
     except FileNotFoundError:
         cron = ""
+    return _unix_installed_from_cron(cron)
+
+
+def _canonical_task_names() -> set[str]:
+    """Every task name the current installer emits — canonical AgentOS_* set."""
+    return set(GOVERNOR_ELIGIBLE) | {name for name, _ in NOT_MIGRATABLE}
+
+
+def _leaf_task_name(task_name: str) -> str:
+    """schtasks prints `\\Folder\\Name` (or `\\Name` at root) — return the leaf."""
+    return task_name.strip().rsplit("\\", 1)[-1]
+
+
+def detect_windows_legacy_action_tasks() -> set[str]:
+    """Names of Windows tasks whose ACTION runs an m3 entrypoint but whose name is
+    NOT a canonical AgentOS_* one (legacy / hand-named, e.g. `m3-memory-sync`).
+
+    Returned as ACTUAL task names so the caller removes the right task. Matches on
+    the "Task To Run" field via _WINDOWS_ACTION_MARKERS (which point at the Python
+    entrypoints the action invokes directly, NOT the Unix `pg_sync.sh` wrapper).
+
+    Read-only and never raises: a missing `schtasks` or a parse hiccup yields an
+    empty set. Canonical-named tasks are excluded — they are already detected by
+    the name-based query, and re-listing them here would be redundant.
+    """
+    try:
+        r = subprocess.run(
+            ["schtasks", "/Query", "/FO", "LIST", "/V"],
+            capture_output=True, text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return set()
+    if r.returncode != 0 or not r.stdout:
+        return set()
+
+    canonical = _canonical_task_names()
+    markers = tuple(_WINDOWS_ACTION_MARKERS.values())
+    found: set[str] = set()
+    cur_name: str | None = None
+    for raw in r.stdout.splitlines():
+        line = raw.strip()
+        if line.startswith("TaskName:"):
+            cur_name = line.split(":", 1)[1].strip()
+        elif line.startswith("Task To Run:") and cur_name:
+            action = line.split(":", 1)[1]
+            leaf = _leaf_task_name(cur_name)
+            # Skip canonical tasks (already counted) and Microsoft/OS tasks that
+            # merely mention a marker substring would be a non-issue — the markers
+            # are m3 script filenames, vanishingly unlikely to appear elsewhere.
+            if leaf not in canonical and any(m in action for m in markers):
+                # Use the leaf name: schtasks /Delete /TN works with the leaf for
+                # root-level tasks, which is where the installer (and the legacy
+                # hand-named tasks) live.
+                found.add(leaf)
+            cur_name = None
+    return found
+
+
+def _unix_installed_from_cron(cron: str) -> set[str]:
+    """Unix detection body — split out so the Windows path can return early."""
+    names: set[str] = set()
     for name, marker in _UNIX_CRON_MARKERS.items():
         if marker and marker in cron:
             names.add(name)
@@ -131,6 +209,28 @@ def _list_installed_task_names() -> set[str]:
 # detected by service-file presence instead.
 _UNIX_CRON_MARKERS = {
     "AgentOS_HourlySync": "pg_sync.sh",
+    "AgentOS_ChatlogEmbedSweep": "chatlog_embed_sweeper.py",
+    "AgentOS_ObservationDrain": "m3_enrich.py",
+    "AgentOS_Maintenance": "memory_maintenance.py",
+    "AgentOS_WeeklyAuditor": "weekly_auditor.py",
+    "AgentOS_SecretRotator": "secret_rotator.py",
+}
+
+# Map AgentOS_* names to the token that appears in the WINDOWS task ACTION
+# ("Task To Run"), so we can recognise a legacy/hand-named scheduled task by what
+# it RUNS even when its task name is not the canonical AgentOS_* one. This is the
+# Windows analogue of _UNIX_CRON_MARKERS, but the markers DIFFER by design: the
+# Windows task action invokes the Python entrypoint DIRECTLY (e.g. sync_all.py),
+# whereas the Unix crontab invokes the `pg_sync.sh` wrapper. Reusing
+# _UNIX_CRON_MARKERS here would make HourlySync look for `pg_sync.sh`, which never
+# appears in a Windows action — so a legacy task like the old `m3-memory-sync`
+# (action: ...\\sync_all.py) would be missed. Keep these two maps independent.
+#
+# AgentOS_CognitiveLoop is intentionally absent: it is a not-migratable keepalive
+# the governor already paces, so we do not want a legacy-action match to flag it
+# for removal.
+_WINDOWS_ACTION_MARKERS = {
+    "AgentOS_HourlySync": "sync_all.py",
     "AgentOS_ChatlogEmbedSweep": "chatlog_embed_sweeper.py",
     "AgentOS_ObservationDrain": "m3_enrich.py",
     "AgentOS_Maintenance": "memory_maintenance.py",

--- a/bin/governor_migration.py
+++ b/bin/governor_migration.py
@@ -139,6 +139,23 @@ def _leaf_task_name(task_name: str) -> str:
     return task_name.strip().rsplit("\\", 1)[-1]
 
 
+def _action_invokes_marker(action: str, markers: tuple[str, ...]) -> bool:
+    """True iff the task action INVOKES one of the m3 entrypoint scripts.
+
+    Path-anchored, not a bare substring. The installer always builds the action
+    as `"<python>" "<root>\\bin\\<script>.py" ...` (see install_schedules.py
+    `_script()` / `/TR`), so a genuine m3 task names the script as a path tail:
+    preceded by a path separator (`\\` or `/`). Requiring that separator is a
+    §3/§6 hardening — it keeps this DESTRUCTIVE detection (matches feed
+    `schtasks /Delete`) precise, so an unrelated task that merely MENTIONS a
+    script filename in an argument or comment is not over-matched and removed.
+    The legacy hand-named tasks we want to catch (e.g. `m3-memory-sync` ->
+    `...\\bin\\sync_all.py`) still match, since they invoke the script by path.
+    """
+    low = action.lower()
+    return any(("\\" + m.lower()) in low or ("/" + m.lower()) in low for m in markers)
+
+
 def detect_windows_legacy_action_tasks() -> set[str]:
     """Names of Windows tasks whose ACTION runs an m3 entrypoint but whose name is
     NOT a canonical AgentOS_* one (legacy / hand-named, e.g. `m3-memory-sync`).
@@ -146,6 +163,8 @@ def detect_windows_legacy_action_tasks() -> set[str]:
     Returned as ACTUAL task names so the caller removes the right task. Matches on
     the "Task To Run" field via _WINDOWS_ACTION_MARKERS (which point at the Python
     entrypoints the action invokes directly, NOT the Unix `pg_sync.sh` wrapper).
+    The match is path-anchored (see `_action_invokes_marker`) so this destructive
+    detection cannot over-match a task that only mentions a script name.
 
     Read-only and never raises: a missing `schtasks` or a parse hiccup yields an
     empty set. Canonical-named tasks are excluded — they are already detected by
@@ -172,10 +191,7 @@ def detect_windows_legacy_action_tasks() -> set[str]:
         elif line.startswith("Task To Run:") and cur_name:
             action = line.split(":", 1)[1]
             leaf = _leaf_task_name(cur_name)
-            # Skip canonical tasks (already counted) and Microsoft/OS tasks that
-            # merely mention a marker substring would be a non-issue — the markers
-            # are m3 script filenames, vanishingly unlikely to appear elsewhere.
-            if leaf not in canonical and any(m in action for m in markers):
+            if leaf not in canonical and _action_invokes_marker(action, markers):
                 # Use the leaf name: schtasks /Delete /TN works with the leaf for
                 # root-level tasks, which is where the installer (and the legacy
                 # hand-named tasks) live.

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -307,6 +307,57 @@ async def run_consolidate_pass(args):
         logger.error(f"Consolidation pass error: {type(e).__name__}: {e}")
 
 
+def has_chatlog_prune_work(chatlog_db: Optional[str], prune_days: float,
+                           min_rows: int) -> bool:
+    """SQL check: are there enough aged chat_log turns to bother pruning?
+    Event-driven gate (mirrors has_consolidate_work) so the loop only does a
+    sweep when a real backlog of prune-eligible noise has accumulated."""
+    try:
+        ctx = M3Context(chatlog_db)
+        sql = (
+            "SELECT 1 FROM memory_items "
+            "WHERE type='chat_log' AND is_deleted=0 AND importance <= 0.3 "
+            "AND created_at < datetime('now', ?) "
+            "GROUP BY type HAVING COUNT(*) > ? LIMIT 1"
+        )
+        return len(ctx.query_memory(sql, (f"-{int(prune_days)} days", min_rows))) > 0
+    except Exception as e:
+        logger.debug(f"Chatlog-prune work check failed (non-fatal): {e}")
+        return False
+
+
+async def run_chatlog_prune_pass(args):
+    """Aged noise pruning for chatlog turns — governor-gated, event-driven.
+
+    Suppresses 14-45d noise (importance down) and soft-deletes >45d
+    high-confidence noise (durable-signal / substantial-structured turns are
+    protected to suppress-only). Tombstones propagate fleet-wide via
+    is_deleted+updated_at sync and stay recoverable. Real writes require
+    M3_CHATLOG_PRUNE_AUTO=1 (else dry-run) — same opt-in contract as belief
+    consolidation. Delegates to chatlog_prune.run so the loop and the standalone
+    CLI share ONE implementation."""
+    if not has_chatlog_prune_work(args.chatlog_db, args.chatlog_prune_days,
+                                  args.chatlog_prune_threshold):
+        logger.debug("No chatlog-prune work (no aged backlog over threshold). Skipping.")
+        return
+    apply = os.environ.get("M3_CHATLOG_PRUNE_AUTO", "0").lower() in ("1", "true", "yes")
+    logger.info("Starting chatlog noise-prune pass (apply=%s)...", apply)
+    try:
+        import chatlog_prune
+        from types import SimpleNamespace
+        opts = SimpleNamespace(
+            fresh_days=args.chatlog_prune_fresh_days,
+            prune_days=args.chatlog_prune_days,
+            status_min_cluster=5, generic_imp_max=0.3, keep_imp_floor=0.4,
+            generic_protect_len=300, generic_delete_maxlen=300,
+            no_generic=False, apply=apply)
+        summary = chatlog_prune.run(args.chatlog_db, opts)
+        logger.info("Chatlog-prune pass: suppress=%s soft-delete=%s (apply=%s)",
+                    summary.get("writes_decay"), summary.get("writes_prune"), apply)
+    except Exception as e:
+        logger.error(f"Chatlog-prune pass error: {type(e).__name__}: {e}")
+
+
 async def main_loop(args):
     """Main execution loop with adaptive backoff and signal awareness."""
     logger.info(f"Cognitive Loop heartbeat started. Interval: {args.interval}s")
@@ -348,6 +399,10 @@ async def main_loop(args):
 
         if not args.skip_consolidate:
             await run_consolidate_pass(args)
+            if _STOP_EVENT.is_set(): break
+
+        if not args.skip_chatlog_prune:
+            await run_chatlog_prune_pass(args)
             if _STOP_EVENT.is_set(): break
 
         elapsed = time.monotonic() - start_time
@@ -395,6 +450,17 @@ def main():
                         help="Only consolidate items older than N days (default: 7)")
     parser.add_argument("--consolidate-source-type", default="observation",
                         help="Episodic source memory type to roll up (default: observation)")
+
+    # Chatlog aged noise-prune pass. Governor-gated + event-driven; real
+    # writes require M3_CHATLOG_PRUNE_AUTO=1 (else dry-run). Replaces a fixed cron.
+    parser.add_argument("--skip-chatlog-prune", action="store_true",
+                        help="Skip the chatlog noise-prune pass")
+    parser.add_argument("--chatlog-prune-threshold", type=int, default=2000,
+                        help="Min aged prune-eligible chat_log rows before a sweep (default: 2000)")
+    parser.add_argument("--chatlog-prune-fresh-days", type=float, default=14.0,
+                        help="Keep noise newer than N days untouched (default: 14)")
+    parser.add_argument("--chatlog-prune-days", type=float, default=45.0,
+                        help="Soft-delete aged noise older than N days (default: 45)")
 
     args = parser.parse_args()
 

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -357,10 +357,15 @@ async def run_chatlog_prune_pass(args):
             prune_days=args.chatlog_prune_days,
             status_min_cluster=5, generic_imp_max=0.3, keep_imp_floor=0.4,
             generic_protect_len=300, generic_delete_maxlen=300,
+            # Bound writes per cycle (§8): the loop fires every --interval, so a
+            # large backlog drains over many cycles instead of one monster pass
+            # that blocks the heartbeat. Oldest noise is handled first.
+            max_actions=args.chatlog_prune_max_actions,
             no_generic=False, apply=apply)
         summary = chatlog_prune.run(args.chatlog_db, opts)
-        logger.info("Chatlog-prune pass: suppress=%s soft-delete=%s (apply=%s)",
-                    summary.get("writes_decay"), summary.get("writes_prune"), apply)
+        logger.info("Chatlog-prune pass: suppress=%s soft-delete=%s capped=%s (apply=%s)",
+                    summary.get("writes_decay"), summary.get("writes_prune"),
+                    summary.get("capped"), apply)
     except Exception as e:
         logger.error(f"Chatlog-prune pass error: {type(e).__name__}: {e}")
 
@@ -468,6 +473,10 @@ def main():
                         help="Keep noise newer than N days untouched (default: 14)")
     parser.add_argument("--chatlog-prune-days", type=float, default=45.0,
                         help="Soft-delete aged noise older than N days (default: 45)")
+    parser.add_argument("--chatlog-prune-max-actions", type=int, default=5000,
+                        help="Max decay+prune writes per cycle (default: 5000; 0 = "
+                             "no cap). Caps one pass so a backlog drains across "
+                             "cycles instead of blocking the heartbeat.")
 
     args = parser.parse_args()
 

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -222,7 +222,13 @@ async def run_entity_pass(args):
             force=False,
             dry_run=False,
             skip_preflight=True,
-            yes=True
+            yes=True,
+            # m3_entities._main_async reads args.embed_url/embed_model directly
+            # (not via getattr). The argparse CLI defaults them to the
+            # M3_EMBED_URL/M3_EMBED_MODEL env vars; mirror that here so the
+            # loop honors the same embedder override and doesn't AttributeError.
+            embed_url=os.environ.get("M3_EMBED_URL"),
+            embed_model=os.environ.get("M3_EMBED_MODEL"),
         )
         await m3_entities._main_async(ent_args)
     except Exception as e:
@@ -343,8 +349,9 @@ async def run_chatlog_prune_pass(args):
     apply = os.environ.get("M3_CHATLOG_PRUNE_AUTO", "0").lower() in ("1", "true", "yes")
     logger.info("Starting chatlog noise-prune pass (apply=%s)...", apply)
     try:
-        import chatlog_prune
         from types import SimpleNamespace
+
+        import chatlog_prune
         opts = SimpleNamespace(
             fresh_days=args.chatlog_prune_fresh_days,
             prune_days=args.chatlog_prune_days,

--- a/bin/m3_entities.py
+++ b/bin/m3_entities.py
@@ -621,11 +621,16 @@ async def _main_async(args: argparse.Namespace) -> int:
     print(f"[m3-entities]   preds: {len(valid_predicates)} ({sorted(valid_predicates)[:6]}...)", flush=True)
 
     # Apply embedder override if requested. CLI flag wins, env var is fallback,
-    # both already merged into args.embed_url/embed_model by argparse.
-    if args.embed_url:
-        mc.set_embed_override(args.embed_url, args.embed_model)
-        print(f"[m3-entities] embedder override: {args.embed_url} "
-              f"(model: {args.embed_model or 'default'})", flush=True)
+    # both already merged into args.embed_url/embed_model by argparse. Use
+    # getattr so a hand-built Namespace (e.g. the cognitive loop's
+    # run_entity_pass) that omits these fields doesn't AttributeError — matches
+    # the defensive read in m3_enrich.py.
+    embed_url = getattr(args, "embed_url", None)
+    embed_model = getattr(args, "embed_model", None)
+    if embed_url:
+        mc.set_embed_override(embed_url, embed_model)
+        print(f"[m3-entities] embedder override: {embed_url} "
+              f"(model: {embed_model or 'default'})", flush=True)
 
     type_allowlist = _build_type_allowlist(args)
 

--- a/bin/promote_pipeline.py
+++ b/bin/promote_pipeline.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""LLM-judged promotion pipeline: tightened candidate selection + SLM judge.
+
+Stage 1 (--select): high-precision candidate selection (~1-2k) from chatlog.
+Stage 2 (--smoke N / --run): batched judge via LM Studio; distill PROMOTE
+         items to crisp facts. Writes accepted to --out jsonl.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sqlite3
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+
+cp = importlib.util.module_from_spec(
+    s := importlib.util.spec_from_file_location("cp", os.path.join(os.path.dirname(__file__), "chatlog_prune.py")))
+s.loader.exec_module(cp)
+
+# ── Tightened signals (strict; precision over recall) ─────────────────────────
+T_DECISION = re.compile(r"\b(we (decided|chose|went with|will use)|decision:|"
+                        r"settled on|going with\b|the plan is to|chosen approach|"
+                        r"production footgun|the rule is|canonical (form|way) is)\b", re.I)
+T_DIRECTIVE = re.compile(r"\b(from now on|going forward|always (use|do|prefer)|"
+                         r"never (use|do)|by default (use|we)|prefer \w+ (over|to)|"
+                         r"make sure to always|remember that .* (is|are|should))\b", re.I)
+T_SPEC = re.compile(r"\b(hostname is|runs on port \d|listening on \d|"
+                    r"\b\d{1,3}(\.\d{1,3}){3}:\d+|configured (to|with) |"
+                    r"the (endpoint|url|path|model|db|database) (is|=|:) |"
+                    r"installed (at|in) |API key |lives (at|in) /|stored (at|in) )", re.I)
+# status / progress vocabulary that DISQUALIFIES even if otherwise matching
+DISQUALIFY = re.compile(r"\b(ETA|r/s|tok/s|windows? done|poll(ing)?|workers? alive|"
+                        r"in[_\s]?progress|\d+\s*/\s*\d+\s+(done|sessions|windows)|"
+                        r"completion[:\s]+\d|so far|still (running|going)|"
+                        r"\bstatus\b|\bhealthy\b|no action|stable\.)\b", re.I)
+
+LM_URL = os.environ.get("LM_URL", "http://localhost:1234/v1/chat/completions")
+LM_MODEL = os.environ.get("LM_MODEL", "google/gemma-4-26b-a4b")
+LM_TOKEN = os.environ.get("LM_API_TOKEN", "")
+
+
+def select(db: str, min_age=14.0, lo=120, hi=4000):
+    now = time.time()
+    c = sqlite3.connect(db); c.row_factory = sqlite3.Row
+    try:
+        return _select(c, now, min_age, lo, hi)
+    finally:
+        c.close()  # close even if classify()/float() raises mid-loop
+
+
+def _select(c, now, min_age, lo, hi):
+    rows = c.execute("""SELECT id, CASE WHEN title LIKE 'user@%' THEN 'user'
+        WHEN title LIKE 'assistant@%' THEN 'assistant' WHEN title LIKE 'system@%' THEN 'system'
+        WHEN title LIKE 'tool@%' THEN 'tool' ELSE '' END role, content, importance, created_at
+        FROM memory_items WHERE type='chat_log' AND is_deleted=0""").fetchall()
+    cluster, norms = defaultdict(int), {}
+    for r in rows:
+        n = cp._norm_key(r["content"] or ""); norms[r["id"]] = n
+        if n: cluster[n] += 1
+    seen = set(); out = []
+    class A: keep_imp_floor=0.4; status_min_cluster=5; generic_imp_max=0.3; no_generic=True
+    for r in rows:
+        content = (r["content"] or "").strip()
+        if not (lo <= len(content) <= hi):
+            continue
+        if cp._age_days(r["created_at"], now) < min_age:
+            continue
+        if DISQUALIFY.search(content):
+            continue
+        imp = float(r["importance"]) if r["importance"] is not None else 0.3
+        if cp.classify(r["role"], content, imp, norms[r["id"]], cluster[norms[r["id"]]], A())[0] is not None:
+            continue
+        sig = ("decision" if T_DECISION.search(content) else
+               "directive" if T_DIRECTIVE.search(content) else
+               "spec" if T_SPEC.search(content) else None)
+        if not sig:
+            continue
+        k = norms[r["id"]]
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append({"id": r["id"], "role": r["role"], "signal": sig,
+                    "created_at": r["created_at"], "content": content})
+    return out
+
+
+RUBRIC = """You curate an AI agent's long-term memory. Decide if each chat turn contains a DURABLE, REUSABLE fact worth keeping forever.
+
+PROMOTE only if it states something stable and reusable later:
+- a decision WITH its rationale, a standing preference/directive/convention,
+- a configuration/spec fact (hostnames, ports, paths, versions, hardware),
+- a learned technical fact or non-obvious gotcha.
+
+SKIP (most turns) if it is: status/progress, a one-off action narration, a
+question, transient state, meta-chatter, or already-obvious.
+
+For each item return: {"i":<index>,"verdict":"PROMOTE"|"SKIP",
+"type":"fact"|"decision"|"preference"|"reference"|"knowledge",
+"title":"<=8 words","fact":"<=2 sentences, standalone, no 'the assistant/user said'"}
+Output ONLY a JSON array, one object per input item, same order."""
+
+
+def judge(items):
+    # Only ever speak HTTP(S) to the LLM endpoint. LM_URL is operator-supplied,
+    # but a misconfigured file:/ or custom scheme would otherwise be opened
+    # blindly (Bandit B310 / CWE-22); reject anything but http/https up front.
+    if urllib.parse.urlparse(LM_URL).scheme not in ("http", "https"):
+        raise ValueError(f"LM_URL must be http(s); refusing scheme in {LM_URL!r}")
+    payload = "\n".join(f'[{i}] ({it["signal"]}/{it["role"]}) {it["content"][:1200]}'
+                        for i, it in enumerate(items))
+    body = json.dumps({"model": LM_MODEL, "temperature": 0, "max_tokens": 2200,
+                       "messages": [{"role": "system", "content": RUBRIC},
+                                    {"role": "user", "content": payload}]}).encode()
+    req = urllib.request.Request(LM_URL, data=body,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {LM_TOKEN}"})
+    with urllib.request.urlopen(req, timeout=300) as resp:  # nosec B310 - scheme guarded above
+        data = json.load(resp)
+    txt = data["choices"][0]["message"]["content"]
+    m = re.search(r"\[.*\]", txt, re.S)
+    return json.loads(m.group(0)) if m else []
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--select", action="store_true")
+    ap.add_argument("--smoke", type=int, default=0)
+    ap.add_argument("--run", action="store_true")
+    ap.add_argument("--batch", type=int, default=8)
+    # Platform-appropriate temp dir (Bandit B108): /tmp does not exist on
+    # Windows, where this project commonly runs. Override with --out as needed.
+    ap.add_argument("--out",
+                    default=os.path.join(tempfile.gettempdir(), "promote_accepted.jsonl"))
+    ap.add_argument("--samples", type=int, default=8)
+    args = ap.parse_args()
+
+    cands = select(args.db)
+    bysig = defaultdict(int)
+    for c in cands: bysig[c["signal"]] += 1
+    print(f"tightened candidates: {len(cands)}  by_signal={dict(bysig)}")
+    if args.select:
+        for c in cands[:args.samples]:
+            print(f"  [{c['signal']}/{c['role']}] {' '.join(c['content'].split())[:160]}")
+        return
+    todo = cands[:args.smoke] if args.smoke else cands
+    accepted = []; t0 = time.time()
+    # UTF-8 + LF: chatlog facts carry em-dashes/quotes/emoji that the Windows
+    # locale codepage can't encode — default text mode would UnicodeEncodeError
+    # mid-run and lose minutes of LLM work. newline="" avoids CRLF in JSONL.
+    with open(args.out, "w", encoding="utf-8", newline="") as f:
+        for b in range(0, len(todo), args.batch):
+            batch = todo[b:b + args.batch]
+            try:
+                verdicts = judge(batch)
+            except Exception as e:
+                print(f"  batch {b}: ERROR {e}"); continue
+            for it, v in zip(batch, verdicts):
+                if isinstance(v, dict) and v.get("verdict") == "PROMOTE" and v.get("fact"):
+                    rec = {"source_id": it["id"], "signal": it["signal"],
+                           "type": v.get("type", "fact"), "title": v.get("title", ""),
+                           "fact": v["fact"]}
+                    accepted.append(rec); f.write(json.dumps(rec) + "\n"); f.flush()
+            done = min(b + args.batch, len(todo))
+            print(f"  judged {done}/{len(todo)}  accepted={len(accepted)}  ({time.time()-t0:.0f}s)")
+    print(f"DONE accepted={len(accepted)} -> {args.out}")
+    # show a few accepted
+    for r in accepted[:args.samples]:
+        print(f"  +{r['type']}: {r['title']} :: {r['fact'][:140]}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chatlog_prune_cap.py
+++ b/tests/test_chatlog_prune_cap.py
@@ -1,0 +1,88 @@
+"""Tests for chatlog_prune's per-run action cap and aged-window scan scoping.
+
+Guards the §4/§8 bounding added so a large chatlog backlog drains across many
+cognitive-loop cycles instead of one unbounded whole-table pass.
+"""
+from __future__ import annotations
+
+import datetime
+import os
+import sqlite3
+import sys
+from types import SimpleNamespace
+
+_BIN = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "bin"))
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+import chatlog_prune as cp
+
+
+def _opts(**over):
+    base = dict(
+        fresh_days=14.0, prune_days=45.0, status_min_cluster=5,
+        generic_imp_max=0.3, keep_imp_floor=0.4, generic_protect_len=300,
+        generic_delete_maxlen=300, no_generic=False, max_actions=0,
+        apply=True,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _seed(db_path, *, aged_noise: int, fresh_noise: int):
+    """Create a minimal memory_items table with N aged + M fresh noise turns."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE memory_items(id TEXT PRIMARY KEY, type TEXT, title TEXT, "
+        "content TEXT, importance REAL, created_at TEXT, is_deleted INT DEFAULT 0, "
+        "updated_at TEXT, valid_to TEXT)"
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    rows = []
+    for i in range(aged_noise):  # 90+ days old => prune-eligible
+        ts = (now - datetime.timedelta(days=90 + i)).isoformat()
+        rows.append((f"old{i}", "chat_log", "user@x", "status", 0.1, ts))
+    for i in range(fresh_noise):  # 1 day old => must be left untouched
+        ts = (now - datetime.timedelta(days=1)).isoformat()
+        rows.append((f"fresh{i}", "chat_log", "user@x", "status", 0.1, ts))
+    conn.executemany(
+        "INSERT INTO memory_items(id,type,title,content,importance,created_at) "
+        "VALUES(?,?,?,?,?,?)", rows)
+    conn.commit()
+    conn.close()
+
+
+def test_max_actions_caps_writes_and_flags(tmp_path):
+    db = str(tmp_path / "cap.db")
+    _seed(db, aged_noise=10, fresh_noise=3)
+    summary = cp.run(db, _opts(max_actions=4))
+    # Exactly the cap is acted on, capped flag is surfaced (not silent).
+    assert summary["writes_prune"] + summary["writes_decay"] == 4
+    assert summary["capped"] is True
+    # 6 aged rows remain un-deleted for the next run.
+    conn = sqlite3.connect(db)
+    remaining = conn.execute(
+        "SELECT COUNT(*) FROM memory_items WHERE type='chat_log' AND is_deleted=0"
+    ).fetchone()[0]
+    conn.close()
+    # 6 aged not-yet-pruned + 3 fresh untouched = 9.
+    assert remaining == 9
+
+
+def test_no_cap_processes_all_aged(tmp_path):
+    db = str(tmp_path / "nocap.db")
+    _seed(db, aged_noise=10, fresh_noise=3)
+    summary = cp.run(db, _opts(max_actions=0))
+    assert summary["capped"] is False
+    assert summary["writes_prune"] + summary["writes_decay"] == 10
+
+
+def test_scan_scoped_to_aged_window_skips_fresh(tmp_path):
+    # The fresh rows must never be scanned/acted on: the SELECT filters by
+    # created_at < fresh cutoff, so `scanned` reflects only the aged window.
+    db = str(tmp_path / "scope.db")
+    _seed(db, aged_noise=5, fresh_noise=100)
+    summary = cp.run(db, _opts(max_actions=0))
+    # Only the 5 aged rows are pulled into Python, not the 100 fresh ones.
+    assert summary["scanned"] == 5
+    assert summary["writes_prune"] + summary["writes_decay"] == 5

--- a/tests/test_governor_migration.py
+++ b/tests/test_governor_migration.py
@@ -214,6 +214,35 @@ def test_windows_action_scan_skips_canonical_names(monkeypatch):
     assert out["eligible"] == ["AgentOS_HourlySync"]
 
 
+def test_windows_action_match_is_path_anchored_not_bare_substring(monkeypatch):
+    # §3/§6 hardening: detection feeds `schtasks /Delete`, so the action match
+    # must be path-anchored. A task that merely MENTIONS a script filename (not as
+    # an invoked path) must NOT be matched and scheduled for deletion.
+    monkeypatch.setattr(gm, "_os_name", lambda: "Windows")
+    blob = _verbose_list([
+        # bare mention in an argument — NOT an invocation, must be ignored
+        (r"\unrelated-backup-job",
+         r'C:\tools\backup.exe --note "remember to port sync_all.py settings"'),
+    ])
+    monkeypatch.setattr(gm.subprocess, "run", _win_run_factory(blob, set()))
+    out = gm.detect_scheduled_tasks()
+    assert "unrelated-backup-job" not in out["eligible"]
+    assert out["eligible"] == []
+
+
+def test_action_invokes_marker_path_anchored_helper():
+    markers = ("sync_all.py", "m3_enrich.py")
+    # Invoked by path (Windows or POSIX separator) -> match.
+    assert gm._action_invokes_marker(r'"py" "C:\m3\bin\sync_all.py"', markers)
+    assert gm._action_invokes_marker('python /opt/m3/bin/sync_all.py', markers)
+    # Case-insensitive (Windows paths) -> match.
+    assert gm._action_invokes_marker(r'"PY" "C:\M3\BIN\SYNC_ALL.PY"', markers)
+    # Bare mention with no leading separator -> no match.
+    assert not gm._action_invokes_marker('echo sync_all.py is the script', markers)
+    # Different marker not present -> no match.
+    assert not gm._action_invokes_marker(r'"py" "C:\m3\bin\other.py"', markers)
+
+
 def test_windows_action_marker_is_sync_all_not_pg_sync_sh():
     # CROSS-OS TRAP GUARD: the Windows action invokes sync_all.py directly; the
     # Unix wrapper pg_sync.sh never appears in a Windows action. The two marker

--- a/tests/test_governor_migration.py
+++ b/tests/test_governor_migration.py
@@ -144,3 +144,113 @@ def test_not_migratable_lines_have_reasons():
     lines = gm.not_migratable_lines()
     assert len(lines) == len(gm.NOT_MIGRATABLE)
     assert all("—" in line for line in lines)  # name — reason format
+
+
+# ── Windows legacy-action detection (hardening A) ──────────────────────────────
+# A pre-bf110222 / hand-named task (e.g. `m3-memory-sync`) runs sync_all.py but
+# is NOT named AgentOS_HourlySync, so the name-only query misses it. Detection
+# must catch it by its ACTION and surface it under its REAL name for removal.
+
+def _verbose_list(records: list[tuple[str, str]]) -> str:
+    """Render a fake `schtasks /Query /FO LIST /V` blob from (TaskName, action)."""
+    blocks = []
+    for name, action in records:
+        blocks.append(
+            f"HostName:                             HOSTPC\n"
+            f"TaskName:                             {name}\n"
+            f"Task To Run:                          {action}\n"
+        )
+    return "\n".join(blocks)
+
+
+def _win_run_factory(verbose_blob: str, name_present: set[str]):
+    """Build a fake subprocess.run that answers BOTH query shapes:
+    - /TN <name>            → present iff name in name_present
+    - /FO LIST /V           → returns the verbose blob
+    """
+    class _R:
+        def __init__(self, rc, out):
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = ""
+
+    def fake_run(cmd, **kw):
+        if "/V" in cmd:
+            return _R(0, verbose_blob)
+        name = cmd[-1]  # /TN <name>
+        return _R(0, name) if name in name_present else _R(1, "")
+
+    return fake_run
+
+
+def test_windows_detects_legacy_sync_task_by_action(monkeypatch):
+    monkeypatch.setattr(gm, "_os_name", lambda: "Windows")
+    # No canonical task installed by name; a legacy task runs sync_all.py.
+    blob = _verbose_list([
+        (r"\m3-memory-sync",
+         r'powershell.exe -Command "& ...\.venv\Scripts\python.exe ...\bin\sync_all.py"'),
+        (r"\Microsoft\Windows\SomethingElse", r"C:\Windows\system32\noop.exe"),
+    ])
+    monkeypatch.setattr(gm.subprocess, "run", _win_run_factory(blob, set()))
+    out = gm.detect_scheduled_tasks()
+    # Surfaced under its REAL name so `schtasks /Delete /TN m3-memory-sync` works.
+    assert "m3-memory-sync" in out["eligible"]
+    assert out["not_migratable_present"] == []
+
+
+def test_windows_action_scan_skips_canonical_names(monkeypatch):
+    # A task NAMED AgentOS_HourlySync running sync_all.py must NOT be double-listed
+    # by the action scan — it's already found by the name-based query.
+    monkeypatch.setattr(gm, "_os_name", lambda: "Windows")
+    blob = _verbose_list([
+        (r"\AgentOS_HourlySync", r'"...\pythonw.exe" "...\bin\sync_all.py"'),
+    ])
+    monkeypatch.setattr(
+        gm.subprocess, "run",
+        _win_run_factory(blob, {"AgentOS_HourlySync"}),
+    )
+    out = gm.detect_scheduled_tasks()
+    # Exactly one occurrence — found by name, not duplicated by action.
+    assert out["eligible"] == ["AgentOS_HourlySync"]
+
+
+def test_windows_action_marker_is_sync_all_not_pg_sync_sh():
+    # CROSS-OS TRAP GUARD: the Windows action invokes sync_all.py directly; the
+    # Unix wrapper pg_sync.sh never appears in a Windows action. The two marker
+    # maps MUST stay independent or HourlySync legacy tasks go undetected.
+    assert gm._WINDOWS_ACTION_MARKERS["AgentOS_HourlySync"] == "sync_all.py"
+    assert gm._UNIX_CRON_MARKERS["AgentOS_HourlySync"] == "pg_sync.sh"
+
+
+def test_windows_legacy_detection_never_raises_without_schtasks(monkeypatch):
+    monkeypatch.setattr(gm, "_os_name", lambda: "Windows")
+
+    def boom(*a, **k):
+        raise FileNotFoundError("schtasks")
+
+    monkeypatch.setattr(gm.subprocess, "run", boom)
+    # Whole detect path must swallow it and return empty, not raise.
+    assert gm.detect_windows_legacy_action_tasks() == set()
+    assert gm.detect_scheduled_tasks() == {"eligible": [], "not_migratable_present": []}
+
+
+def test_windows_legacy_does_not_reclassify_not_migratable(monkeypatch):
+    # A hand-named task whose leaf collides with a NOT_MIGRATABLE name must not be
+    # pulled into `eligible` (that would schedule a security task for removal).
+    monkeypatch.setattr(gm, "_os_name", lambda: "Windows")
+    blob = _verbose_list([
+        (r"\AgentOS_SecretRotator", r'"...\pythonw.exe" "...\bin\secret_rotator.py"'),
+    ])
+    monkeypatch.setattr(
+        gm.subprocess, "run",
+        _win_run_factory(blob, {"AgentOS_SecretRotator"}),
+    )
+    out = gm.detect_scheduled_tasks()
+    assert "AgentOS_SecretRotator" in out["not_migratable_present"]
+    assert "AgentOS_SecretRotator" not in out["eligible"]
+
+
+def test_leaf_task_name_strips_path():
+    assert gm._leaf_task_name(r"\m3-memory-sync") == "m3-memory-sync"
+    assert gm._leaf_task_name(r"\Microsoft\Windows\Foo\Bar") == "Bar"
+    assert gm._leaf_task_name("PlainName") == "PlainName"


### PR DESCRIPTION
Re-created after `main` was force-reset (concurrent session); rebased onto current `main`. Was previously #56.

**Note:** depends on the numpy/Mypy fix in the companion PR (cap numpy <2.5) to pass the Mypy CI job — both reset together.

## Changes

**1. Windows governor-migration detects legacy tasks by ACTION, not just name.** The detector matched scheduled tasks only by exact `AgentOS_*` name, so a legacy/hand-named task (e.g. a pre-`bf110222` `m3-memory-sync` running `…\bin\sync_all.py`) was invisible to `m3 governor migrate` — it kept firing forever. Added `detect_windows_legacy_action_tasks()` which scans `schtasks /Query /FO LIST /V` and matches the **path-anchored** action (`\sync_all.py`, not a bare substring — §3/§6: this feeds `schtasks /Delete`, so the match must be precise), surfacing matches under their actual task name for removal.

**2. chatlog_prune per-run cap (§4/§8).** The prune pass scanned the entire `chat_log` table and acted on all eligible noise in one shot — the one cognitive-loop pass without a per-cycle bound. Now: scope the scan to the actionable aged window (`created_at < fresh cutoff`), and a `--max-actions` cap (loop default 5000, oldest-first) so a large backlog drains across cycles instead of one monster pass. The cap is surfaced (`summary["capped"]`), not silent. Also added §10 WAL pragmas + checkpoint to the `--apply` writer.

Includes the 4 recovered chatlog/cognitive-loop commits (hostname-casing fix, aged-noise prune + SLM-judged promote, governor-paced prune pass, embed_url passthrough) that were dropped in an earlier force-push and survive only on this branch.

## Verification
23 governor + prune-cap tests pass; ruff clean; security-reviewed (see prior review). PII/hostname scrubbed.