### PR TITLE
fix(embed): stop the GPU embed-storm + config-driven proper-embedder identity

### DIFF
--- a/bin/install_schedules.py
+++ b/bin/install_schedules.py
@@ -360,6 +360,26 @@ def install_windows_tasks(m3_memory_root, selector: str | None = None):
         result = subprocess.run(schtasks_cmd, capture_output=True, text=True)
         if result.returncode == 0:
             _safe_print(f"{OK} Created Windows Task: {task['name']}")
+            # Harden: schtasks /Create can't set these, so use PowerShell.
+            # MultipleInstances=IgnoreNew — never start a second copy while one
+            # is running, so a stuck/slow run doesn't STACK every interval and
+            # over-dispatch the local LLM. ExecutionTimeLimit caps a hung run.
+            # Best-effort: a failure here must not fail the install.
+            ps = (
+                f"$t = Get-ScheduledTask -TaskName '{task['name']}' "
+                f"-ErrorAction SilentlyContinue; if ($t) {{ $s = $t.Settings; "
+                f"$s.MultipleInstances = 'IgnoreNew'; "
+                f"$s.ExecutionTimeLimit = 'PT1H'; "
+                f"Set-ScheduledTask -TaskName '{task['name']}' -Settings $s "
+                f"| Out-Null }}"
+            )
+            try:
+                subprocess.run(
+                    ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps],
+                    capture_output=True, text=True, timeout=20,
+                )
+            except Exception:
+                pass  # hardening is best-effort; the task still works without it
         else:
             _safe_print(f"{FAIL} Failed to create task {task['name']}: {result.stderr.strip()}")
             success = False

--- a/bin/llm_failover.py
+++ b/bin/llm_failover.py
@@ -9,6 +9,7 @@ Used by custom_tool_bridge.py and memory_bridge.py.
 import logging
 import os
 import re
+import time
 from typing import Optional
 
 import httpx
@@ -90,21 +91,31 @@ READ_TIMEOUT = 10.0      # for model list fetches only
 _LLM_ENDPOINT_CACHE: Optional[tuple[str, str]] = None
 _SMALL_LLM_ENDPOINT_CACHE: Optional[tuple[str, str]] = None
 _EMBED_ENDPOINT_CACHE: Optional[tuple[str, str]] = None
+# Negative-result cache for embed discovery. Without this, a host with no
+# embedding model loaded would re-run the GET /v1/models probe of EVERY endpoint
+# on EVERY embed call (the positive cache only short-circuits a SUCCESS) — its
+# own per-call request storm. Remember a "no embed endpoint" result for
+# _EMBED_NEG_TTL seconds, then re-probe (so it recovers when a model is loaded).
+_EMBED_NEG_CACHE_TS: float = 0.0
+_EMBED_NEG_TTL: float = float(os.environ.get("M3_EMBED_DISCOVERY_NEG_TTL", "60"))
 
 
 def clear_failover_caches() -> None:
     """Forget all cached endpoints. Call after a persistent failure
     so the next discovery attempt probes the network."""
     global _LLM_ENDPOINT_CACHE, _SMALL_LLM_ENDPOINT_CACHE, _EMBED_ENDPOINT_CACHE
+    global _EMBED_NEG_CACHE_TS
     _LLM_ENDPOINT_CACHE = None
     _SMALL_LLM_ENDPOINT_CACHE = None
     _EMBED_ENDPOINT_CACHE = None
+    _EMBED_NEG_CACHE_TS = 0.0
 
 
 def clear_embed_cache() -> None:
     """Legacy helper for forgetting only the embed cache."""
-    global _EMBED_ENDPOINT_CACHE
+    global _EMBED_ENDPOINT_CACHE, _EMBED_NEG_CACHE_TS
     _EMBED_ENDPOINT_CACHE = None
+    _EMBED_NEG_CACHE_TS = 0.0
 
 
 def parse_model_size(model_id: str) -> float:
@@ -298,8 +309,10 @@ async def get_best_embed(client: httpx.AsyncClient, token: str) -> Optional[tupl
     """
     Find an embedding model across endpoints, with fallback to any available model.
 
-    Iterates LLM_ENDPOINTS in failover order. Prefers models matching EMBED_EXCLUSIONS.
-    Falls back to first endpoint with any usable model if no embed model found.
+    Iterates LLM_ENDPOINTS in failover order, returning the first endpoint that
+    advertises an EMBEDDING model (prefers BGE-M3). Returns None if no endpoint
+    serves an embedding model — a chat-only endpoint is NOT a valid fallback
+    (POSTing /embeddings to it 400s), so the caller takes its own embed fallback.
 
     Result is cached process-globally after first successful discovery. Reset
     via clear_embed_cache() on persistent failure.
@@ -311,11 +324,14 @@ async def get_best_embed(client: httpx.AsyncClient, token: str) -> Optional[tupl
     Returns:
         Tuple of (base_url, model_id) or None if no models found anywhere
     """
-    global _EMBED_ENDPOINT_CACHE
+    global _EMBED_ENDPOINT_CACHE, _EMBED_NEG_CACHE_TS
     if _EMBED_ENDPOINT_CACHE is not None:
         return _EMBED_ENDPOINT_CACHE
-
-    fallback_result = None
+    # Negative cache: a recent "no embed endpoint" result short-circuits the
+    # all-endpoints /models probe so a host without an embedding model doesn't
+    # re-probe on every single embed call.
+    if _EMBED_NEG_CACHE_TS and (time.time() - _EMBED_NEG_CACHE_TS) < _EMBED_NEG_TTL:
+        return None
 
     for endpoint in LLM_ENDPOINTS:
         try:
@@ -373,10 +389,16 @@ async def get_best_embed(client: httpx.AsyncClient, token: str) -> Optional[tupl
             _EMBED_ENDPOINT_CACHE = (endpoint, embed_models[0])
             return _EMBED_ENDPOINT_CACHE
 
-        # Record fallback if this endpoint has any usable model
-        if other_models and fallback_result is None:
-            fallback_result = (endpoint, other_models[0])
-
-    if fallback_result is not None:
-        _EMBED_ENDPOINT_CACHE = fallback_result
-    return fallback_result
+    # No endpoint advertised an EMBEDDING model. Do NOT fall back to a chat-only
+    # endpoint: POSTing /embeddings to a chat model returns 400 on every call,
+    # and the caller would retry it into a storm. Return None so the caller takes
+    # its real fallback (CPU embed server / cloud / graceful skip) instead of
+    # hammering an endpoint that structurally cannot embed — fail cleanly rather
+    # than returning a known-doomed target. Stamp the negative cache so we don't
+    # re-probe every call for the next _EMBED_NEG_TTL seconds.
+    _EMBED_NEG_CACHE_TS = time.time()
+    logger.warning(
+        "[llm_failover] no embedding model found across endpoints — returning "
+        "None so the caller uses its embed fallback (negative-cached %.0fs).",
+        _EMBED_NEG_TTL)
+    return None

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -51,10 +51,15 @@ def daemonize_windows(args):
         if arg != "--background":
             argv.append(arg)
 
-    # Spawn and exit parent
+    # Spawn the detached child, then HARD-exit the parent. os._exit(0) — not
+    # sys.exit(0) — because sys.exit raises SystemExit, which an outer try/except
+    # (or the asyncio runner if we got here late) can swallow, leaving the parent
+    # ALIVE alongside the child. Two live loops each dispatch their own
+    # Semaphore(2) of SLM calls = over-dispatch that storms the local LLM.
     subprocess.Popen(argv, creationflags=subprocess.CREATE_NO_WINDOW | subprocess.DETACHED_PROCESS)
     print("Cognitive Loop started in background (Windows pythonw).")
-    sys.exit(0)
+    sys.stdout.flush()
+    os._exit(0)
 
 def daemonize_unix():
     """Double-fork to detach from the terminal."""

--- a/bin/memory/config.py
+++ b/bin/memory/config.py
@@ -107,6 +107,34 @@ FILES_DB_PROMPT_ON_FIRST_USE: bool = os.environ.get(
 # the default must name BGE-M3 — an operator can still override via EMBED_MODEL.
 EMBED_MODEL: str = os.environ.get("EMBED_MODEL", "text-embedding-bge-m3")
 EMBED_DIM: int = int(os.environ.get("EMBED_DIM", "1024"))
+
+# ── Proper-embedder identity ───────────────────────────────────────────────────
+# A stored vector is only comparable to the rest of the store if it came from the
+# SAME embedder: same model name, dimension, normalization scheme, and embed
+# space. These knobs define that identity (model-agnostic — driven by config, not
+# a hardcoded model). A tier whose output fails this identity is treated as a
+# failed tier (the cascade tries the next one); if no tier validates, embedding
+# is DEFERRED (the row stays keyword-searchable and is retried next sweep).
+#   require_unit_norm: output vectors must be L2-unit-length (the cosine/vector
+#       store assumes this). Off only for an embedder that emits raw magnitudes.
+#   norm_tol: tolerance for the sampled unit-norm check.
+#   space_tag: an explicit embed-space id; defaults to EMBED_MODEL. Bump it (or
+#       EMBED_MODEL) when the vector space changes so old vectors are excluded.
+#   compatible_models: extra embed_model strings that map to the SAME space
+#       (back-compat for vectors written under a different-but-equivalent tag).
+EMBED_REQUIRE_UNIT_NORM: bool = (
+    os.environ.get("M3_EMBED_REQUIRE_UNIT_NORM", "1").lower() not in ("0", "false", "no"))
+EMBED_NORM_TOL: float = float(os.environ.get("M3_EMBED_NORM_TOL", "0.05"))
+EMBED_SPACE_TAG: str = (os.environ.get("M3_EMBED_SPACE_TAG") or "").strip() or EMBED_MODEL
+# Tier-2 (the local CPU HTTP embed server) historically mis-tagged its vectors
+# with the tier-1 GGUF filename; it should carry the proper identity name.
+EMBED_FALLBACK_MODEL_TAG: str = (
+    (os.environ.get("M3_EMBED_FALLBACK_MODEL_TAG") or "").strip() or EMBED_MODEL)
+# Operator-supplied extra compatible model tags (comma-separated).
+EMBED_COMPATIBLE_MODELS: tuple[str, ...] = tuple(
+    m.strip() for m in (os.environ.get("M3_EMBED_COMPATIBLE_MODELS") or "").split(",")
+    if m.strip())
+
 EMBED_TIMEOUT_READ: float = 30.0
 ORIGIN_DEVICE: str = os.environ.get("ORIGIN_DEVICE") or os.environ.get("COMPUTERNAME") or os.environ.get("HOSTNAME") or platform.node()
 

--- a/bin/memory/embed.py
+++ b/bin/memory/embed.py
@@ -240,6 +240,13 @@ def _validate_identity(vecs, attached_model: str, source_label: str) -> bool:
         if attached_model not in _compatible_model_names():
             _identity_warn(source_label, f"foreign model {attached_model!r}")
             return False
+        # Finite-ness is a hard invariant, independent of the unit-norm policy: a
+        # NaN/inf component is never a valid embedding (it poisons every cosine
+        # distance) and NaN slips past the norm tolerance check (NaN compares
+        # False to everything), so reject non-finite vectors unconditionally.
+        if not _sample_is_finite(vecs):
+            _identity_warn(source_label, "non-finite vector components")
+            return False
         if config.EMBED_REQUIRE_UNIT_NORM and not _sample_is_unit(vecs):
             _identity_warn(source_label, "vectors not unit-normalized")
             return False
@@ -274,20 +281,40 @@ def _accept_bulk(out, miss_indices, vecs, model: str, label: str) -> list[int]:
     return still
 
 
-def _sample_is_unit(vecs) -> bool:
-    """Cheap L2-norm check on a SAMPLE (not every vector in a bulk batch)."""
+def _identity_samples(vecs) -> list:
+    """The first/middle/last vectors of a bulk batch, or [vecs] for a single
+    vector — the sample set shared by the finite-ness and unit-norm checks."""
     if vecs and isinstance(vecs[0], (list, tuple)):
         n = len(vecs)
         idxs = {0, n // 2, n - 1}  # first, middle, last
-        samples = [vecs[i] for i in idxs]
-    else:
-        samples = [vecs]
+        return [vecs[i] for i in idxs]
+    return [vecs]
+
+
+def _sample_is_finite(vecs) -> bool:
+    """All components of the sampled vector(s) are finite (no NaN/inf). Cheap:
+    samples first/middle/last like the norm check. Runs regardless of the
+    unit-norm policy — a non-finite component is never a valid embedding."""
+    for v in _identity_samples(vecs):
+        if not v:
+            return False
+        if not all(math.isfinite(x) for x in v):
+            return False
+    return True
+
+
+def _sample_is_unit(vecs) -> bool:
+    """Cheap L2-norm check on a SAMPLE (not every vector in a bulk batch)."""
+    samples = _identity_samples(vecs)
     tol = config.EMBED_NORM_TOL
     for v in samples:
         if not v:
             return False
         norm = math.sqrt(sum(x * x for x in v))
-        if abs(norm - 1.0) > tol:
+        # A non-finite norm (NaN/inf) must be rejected explicitly: NaN compares
+        # False to everything, so `abs(nan - 1.0) > tol` is False and a NaN
+        # vector would otherwise slip through and poison every cosine distance.
+        if not math.isfinite(norm) or abs(norm - 1.0) > tol:
             return False
     return True
 

--- a/bin/memory/embed.py
+++ b/bin/memory/embed.py
@@ -194,6 +194,86 @@ _embedded_embedder = None
 _embedded_embed_checked = False
 
 
+# ── Embedder identity gate ─────────────────────────────────────────────────────
+# A vector is only acceptable if it came from the configured ("proper") embedder.
+# These resolve config LIVE (so set_embed_override / env changes are honoured) and
+# are model-agnostic. _validate_identity is the single gate every tier calls.
+
+def _proper_embed_dim() -> int:
+    return int(config.EMBED_DIM)
+
+
+def _compatible_model_names() -> frozenset[str]:
+    """The embed_model tags that map to the proper embed space. A tier whose tag
+    is in this set is accepted; anything else is a foreign embedder. Includes the
+    configured name, the tier-1 GGUF tag, the tier-2 fallback tag, the space tag,
+    any runtime model override, and operator-supplied extras."""
+    names = {
+        config.EMBED_MODEL,
+        config.EMBED_SPACE_TAG,
+        config.EMBED_FALLBACK_MODEL_TAG,
+        _EMBED_GGUF_MODEL_TAG,
+        config._EMBED_MODEL_OVERRIDE or config.EMBED_MODEL,
+        *config.EMBED_COMPATIBLE_MODELS,
+    }
+    return frozenset(n for n in names if n)
+
+
+# Log a given identity-rejection reason at most once per source label, so a
+# misconfigured tier is visible without flooding the log (the storm we just fixed).
+_IDENTITY_WARNED: set[str] = set()
+
+
+def _validate_identity(vecs, attached_model: str, source_label: str) -> bool:
+    """True iff `vecs` (a single vector or a list) is acceptable for the store:
+    correct dimension, a compatible model tag, and (if required) unit-length.
+    A failure means this tier did not produce a PROPER vector — the caller must
+    cascade to the next tier (or defer), NEVER store the vector. Never raises."""
+    try:
+        sample = vecs[0] if (vecs and isinstance(vecs[0], (list, tuple))) else vecs
+        if not sample:
+            return False
+        dim = _proper_embed_dim()
+        if len(sample) != dim:
+            _identity_warn(source_label, f"dim {len(sample)} != {dim}")
+            return False
+        if attached_model not in _compatible_model_names():
+            _identity_warn(source_label, f"foreign model {attached_model!r}")
+            return False
+        if config.EMBED_REQUIRE_UNIT_NORM and not _sample_is_unit(vecs):
+            _identity_warn(source_label, "vectors not unit-normalized")
+            return False
+        return True
+    except Exception:
+        return False  # never let the gate itself break the cascade
+
+
+def _identity_warn(source_label: str, reason: str) -> None:
+    key = f"{source_label}:{reason.split(' ')[0]}"
+    if key not in _IDENTITY_WARNED:
+        _IDENTITY_WARNED.add(key)
+        logger.warning("Embed identity rejected from %s: %s — cascading/deferring "
+                       "rather than storing a non-proper vector.", source_label, reason)
+
+
+def _sample_is_unit(vecs) -> bool:
+    """Cheap L2-norm check on a SAMPLE (not every vector in a bulk batch)."""
+    if vecs and isinstance(vecs[0], (list, tuple)):
+        n = len(vecs)
+        idxs = {0, n // 2, n - 1}  # first, middle, last
+        samples = [vecs[i] for i in idxs]
+    else:
+        samples = [vecs]
+    tol = config.EMBED_NORM_TOL
+    for v in samples:
+        if not v:
+            return False
+        norm = math.sqrt(sum(x * x for x in v))
+        if abs(norm - 1.0) > tol:
+            return False
+    return True
+
+
 def discover_bge_m3_gguf(budget_s: float = _EMBED_GGUF_WALK_BUDGET_S) -> str | None:
     """Probe the canonical model directories for a bge-m3 GGUF and return its
     path, or None. Bounded: at most `budget_s` wall-clock and depth ~4 per dir,

--- a/bin/memory/embed.py
+++ b/bin/memory/embed.py
@@ -256,6 +256,24 @@ def _identity_warn(source_label: str, reason: str) -> None:
                        "rather than storing a non-proper vector.", source_label, reason)
 
 
+def _accept_bulk(out, miss_indices, vecs, model: str, label: str) -> list[int]:
+    """Assign each proper vector into `out` at its original index; return the
+    LOCAL indices (into miss_indices/vecs) whose vector was missing or failed the
+    embedder-identity gate, so the caller can narrow the cascade to just those.
+    Validates the batch once (cheap, sampled) before accepting any vector — a
+    foreign-identity batch is rejected wholesale so no bad vector is stored."""
+    real = [v for v in vecs if v is not None]
+    if real and not _validate_identity(real, model, label):
+        return list(range(len(vecs)))  # whole batch is not proper -> all miss
+    still: list[int] = []
+    for j, (idx, vec) in enumerate(zip(miss_indices, vecs)):
+        if vec is not None:
+            out[idx] = (vec, model)
+        else:
+            still.append(j)
+    return still
+
+
 def _sample_is_unit(vecs) -> bool:
     """Cheap L2-norm check on a SAMPLE (not every vector in a bulk batch)."""
     if vecs and isinstance(vecs[0], (list, tuple)):
@@ -651,10 +669,9 @@ def set_embed_override(url: str | None, model: str | None = None) -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Per-call + bulk semaphores, dim-validation flag
+# Per-call + bulk semaphores
 # ──────────────────────────────────────────────────────────────────────────────
 _EMBED_SEM = asyncio.Semaphore(4)
-_EMBED_DIM_VALIDATED = False
 
 EMBED_BULK_CHUNK = int(os.environ.get("EMBED_BULK_CHUNK", "1024"))
 EMBED_BULK_CONCURRENCY = int(os.environ.get("EMBED_BULK_CONCURRENCY", "4"))
@@ -665,7 +682,6 @@ _EMBED_BULK_SEM = asyncio.Semaphore(EMBED_BULK_CONCURRENCY)
 # The cascade itself
 # ──────────────────────────────────────────────────────────────────────────────
 async def _embed(text: str) -> tuple[list[float] | None, str]:
-    global _EMBED_DIM_VALIDATED
     c_hash = _content_hash(text)
     embedded = _get_embedded_embedder()
     cache_model = _EMBED_GGUF_MODEL_TAG if embedded is not None else config.EMBED_MODEL
@@ -689,12 +705,8 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
         try:
             _track_cost_lazy("embed_calls", len(text.split()) * 2)
             vec = await asyncio.to_thread(lambda: embedded.embed([text])[0])
-            if not _EMBED_DIM_VALIDATED:
-                if len(vec) != config.EMBED_DIM:
-                    logger.error(
-                        f"Embedded embedding dim {len(vec)} != EMBED_DIM {config.EMBED_DIM}"
-                    )
-                _EMBED_DIM_VALIDATED = True
+            if not _validate_identity(vec, _EMBED_GGUF_MODEL_TAG, "tier1-embedded"):
+                raise EmbeddedBackendError("output failed embedder-identity check")
             if _EMBEDDED_BREAKER is not None:
                 _EMBEDDED_BREAKER.record_success()
             _record_embed_backend(_embedded_label(), 1)
@@ -733,16 +745,14 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
             resp.raise_for_status()
             payload = resp.json()
             emb = payload["data"][0]["embedding"]
-            if not _EMBED_DIM_VALIDATED:
-                if len(emb) != config.EMBED_DIM:
-                    logger.error(
-                        f"CPU fallback embedding dim {len(emb)} != EMBED_DIM {config.EMBED_DIM}"
-                    )
-                _EMBED_DIM_VALIDATED = True
+            # The CPU HTTP service carries the proper-identity fallback tag, NOT
+            # the tier-1 GGUF filename (a historical mis-tag).
+            if not _validate_identity(emb, config.EMBED_FALLBACK_MODEL_TAG, "tier2-cpu-http"):
+                raise EmbedFallbackError("output failed embedder-identity check")
             if _CPU_FALLBACK_BREAKER is not None:
                 _CPU_FALLBACK_BREAKER.record_success()
             _record_embed_backend("cpu-http-fallback", 1)
-            return emb, _EMBED_GGUF_MODEL_TAG
+            return emb, config.EMBED_FALLBACK_MODEL_TAG
         except Exception as e:
             wrapped = EmbedFallbackError(f"{_EMBED_FALLBACK_URL}: {e}")
             wrapped.__cause__ = e
@@ -800,13 +810,9 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
                     resp.raise_for_status()
                     emb = resp.json()["data"][0]["embedding"]
 
-                    if not _EMBED_DIM_VALIDATED:
-                        if len(emb) != config.EMBED_DIM:
-                            logger.error(
-                                f"Embedding dimension mismatch: got {len(emb)}, "
-                                f"expected EMBED_DIM={config.EMBED_DIM}. Update EMBED_DIM env var."
-                            )
-                        _EMBED_DIM_VALIDATED = True
+                    if not _validate_identity(emb, model, "tier3-primary"):
+                        raise RuntimeError(
+                            f"primary embed output failed identity (model={model!r})")
 
                     if _PRIMARY_BREAKER is not None:
                         _PRIMARY_BREAKER.record_success()
@@ -897,8 +903,8 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
                     resp.raise_for_status()
                     emb = resp.json()["data"][0]["embedding"]
 
-                    if len(emb) != config.EMBED_DIM:
-                        logger.error(f"Cloud Enclave embedding dim {len(emb)} != EMBED_DIM {config.EMBED_DIM}")
+                    if not _validate_identity(emb, config.EMBED_MODEL, "tier4-cloud"):
+                        raise RuntimeError("cloud enclave output failed identity check")
 
                     if _CLOUD_BREAKER is not None:
                         _CLOUD_BREAKER.record_success()
@@ -982,12 +988,12 @@ async def _embed_many_cloud_fallback(
         data = resp.json()["data"]
         vecs = _order_embeddings(data, len(cloud_texts))
 
-        if vecs is not None:
+        real = [v for v in vecs if v is not None] if vecs is not None else []
+        if vecs is not None and (not real or _validate_identity(
+                real, config.EMBED_MODEL, "tier4-cloud-bulk")):
             _cloud_served = 0
             for idx, vec in zip(cloud_indices, vecs):
                 if vec is not None:
-                    if len(vec) != config.EMBED_DIM:
-                        logger.error(f"Cloud Enclave embedding dim {len(vec)} != EMBED_DIM {config.EMBED_DIM}")
                     out[idx] = (vec, config.EMBED_MODEL)
                     _cloud_served += 1
 
@@ -1063,10 +1069,15 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
         try:
             _track_cost_lazy("embed_calls", sum(len(t.split()) * 2 for t in miss_texts))
             vecs = await asyncio.to_thread(lambda: embedded.embed(miss_texts))
-            for idx, vec in zip(miss_indices, vecs):
-                out[idx] = (vec, _EMBED_GGUF_MODEL_TAG)
-            _record_embed_backend(_embedded_label(), len(miss_texts))
-            return out  # type: ignore[return-value]
+            # Identity gate (previously this bulk path had NO dim/model check): a
+            # row whose vector isn't proper stays in the miss set and cascades.
+            kept_local = _accept_bulk(out, miss_indices, vecs,
+                                      _EMBED_GGUF_MODEL_TAG, "tier1-embedded-bulk")
+            if not kept_local:
+                _record_embed_backend(_embedded_label(), len(miss_texts))
+                return out  # type: ignore[return-value]
+            miss_indices = [miss_indices[j] for j in kept_local]
+            miss_texts = [miss_texts[j] for j in kept_local]
         except Exception as e:
             # An n_ctx overflow ("N tokens > n_ctx") fails the WHOLE batch even
             # though only one row is too long. Don't cascade the whole batch to
@@ -1113,10 +1124,15 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
                 f"CPU fallback response for {len(miss_texts)} inputs could not be "
                 f"aligned (bad/missing index or count)"
             )
-        for idx, vec in zip(miss_indices, vecs):
-            out[idx] = (vec, _EMBED_GGUF_MODEL_TAG)
-        _record_embed_backend("cpu-http-fallback", len(miss_texts))
-        return out  # type: ignore[return-value]
+        # Retag to the proper-identity fallback tag (not the tier-1 GGUF name)
+        # and gate: rows failing identity stay in the miss set and cascade.
+        kept_local = _accept_bulk(out, miss_indices, vecs,
+                                  config.EMBED_FALLBACK_MODEL_TAG, "tier2-cpu-http-bulk")
+        if not kept_local:
+            _record_embed_backend("cpu-http-fallback", len(miss_texts))
+            return out  # type: ignore[return-value]
+        miss_indices = [miss_indices[j] for j in kept_local]
+        miss_texts = [miss_texts[j] for j in kept_local]
     except Exception as e:
         logger.warning(
             f"CPU HTTP fallback ({_EMBED_FALLBACK_URL}) bulk failed ({e}) — using primary HTTP"
@@ -1215,21 +1231,20 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
     ]
     chunk_results = await asyncio.gather(*(_post_chunk(c) for c in chunks))
 
-    global _EMBED_DIM_VALIDATED
     flat: list[list[float] | None] = []
     for cr in chunk_results:
         flat.extend(cr)
+    # Identity gate: a primary-HTTP vector that isn't proper is set to None so it
+    # stays a miss and is handed to the cloud fallback (never stored as-is).
+    real = [v for v in flat if v is not None]
+    primary_ok = (not real) or _validate_identity(real, model, "tier3-primary-bulk")
     _primary_served = 0
     for local_i, vec in enumerate(flat):
-        if vec is not None and not _EMBED_DIM_VALIDATED:
-            if len(vec) != config.EMBED_DIM:
-                logger.error(
-                    f"Embedding dimension mismatch: got {len(vec)}, expected {config.EMBED_DIM}"
-                )
-            _EMBED_DIM_VALIDATED = True
-        out[miss_indices[local_i]] = (vec, model)
-        if vec is not None:
+        if vec is not None and primary_ok:
+            out[miss_indices[local_i]] = (vec, model)
             _primary_served += 1
+        else:
+            out[miss_indices[local_i]] = (None, model)
     if _primary_served:
         _record_embed_backend("http-primary", _primary_served)
 

--- a/bin/memory/embed.py
+++ b/bin/memory/embed.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -307,6 +308,28 @@ DENSE_TOKEN_OVERLAP = 500
 DENSE_MIN_SUB_CHARS = 2000
 _DENSE_ERR_RE = re.compile(r"(\d+)\s*tokens\s*>\s*n_ctx")
 
+# Per-call embed-failure sentinels (returned by _post_once, NOT shared state).
+# Distinct objects so a chunk's outcome can't leak into a concurrent chunk's.
+_EMBED_TRANSIENT = object()   # retryable: timeout / 5xx / 413 / 429
+_EMBED_PERMANENT = object()   # non-retryable 4xx: don't retry or bisect
+
+
+def _order_embeddings(data: list[dict], n_inputs: int) -> list[list[float]] | None:
+    """Return embeddings in INPUT order, or None if the response can't be safely
+    aligned. An OpenAI-style embeddings response carries a per-item `index`; we
+    sort by it. But a server that OMITS index (every item defaults to 0) would
+    pass a naive len-check while the vectors are in arbitrary order — storing a
+    semantically-WRONG vector under a memory id with no error. Require `index` to
+    be a complete permutation of range(n_inputs) before trusting order; reject
+    (treat as failure) otherwise."""
+    if len(data) != n_inputs:
+        return None
+    seen = [d.get("index") for d in data]
+    if any(ix is None for ix in seen) or sorted(seen) != list(range(n_inputs)):
+        return None  # missing / duplicate / out-of-range index -> not alignable
+    ordered = sorted(data, key=lambda d: d["index"])
+    return [d["embedding"] for d in ordered]
+
 
 def _subdivide_dense_chunk(text: str, observed_tokens: int) -> list[str]:
     """Re-split a chunk that overflowed the bge-m3 token ceiling."""
@@ -329,6 +352,66 @@ def _subdivide_dense_chunk(text: str, observed_tokens: int) -> list[str]:
             return out
         out.append(text[start:end])
         start += stride
+
+
+def _mean_pool(vecs: list[list[float]]) -> list[float] | None:
+    """Average several sub-chunk vectors into one (standard long-doc embedding),
+    then L2-NORMALIZE the result. bge-m3 vectors are unit-length and the store /
+    cosine paths assume that invariant — mean-pooling alone yields a sub-unit
+    vector (norm < 1), so it MUST be renormalized or it is incomparable to every
+    other vector in the store. Returns None if there's nothing to pool."""
+    if not vecs:
+        return None
+    if len(vecs) == 1:
+        return vecs[0]  # already a normalized model output
+    dim = len(vecs[0])
+    acc = [0.0] * dim
+    n = 0
+    for v in vecs:
+        if len(v) != dim:  # defensive: skip a malformed sub-vector
+            continue
+        for k in range(dim):
+            acc[k] += v[k]
+        n += 1
+    if n == 0:
+        return None
+    norm = math.sqrt(sum(x * x for x in acc))
+    if norm == 0.0:
+        return [0.0] * dim  # degenerate (opposing vectors); avoid /0
+    return [x / norm for x in acc]  # mean then L2-normalize (the /n cancels)
+
+
+async def _embedded_bulk_with_subdivide(
+    embedded, texts: list[str]
+) -> list[list[float] | None]:
+    """Embed each text via the in-process (tier-1) embedder, subdividing any row
+    that overflows n_ctx and mean-pooling its sub-chunk vectors. Returns one
+    vector per input (None for a row tier 1 still can't embed). Keeps an
+    oversized row IN-PROCESS instead of cascading the whole batch to HTTP."""
+    def _embed_list(items: list[str]) -> list[list[float]]:
+        return embedded.embed(items)
+
+    results: list[list[float] | None] = []
+    for text in texts:
+        try:
+            vecs = await asyncio.to_thread(_embed_list, [text])
+            results.append(vecs[0])
+            continue
+        except Exception as e:
+            m = _DENSE_ERR_RE.search(str(e))
+            if not m:
+                results.append(None)
+                continue
+            observed = int(m.group(1))
+        # Overflow: split into sub-chunks, embed each, mean-pool.
+        try:
+            subs = _subdivide_dense_chunk(text, observed)
+            sub_vecs = await asyncio.to_thread(_embed_list, subs)
+            results.append(_mean_pool([v for v in sub_vecs if v is not None]))
+        except Exception as e2:
+            logger.warning("Subdivide-embed failed for oversized row: %s", e2)
+            results.append(None)
+    return results
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -817,10 +900,9 @@ async def _embed_many_cloud_fallback(
         )
         resp.raise_for_status()
         data = resp.json()["data"]
-        ordered = sorted(data, key=lambda d: d.get("index", 0))
-        vecs = [d["embedding"] for d in ordered]
+        vecs = _order_embeddings(data, len(cloud_texts))
 
-        if len(vecs) == len(cloud_texts):
+        if vecs is not None:
             _cloud_served = 0
             for idx, vec in zip(cloud_indices, vecs):
                 if vec is not None:
@@ -834,7 +916,9 @@ async def _embed_many_cloud_fallback(
                     _CLOUD_BREAKER.record_success()
                 _record_embed_backend("cloud-enclave", _cloud_served)
         else:
-            logger.error(f"Cloud enclave returned {len(vecs)} vectors for {len(cloud_texts)} inputs")
+            logger.error("Cloud enclave response for %d inputs could not be "
+                         "aligned (bad/missing index or count) — not stored.",
+                         len(cloud_texts))
             if _CLOUD_BREAKER is not None:
                 _CLOUD_BREAKER.record_failure()
     except Exception as e:
@@ -904,7 +988,32 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
             _record_embed_backend(_embedded_label(), len(miss_texts))
             return out  # type: ignore[return-value]
         except Exception as e:
-            logger.warning(f"Embedded bulk embed failed ({e}) — falling back to CPU HTTP")
+            # An n_ctx overflow ("N tokens > n_ctx") fails the WHOLE batch even
+            # though only one row is too long. Don't cascade the whole batch to
+            # HTTP for that — subdivide the oversized row(s) in-process (tier 1
+            # handles them), and only the rows tier 1 genuinely can't do fall
+            # through. This keeps a single oversized row from cascading to the
+            # HTTP tiers (and, when those are down, fanning out into a 4xx storm).
+            if _DENSE_ERR_RE.search(str(e)):
+                resolved = await _embedded_bulk_with_subdivide(embedded, miss_texts)
+                still_missing_local = []
+                for j, (idx, vec) in enumerate(zip(miss_indices, resolved)):
+                    if vec is not None:
+                        out[idx] = (vec, _EMBED_GGUF_MODEL_TAG)
+                    else:
+                        still_missing_local.append(j)
+                if not still_missing_local:
+                    _record_embed_backend(_embedded_label(), len(miss_texts))
+                    return out  # type: ignore[return-value]
+                # Narrow the cascade to ONLY the rows tier 1 couldn't embed.
+                miss_indices = [miss_indices[j] for j in still_missing_local]
+                miss_texts = [miss_texts[j] for j in still_missing_local]
+                logger.warning(
+                    "Embedded bulk: %d oversized row(s) embedded via subdivide; "
+                    "%d still unresolved — falling back to CPU HTTP for those.",
+                    len(resolved) - len(still_missing_local), len(still_missing_local))
+            else:
+                logger.warning(f"Embedded bulk embed failed ({e}) — falling back to CPU HTTP")
 
     # Tier 2 (bulk): same architecture as single-_embed — always try the
     # always-on 8082 service regardless of tier-1 GGUF configuration.
@@ -918,11 +1027,11 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
         )
         resp.raise_for_status()
         data = resp.json()["data"]
-        ordered = sorted(data, key=lambda d: d.get("index", 0))
-        vecs = [d["embedding"] for d in ordered]
-        if len(vecs) != len(miss_texts):
+        vecs = _order_embeddings(data, len(miss_texts))
+        if vecs is None:
             raise RuntimeError(
-                f"CPU fallback returned {len(vecs)} vectors for {len(miss_texts)} inputs"
+                f"CPU fallback response for {len(miss_texts)} inputs could not be "
+                f"aligned (bad/missing index or count)"
             )
         for idx, vec in zip(miss_indices, vecs):
             out[idx] = (vec, _EMBED_GGUF_MODEL_TAG)
@@ -948,9 +1057,15 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
             return out  # type: ignore[return-value]
         base_url, model = result
 
-    _last_embed_err: dict[str, str] = {"msg": ""}
+    # _post_once returns a PER-CALL result — never shared mutable state. Each
+    # concurrent chunk decides its own fate; a permanent 4xx in one chunk must
+    # NOT cause a concurrent chunk's transient failure to be dropped as permanent
+    # (that would silently lose embeddable rows). Sentinels:
+    #   list[...]              -> success (the vectors)
+    #   _EMBED_TRANSIENT       -> retryable (timeout / 5xx / 413 / 429)
+    #   (_EMBED_PERMANENT,msg) -> non-retryable 4xx; don't retry or bisect
 
-    async def _post_once(chunk_texts: list[str]) -> list[list[float] | None] | None:
+    async def _post_once(chunk_texts: list[str]):
         try:
             resp = await client.post(
                 f"{base_url}/embeddings",
@@ -960,31 +1075,49 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
             )
             resp.raise_for_status()
             data = resp.json()["data"]
-            ordered = sorted(data, key=lambda d: d.get("index", 0))
-            return [d["embedding"] for d in ordered]
+            ordered = _order_embeddings(data, len(chunk_texts))
+            if ordered is None:
+                # Response can't be aligned to inputs — treat as transient (a
+                # smaller batch via bisect may return a clean index), never
+                # store mis-aligned vectors.
+                return _EMBED_TRANSIENT
+            return ordered
         except _httpx.HTTPStatusError as e:
-            _last_embed_err["msg"] = f"HTTP {e.response.status_code}: {e.response.text[:300]}"
-            return None
-        except Exception as e:
-            _last_embed_err["msg"] = f"{type(e).__name__}: {e}"
-            return None
+            code = e.response.status_code
+            msg = f"HTTP {code}: {e.response.text[:300]}"
+            # 4xx = the request is wrong and won't succeed on retry — EXCEPT 413
+            # (payload too large) and 429 (rate limit), where a smaller batch /
+            # a wait genuinely helps. Everything else is permanent.
+            if 400 <= code < 500 and code not in (413, 429):
+                return (_EMBED_PERMANENT, msg)
+            return _EMBED_TRANSIENT
+        except Exception:
+            return _EMBED_TRANSIENT
 
     async def _post_chunk(chunk_texts: list[str]) -> list[list[float] | None]:
         async with _EMBED_BULK_SEM:
             for attempt in range(3):
                 result = await _post_once(chunk_texts)
-                if result is not None:
+                if isinstance(result, list):
                     return result
+                # Permanent (non-retryable 4xx): stop immediately — no backoff
+                # retries, no bisect. Drop this chunk; the next sweep can retry
+                # once the underlying cause (e.g. wrong embed endpoint) is fixed.
+                if isinstance(result, tuple) and result[0] is _EMBED_PERMANENT:
+                    logger.warning(
+                        "Bulk embed: permanent failure (%s) — dropping %d input(s) "
+                        "without retry/bisect.", result[1], len(chunk_texts))
+                    return [None] * len(chunk_texts)
                 if attempt < 2:
                     await asyncio.sleep(2 * (2 ** attempt))
 
         if len(chunk_texts) == 1:
-            reason = _last_embed_err.get("msg") or "unknown"
             logger.warning(
-                f"Bulk embed: dropping single input of len={len(chunk_texts[0])} "
-                f"after 3 attempts — last error: {reason}"
-            )
+                "Bulk embed: dropping single input of len=%d after 3 transient "
+                "attempts.", len(chunk_texts[0]))
             return [None]
+        # Only transient/size failures reach here — bisecting can help (smaller
+        # batch, or isolate one oversized item). Permanent failures returned above.
         mid = len(chunk_texts) // 2
         logger.info(
             f"Bulk embed: bisecting failed chunk of {len(chunk_texts)} into "

--- a/bin/memory/search.py
+++ b/bin/memory/search.py
@@ -1039,6 +1039,14 @@ async def memory_search_scored_impl(
     q_vec, _ = await _embed(query)
     if not q_vec:
         return []
+    # The embeddings join is dim-filtered (me.dim = ? below) and the query is
+    # packed at its own length, so a wrong-dim query simply matches no stored
+    # rows rather than crashing. Log it for visibility (a mismatch means a
+    # misconfigured EMBED_DIM or a non-proper query embedder) but don't hard-fail.
+    if len(q_vec) != config.EMBED_DIM:
+        logger.debug("Query embedding dim %d != EMBED_DIM %d; semantic matches "
+                     "will be empty unless the store also uses dim %d.",
+                     len(q_vec), config.EMBED_DIM, len(q_vec))
 
     extra_columns = list(extra_columns or [])
     _BASE_COLS = ["id", "content", "title", "type", "importance"]
@@ -1131,6 +1139,19 @@ async def memory_search_scored_impl(
         raise ValueError(
             f"vector_kind_strategy must be 'default' or 'max', got {vector_kind_strategy!r}"
         )
+
+    # Identity filter: only compare vectors from the proper embedder. A row whose
+    # embed_model isn't a compatible identity, or whose dim differs, is in a
+    # different (incomparable) vector space — and a wrong-dim blob would break the
+    # cosine pack. Restrict the embeddings join to the proper identity.
+    from memory.embed import _compatible_model_names
+    _compat = sorted(_compatible_model_names())
+    if _compat:
+        where_clauses.append(
+            "me.embed_model IN (%s)" % ",".join("?" for _ in _compat))
+        params.extend(_compat)
+    where_clauses.append("me.dim = ?")
+    params.append(config.EMBED_DIM)
 
     where_sql = " AND ".join(where_clauses)
 

--- a/tests/test_confidence_ranking.py
+++ b/tests/test_confidence_ranking.py
@@ -41,15 +41,19 @@ def _vec(primary: float, dim: int):
 
 
 def _seed(conn, mid, content, vec, confidence, *, importance=0.5):
+    from memory.config import EMBED_MODEL
     conn.execute(
         "INSERT INTO memory_items (id, type, title, content, source, change_agent, "
         "created_at, importance, confidence, is_deleted) VALUES (?,?,?,?,?,?,?,?,?,0)",
         (mid, "fact", content[:20], content, "agent", "claude",
          "2026-01-01T00:00:00Z", importance, confidence),
     )
+    # Tag with the configured embedder so the row survives search's proper-identity
+    # filter (embed_model IN compatible AND dim == EMBED_DIM); this test exercises
+    # confidence ranking, not identity, so the rows must be retrievable.
     conn.execute(
         "INSERT INTO memory_embeddings (memory_id, embedding, embed_model, dim) VALUES (?,?,?,?)",
-        (mid, _pack(vec), "test", len(vec)),
+        (mid, _pack(vec), EMBED_MODEL, len(vec)),
     )
 
 

--- a/tests/test_confidence_ranking_effectiveness.py
+++ b/tests/test_confidence_ranking_effectiveness.py
@@ -83,7 +83,7 @@ async def test_confidence_ranking_lifts_corroborated_recall(monkeypatch, tmp_pat
     """Targets (high confidence) compete with same-relevance distractors (low
     confidence). Enabling confidence ranking must lift recall@k for the targets
     and never lower it — the pre-registered §5 direction."""
-    from memory.config import EMBED_DIM
+    from memory.config import EMBED_DIM, EMBED_MODEL
 
     db = tmp_path / "t.db"
     _full_db(db)
@@ -105,7 +105,7 @@ async def test_confidence_ranking_lifts_corroborated_recall(monkeypatch, tmp_pat
             )
             conn.execute(
                 "INSERT INTO memory_embeddings (memory_id, embedding, embed_model, dim) VALUES (?,?,?,?)",
-                (f"target-{i}", _pack(qv), "test", EMBED_DIM),
+                (f"target-{i}", _pack(qv), EMBED_MODEL, EMBED_DIM),
             )
         for j in range(N_DISTRACTORS):
             conn.execute(
@@ -116,7 +116,7 @@ async def test_confidence_ranking_lifts_corroborated_recall(monkeypatch, tmp_pat
             )
             conn.execute(
                 "INSERT INTO memory_embeddings (memory_id, embedding, embed_model, dim) VALUES (?,?,?,?)",
-                (f"distractor-{j}", _pack(qv), "test", EMBED_DIM),
+                (f"distractor-{j}", _pack(qv), EMBED_MODEL, EMBED_DIM),
             )
         conn.commit()
 

--- a/tests/test_dense_chunk_recovery.py
+++ b/tests/test_dense_chunk_recovery.py
@@ -112,5 +112,57 @@ class SubdivideDenseChunkTests(unittest.TestCase):
         self.assertEqual(int(m2.group(1)), 9735)
 
 
+class MeanPoolTests(unittest.TestCase):
+    """_mean_pool averages an oversized row's sub-chunk vectors into one vector
+    AND L2-normalizes it (standard long-doc embedding) — used by
+    _embedded_bulk_with_subdivide so an over-n_ctx row is handled in-process.
+    The normalize step is load-bearing: bge-m3 vectors are unit-length and the
+    store / cosine paths assume that, so a raw mean (norm < 1) is incomparable."""
+
+    def setUp(self):
+        import math
+        import memory.embed as me
+        self.me = me
+        self.math = math
+
+    def _norm(self, v):
+        return self.math.sqrt(sum(x * x for x in v))
+
+    def _assert_unit(self, v):
+        self.assertAlmostEqual(self._norm(v), 1.0, places=5,
+                               msg=f"pooled vector not unit-length: norm={self._norm(v)}")
+
+    def test_pooled_vector_is_unit_length(self):
+        # Mean of [1,1] and [3,3] points along [1,1]; normalized => [0.707, 0.707].
+        out = self.me._mean_pool([[1.0, 1.0], [3.0, 3.0]])
+        self._assert_unit(out)
+        self.assertAlmostEqual(out[0], out[1], places=6)  # symmetric input
+        self.assertAlmostEqual(out[0], 1.0 / self.math.sqrt(2), places=5)
+
+    def test_direction_preserved(self):
+        # Pooling preserves direction (the mean of the inputs), only rescales.
+        out = self.me._mean_pool([[0.0, 6.0], [2.0, 0.0], [4.0, 3.0]])  # mean [2,3]
+        self._assert_unit(out)
+        # [2,3] normalized
+        self.assertAlmostEqual(out[0] / out[1], 2.0 / 3.0, places=5)
+
+    def test_single_vector_passthrough(self):
+        # A single (already-normalized) model output is returned as-is.
+        self.assertEqual(self.me._mean_pool([[5.0, 6.0]]), [5.0, 6.0])
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(self.me._mean_pool([]))
+
+    def test_skips_malformed_subvector(self):
+        # A sub-vector of the wrong dim is skipped, not crashed on; result still unit.
+        out = self.me._mean_pool([[1.0, 1.0], [9.0], [3.0, 3.0]])
+        self._assert_unit(out)
+        self.assertAlmostEqual(out[0], out[1], places=6)
+
+    def test_opposing_vectors_degenerate_to_zero(self):
+        # Mean of opposing vectors is the zero vector — must not divide by zero.
+        self.assertEqual(self.me._mean_pool([[1.0, 0.0], [-1.0, 0.0]]), [0.0, 0.0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dense_chunk_recovery.py
+++ b/tests/test_dense_chunk_recovery.py
@@ -121,6 +121,7 @@ class MeanPoolTests(unittest.TestCase):
 
     def setUp(self):
         import math
+
         import memory.embed as me
         self.me = me
         self.math = math

--- a/tests/test_embed_cascade_order.py
+++ b/tests/test_embed_cascade_order.py
@@ -23,6 +23,11 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
 
+# A proper-identity stub embedding: 1024-dim AND L2-unit-length, so the embedder-
+# identity gate accepts it. (A zero vector has norm 0 and is correctly rejected.)
+# These tests assert tier ORDER, so the exact direction is irrelevant.
+_STUB_EMBEDDING = [1.0] + [0.0] * 1023
+
 
 @pytest.fixture(autouse=True)
 def _isolate_env(monkeypatch, tmp_path):
@@ -77,7 +82,7 @@ async def test_tier2_attempted_when_no_gguf(monkeypatch):
         def raise_for_status(self):
             pass
         def json(self):
-            return {"data": [{"embedding": [0.0] * 1024, "index": 0}]}
+            return {"data": [{"embedding": _STUB_EMBEDDING, "index": 0}]}
 
     class FakeClient:
         async def post(self, url, **kwargs):
@@ -109,7 +114,7 @@ async def test_tier3_skipped_when_tier2_succeeds(monkeypatch):
         def raise_for_status(self):
             pass
         def json(self):
-            return {"data": [{"embedding": [0.0] * 1024, "index": 0}]}
+            return {"data": [{"embedding": _STUB_EMBEDDING, "index": 0}]}
 
     class FakeClient:
         async def post(self, url, **kwargs):

--- a/tests/test_embedder_identity_validate.py
+++ b/tests/test_embedder_identity_validate.py
@@ -69,6 +69,28 @@ def test_non_unit_allowed_when_not_required(monkeypatch):
     assert me._validate_identity(non_unit, config.EMBED_MODEL, "t") is True
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize("require_unit", [True, False])
+def test_non_finite_rejected_regardless_of_norm_policy(monkeypatch, bad, require_unit):
+    """A NaN/inf component is never a valid embedding (it poisons every cosine
+    distance). NaN in particular slips past the norm tolerance (NaN compares
+    False to everything), so finite-ness must be enforced independently of the
+    unit-norm policy."""
+    monkeypatch.setattr(config, "EMBED_REQUIRE_UNIT_NORM", require_unit)
+    vec = _unit(config.EMBED_DIM)
+    vec[0] = bad
+    assert me._validate_identity(vec, config.EMBED_MODEL, "t") is False
+    # also caught when the bad vector is a sampled member of a bulk batch
+    batch = [_unit(config.EMBED_DIM) for _ in range(5)]
+    batch[0] = vec
+    assert me._validate_identity(batch, config.EMBED_MODEL, "t") is False
+
+
+def test_zero_vector_rejected_when_unit_required(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_REQUIRE_UNIT_NORM", True)
+    assert me._validate_identity([0.0] * config.EMBED_DIM, config.EMBED_MODEL, "t") is False
+
+
 def test_bulk_list_validated_by_sample():
     vecs = [_unit(config.EMBED_DIM) for _ in range(5)]
     assert me._validate_identity(vecs, config.EMBED_MODEL, "t") is True

--- a/tests/test_embedder_identity_validate.py
+++ b/tests/test_embedder_identity_validate.py
@@ -1,0 +1,101 @@
+"""Tests for the embedder-identity gate (_validate_identity) and its config.
+
+A vector is only acceptable for the store if it came from the configured
+("proper") embedder: right dimension, a compatible model tag, and (when
+required) unit-length. A tier whose output fails identity must be treated as a
+failed tier so the cascade tries the next one — never store a non-proper vector.
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
+
+import memory.config as config
+import memory.embed as me
+
+
+def _unit(dim: int) -> list[float]:
+    v = [0.0] * dim
+    v[0] = 1.0  # L2 norm = 1
+    return v
+
+
+@pytest.fixture(autouse=True)
+def _reset_identity_warn():
+    me._IDENTITY_WARNED.clear()
+    yield
+    me._IDENTITY_WARNED.clear()
+
+
+def test_proper_vector_and_tag_accepted():
+    assert me._validate_identity(_unit(config.EMBED_DIM), config.EMBED_MODEL, "t") is True
+
+
+def test_wrong_dimension_rejected():
+    assert me._validate_identity([1.0, 0.0], config.EMBED_MODEL, "t") is False
+
+
+def test_foreign_model_rejected():
+    assert me._validate_identity(_unit(config.EMBED_DIM), "some-other-embed", "t") is False
+
+
+def test_compatible_alias_accepted():
+    # The tier-1 GGUF tag maps to the same space as the configured model.
+    assert me._EMBED_GGUF_MODEL_TAG in me._compatible_model_names()
+    assert me._validate_identity(_unit(config.EMBED_DIM), me._EMBED_GGUF_MODEL_TAG, "t") is True
+
+
+def test_operator_compatible_models_env(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_COMPATIBLE_MODELS", ("legacy-embed-v1",))
+    assert "legacy-embed-v1" in me._compatible_model_names()
+    assert me._validate_identity(_unit(config.EMBED_DIM), "legacy-embed-v1", "t") is True
+
+
+def test_non_unit_rejected_when_required(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_REQUIRE_UNIT_NORM", True)
+    non_unit = [0.5] * config.EMBED_DIM  # norm = 0.5*sqrt(dim) >> 1
+    assert me._validate_identity(non_unit, config.EMBED_MODEL, "t") is False
+
+
+def test_non_unit_allowed_when_not_required(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_REQUIRE_UNIT_NORM", False)
+    non_unit = [0.5] * config.EMBED_DIM
+    # dim + model still match; norm not enforced -> accepted
+    assert me._validate_identity(non_unit, config.EMBED_MODEL, "t") is True
+
+
+def test_bulk_list_validated_by_sample():
+    vecs = [_unit(config.EMBED_DIM) for _ in range(5)]
+    assert me._validate_identity(vecs, config.EMBED_MODEL, "t") is True
+    # one wrong-dim member in the sampled positions (0/mid/last) is caught
+    vecs[0] = [1.0, 0.0]
+    assert me._validate_identity(vecs, config.EMBED_MODEL, "t") is False
+
+
+def test_empty_input_rejected():
+    assert me._validate_identity([], config.EMBED_MODEL, "t") is False
+    assert me._validate_identity(None, config.EMBED_MODEL, "t") is False
+
+
+def test_norm_tolerance_respected(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_REQUIRE_UNIT_NORM", True)
+    monkeypatch.setattr(config, "EMBED_NORM_TOL", 0.05)
+    # norm 1.03 is within tol; 1.2 is not.
+    near = _unit(config.EMBED_DIM)
+    near[1] = math.sqrt(1.03**2 - 1.0)  # bump norm to ~1.03
+    assert me._validate_identity(near, config.EMBED_MODEL, "t") is True
+    far = _unit(config.EMBED_DIM)
+    far[1] = math.sqrt(1.2**2 - 1.0)  # norm ~1.2
+    assert me._validate_identity(far, config.EMBED_MODEL, "t") is False
+
+
+def test_warns_once_per_reason():
+    me._validate_identity([1.0, 0.0], config.EMBED_MODEL, "tierX")
+    first = set(me._IDENTITY_WARNED)
+    me._validate_identity([1.0, 0.0, 0.0], config.EMBED_MODEL, "tierX")  # same reason (dim)
+    assert me._IDENTITY_WARNED == first  # no new warn key for the same reason

--- a/tests/test_embedder_identity_validate.py
+++ b/tests/test_embedder_identity_validate.py
@@ -99,3 +99,62 @@ def test_warns_once_per_reason():
     first = set(me._IDENTITY_WARNED)
     me._validate_identity([1.0, 0.0, 0.0], config.EMBED_MODEL, "tierX")  # same reason (dim)
     assert me._IDENTITY_WARNED == first  # no new warn key for the same reason
+
+
+# ── _accept_bulk: assign proper vectors, keep failures in the miss set ──────────
+
+def test_accept_bulk_assigns_proper_and_reports_misses():
+    dim = config.EMBED_DIM
+    out: list = [None, None, None]
+    miss_indices = [0, 1, 2]
+    vecs = [_unit(dim), None, _unit(dim)]  # row 1 missing
+    still = me._accept_bulk(out, miss_indices, vecs, config.EMBED_MODEL, "t")
+    assert out[0] == (_unit(dim), config.EMBED_MODEL)
+    assert out[2] == (_unit(dim), config.EMBED_MODEL)
+    assert out[1] is None
+    assert still == [1]  # only the missing local index is reported
+
+
+def test_accept_bulk_rejects_whole_foreign_batch():
+    # A batch whose vectors fail identity (wrong dim) is rejected wholesale:
+    # nothing is stored, every local index is reported as still-missing.
+    out: list = [None, None]
+    bad = [[1.0, 0.0], [1.0, 0.0]]  # dim 2, not EMBED_DIM
+    still = me._accept_bulk(out, [0, 1], bad, config.EMBED_MODEL, "t")
+    assert out == [None, None]
+    assert still == [0, 1]
+
+
+# ── Search read-path identity filter (SQL construction) ────────────────────────
+
+@pytest.mark.asyncio
+async def test_search_sql_includes_identity_filter(monkeypatch):
+    """The semantic/hybrid search SQL must restrict the embeddings join to the
+    proper identity: embed_model IN (compatible) AND dim = EMBED_DIM."""
+    import memory_core
+
+    async def fake_embed(_q):
+        return (_unit(config.EMBED_DIM), config.EMBED_MODEL)
+    monkeypatch.setattr(memory_core, "_embed", fake_embed)
+
+    captured: list[str] = []
+
+    class _Cur:
+        def fetchall(self): return []
+        def fetchone(self): return None
+
+    class _DB:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, sql, params=None):
+            captured.append(sql)
+            return _Cur()
+        def commit(self): pass
+
+    monkeypatch.setattr(memory_core, "_db", lambda: _DB())
+
+    await memory_core.memory_search_scored_impl("anything", search_mode="semantic")
+    assert captured, "expected at least one query"
+    sql = " ".join(captured)
+    assert "me.embed_model IN" in sql, "identity model filter missing from search SQL"
+    assert "me.dim = ?" in sql, "identity dim filter missing from search SQL"

--- a/tests/test_llm_failover.py
+++ b/tests/test_llm_failover.py
@@ -52,6 +52,25 @@ async def test_get_best_embed_success():
         assert result[0] == "http://localhost:1234/v1"
         assert result[1] == "nomic-embed-text-v1.5"
 
+
+@pytest.mark.asyncio
+async def test_get_best_embed_chat_only_returns_none():
+    """A chat-only endpoint is NOT a valid embedding fallback: POSTing
+    /embeddings to it 400s, which previously triggered a retry storm. When no
+    endpoint advertises an embedding model, get_best_embed must return None so
+    the caller takes its own embed fallback."""
+    mock_client = AsyncMock()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    # Only chat models advertised — no embedding model anywhere.
+    mock_resp.json.return_value = {"data": [{"id": "qwen3-8b"}, {"id": "llama-3-8b"}]}
+    mock_client.get.return_value = mock_resp
+
+    with patch("llm_failover.LLM_ENDPOINTS", ["http://localhost:1234/v1"]):
+        result = await llm_failover.get_best_embed(mock_client, "token")
+        assert result is None, "chat-only endpoint must not be returned as an embed endpoint"
+
+
 @pytest.mark.asyncio
 async def test_get_best_llm_size_sorting():
     """Test that get_best_llm picks the largest available model."""

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -102,13 +102,19 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
     posted_headers = []
     posted_urls = []
 
+    # Proper-identity stub: EMBED_DIM-long and L2-unit-length, so the embedder-
+    # identity gate accepts the tier-4 vector (a short/un-normalized stub is now
+    # correctly rejected). This test asserts PII redaction + tier-4 routing, not
+    # the vector's content.
+    proper_vec = [1.0] + [0.0] * (config.EMBED_DIM - 1)
+
     async def _fake_async_post(self, url, json=None, headers=None, **kwargs):
         if "enclave.test" in str(url):
             posted_urls.append(str(url))
             posted_payloads.append(json)
             posted_headers.append(headers)
             resp = MagicMock()
-            resp.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3, 0.4]}]}
+            resp.json.return_value = {"data": [{"embedding": proper_vec}]}
             resp.raise_for_status = lambda: None
             return resp
         raise RuntimeError("Local HTTP down")
@@ -121,8 +127,8 @@ async def test_tier4_fallback_triggered_with_redaction(monkeypatch):
     # Let's request an embedding with sensitive data
     vec, model = await _embed("My secret key is sk-proj-12345678901234567890 and email is test@domain.com")
 
-    # Tier 4 returned the dummy embedding via the class-level transport mock.
-    assert vec == [0.1, 0.2, 0.3, 0.4]
+    # Tier 4 returned the proper-identity embedding via the class-level mock.
+    assert vec == proper_vec
     assert len(posted_payloads) == 1
     # Verify PII was redacted!
     input_text = posted_payloads[0]["input"]

--- a/tests/test_tier4_cloud.py
+++ b/tests/test_tier4_cloud.py
@@ -13,11 +13,43 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO, "bin"))
 
 import memory.config as config
-from memory.embed import _embed, get_embed_breaker_state, reset_embed_breakers
+
+# Resolve embed entry points from the LIVE module at call time rather than binding
+# them at collection. A sibling test (test_embed_cascade_order) deletes and
+# re-imports memory.* for isolation; a collection-time `from memory.embed import
+# _embed` would then point at the OLD module object while monkeypatch targets
+# ("memory.embed._get_embedded_embedder", ...) resolve via sys.modules to the NEW
+# one — so the patches are silently bypassed and a real tier returns a vector.
+# Going through sys.modules keeps the call and the patch on the same object.
+
+
+def _live_embed_module():
+    import importlib
+    return importlib.import_module("memory.embed")
+
+
+async def _embed(text):
+    return await _live_embed_module()._embed(text)
+
+
+def get_embed_breaker_state():
+    return _live_embed_module().get_embed_breaker_state()
+
+
+def reset_embed_breakers():
+    return _live_embed_module().reset_embed_breakers()
 
 
 @pytest.fixture(autouse=True)
 def clean_breakers(monkeypatch):
+    # Rebind this module's `config` to the LIVE memory.config that memory.embed
+    # actually reads. A sibling test re-imports memory.* for isolation; without
+    # this rebind, `monkeypatch.setattr(config, ...)` below would mutate the
+    # stale collection-time config object while the cascade reads the fresh one,
+    # so e.g. M3_ALLOW_CLOUD_FALLBACK=True wouldn't be seen and tier 4 is skipped.
+    global config
+    import importlib
+    config = importlib.import_module("memory.config")
     reset_embed_breakers()
     # Ultimate cache buster: force content hash to be unique every time to guarantee cache misses
     monkeypatch.setattr("memory.embed._content_hash", lambda t: str(uuid.uuid4()))


### PR DESCRIPTION
## Summary

A background embed-sweep storm pinned the GPU at 84–100% with repeated "no model loaded" errors. The root cause was a chain — one oversized chatlog row → failed in-process embedder → dead embed server → fell back to a **chat** LLM endpoint that 400s `/embeddings` → a retry/bisect storm. Underneath the storm was a deeper latent flaw: **the store compared vectors without verifying they came from the configured embedder.** Tiers cascaded as if interchangeable, but vectors are only comparable if they share model + dimension + normalization + embed-space, so a tier serving a different model / wrong dim / un-normalized output silently wrote an incomparable vector (and a wrong-dim blob could later break search's cosine pack).

This PR stops the storm and makes embedder identity a first-class, config-driven invariant — model-agnostic (swap the embedder by changing config, no code change).

## What changed

**Storm + cascade hardening**
- No retry/bisect on permanent 4xx; oversize rows subdivide in-process with an L2-renormalized mean-pool; response index-alignment guard.
- A chat-only endpoint is no longer treated as an embed fallback, with a TTL negative-cache to stop the discovery GET-storm.
- Per-call failure sentinels replace a shared dict that could drop embeddings under concurrency.
- `daemonize` uses `os._exit`; the scheduled task is set to `MultipleInstances=IgnoreNew` + a 1h execution limit.

**Config-driven proper-embedder identity**
- A single source of truth resolved from config/env (`EMBED_MODEL`, `EMBED_DIM`, `M3_EMBED_REQUIRE_UNIT_NORM`, `M3_EMBED_COMPATIBLE_MODELS`, fallback/space tags) and a `_validate_identity()` gate (dim + compatible model tag + sampled unit-norm + **finiteness**).
- Every tier's output (single + bulk, tiers 1–4) is validated before storing. A tier whose output fails identity is treated as a failed tier so the cascade tries the next one; if no tier yields a proper vector, the write **defers** — the row was already persisted before embedding, so it stays keyword/FTS-searchable and is retried next sweep rather than corrupting the store.
- Search restricts the embeddings join to the proper identity (`embed_model IN (compatible) AND dim = EMBED_DIM`), which also structurally prevents the wrong-length cosine crash. Verified against the live corpus: the two configured-model tags are kept; cross-embedder rows (a different model family, wrong dim) are correctly excluded as incomparable.

## Footguns found and fixed during review

- **NaN/inf vectors slipped through the identity gate.** A NaN component passed the unit-norm check because `abs(nan - 1.0) > tol` is `False` (NaN compares False to everything); with unit-norm enforcement disabled, the only finiteness guard didn't run at all, so a NaN/inf vector would be stored and poison every cosine distance. Added an unconditional finiteness check (independent of the norm policy) + regression tests (NaN/inf/-inf under both policies, zero vector).
- **Test-isolation bug (pre-existing) in the tier-4 suite.** A sibling test deletes and re-imports `memory.*`; the tier-4 tests bound `_embed`/`config` at collection time, so their monkeypatches landed on a different module object than the cascade read — patches were silently bypassed and tests failed only when run after the sibling. Now resolved from the live module at call time; order-independent.
- **Confidence-ranking tests** seeded a placeholder `embed_model` that the new identity filter excludes; reseeded with the configured model so they exercise their actual subject.

## Verification

- Affected embed / search / confidence suites: **green** (order-independent).
- Full suite: **1595 passed, 41 skipped**; the only remaining reds are pre-existing and unrelated to this change (an environmental native crash in a FIPS integrity self-test, and two sync-table migration tests that also fail at the base commit).
- ruff (every file this branch touches) + mypy + bandit (High=0) clean. Tool-catalog drift / leakage pre-push gate: clean.
