### PR TITLE
chore(release): 2026.6.30.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.6.27.0"
+version = "2026.6.30.0"
 description = "Local-first Memory Framework for AI Agents · 99.2% LongMemEval-S retrieval @ k=10 · Supports Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · MCP-native and plugins · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"


### PR DESCRIPTION
Version bump for the 2026.6.30.0 release.

Includes (already merged via #62):
- embed retry-storm fix + cascade/daemonize hardening
- config-driven proper-embedder identity validation
- NaN/inf identity-gate hardening and tier-4 test-isolation fix found in review

Bumps `pyproject.toml` 2026.6.27.0 → 2026.6.30.0 so the release tag and package version match. Build verified locally (sdist + wheel).