### PR TITLE
fix(schedule): self-heal the Windows cognitive loop; register tasks via XML

### DIFF
--- a/bin/install_schedules.py
+++ b/bin/install_schedules.py
@@ -312,6 +312,185 @@ def _filter_tasks(tasks: list, selector: str | None) -> list:
     return matched
 
 
+# ── Windows Task Scheduler XML rendering ──────────────────────────────────────
+# schtasks.exe cannot express MultipleInstances, ExecutionTimeLimit, or trigger
+# Repetition from its CLI flags — the old code shelled out to PowerShell after
+# /Create to patch those in. Task Scheduler's native format IS XML, and
+# `schtasks /Create /XML` accepts a full definition in one call, so we render the
+# spec to XML and drop the PowerShell dependency entirely. (macOS/Linux are
+# unaffected — they use crontab / launchd / systemd.)
+
+# Task Scheduler XML schema namespace (constant for all supported OS versions).
+_TASK_NS = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+
+
+def _xml_escape(text: str) -> str:
+    """Escape the five XML metacharacters for both element text and attribute
+    values. Deliberately not xml.sax.saxutils (Bandit B406 flags that module for
+    untrusted-XML *parsing*; we only *emit* XML) and not a heavy DOM builder —
+    this is the minimal correct escape for the trusted spec values we render."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+# Only the long-lived ONSTART cognitive loop needs a self-heal repetition: it is
+# a single continuous process, so if it dies it never restarts until the next
+# boot. The MINUTE/HOURLY/DAILY/WEEKLY/MONTHLY tasks already re-fire on their own
+# cadence. 30-minute repetition, no duration => repeat indefinitely. Safe because
+# every task sets MultipleInstances=IgnoreNew (a re-fire while alive is a no-op).
+_SELF_HEAL_TASKS = {"AgentOS_CognitiveLoop": "PT30M"}
+
+
+def _xml_repetition(interval_iso: str) -> str:
+    """A <Repetition> that repeats every interval_iso forever (no Duration)."""
+    return (
+        "<Repetition>"
+        f"<Interval>{interval_iso}</Interval>"
+        "<StopAtDurationEnd>false</StopAtDurationEnd>"
+        "</Repetition>"
+    )
+
+
+def _render_trigger_xml(task: dict) -> str:
+    """Map a spec's schedule/modifier/time to a Task Scheduler <Triggers> body.
+
+    Supported schedules mirror the schtasks /SC values used elsewhere:
+      MINUTE / HOURLY  -> TimeTrigger with a Repetition interval
+      DAILY            -> CalendarTrigger / ScheduleByDay
+      WEEKLY           -> CalendarTrigger / ScheduleByWeek (modifier = day-of-week)
+      MONTHLY          -> CalendarTrigger / ScheduleByMonth (modifier = day-of-month)
+      ONSTART          -> BootTrigger (+ self-heal Repetition for the loop)
+    """
+    sched = task["schedule"]
+    mod = task.get("modifier") or ""
+    hh, mm = (task.get("time") or "00:00").split(":")[:2]
+    # A fixed, past StartBoundary date keeps the XML deterministic (no clock read
+    # at install time); Task Scheduler computes the next fire from it. Time-of-day
+    # is what actually matters for the calendar/time triggers.
+    start = f"2020-01-01T{int(hh):02d}:{int(mm):02d}:00"
+
+    if sched == "MINUTE":
+        n = int(mod or "1")
+        return (
+            "<TimeTrigger>"
+            f"<StartBoundary>{start}</StartBoundary>"
+            "<Enabled>true</Enabled>"
+            f"{_xml_repetition(f'PT{n}M')}"
+            "</TimeTrigger>"
+        )
+    if sched == "HOURLY":
+        n = int(mod or "1")
+        return (
+            "<TimeTrigger>"
+            f"<StartBoundary>{start}</StartBoundary>"
+            "<Enabled>true</Enabled>"
+            f"{_xml_repetition(f'PT{n}H')}"
+            "</TimeTrigger>"
+        )
+    if sched == "DAILY":
+        return (
+            "<CalendarTrigger>"
+            f"<StartBoundary>{start}</StartBoundary>"
+            "<Enabled>true</Enabled>"
+            "<ScheduleByDay><DaysInterval>1</DaysInterval></ScheduleByDay>"
+            "</CalendarTrigger>"
+        )
+    if sched == "WEEKLY":
+        # schtasks uses 3-letter day tokens (MON/TUE/.../FRI); XML wants element
+        # names (<Monday/> ...). Map, defaulting to Sunday if unrecognised.
+        days = {
+            "MON": "Monday", "TUE": "Tuesday", "WED": "Wednesday",
+            "THU": "Thursday", "FRI": "Friday", "SAT": "Saturday", "SUN": "Sunday",
+        }
+        day_el = days.get(mod.upper()[:3], "Sunday")
+        return (
+            "<CalendarTrigger>"
+            f"<StartBoundary>{start}</StartBoundary>"
+            "<Enabled>true</Enabled>"
+            "<ScheduleByWeek>"
+            f"<DaysOfWeek><{day_el}/></DaysOfWeek>"
+            "<WeeksInterval>1</WeeksInterval>"
+            "</ScheduleByWeek>"
+            "</CalendarTrigger>"
+        )
+    if sched == "MONTHLY":
+        dom = int(mod or "1")
+        return (
+            "<CalendarTrigger>"
+            f"<StartBoundary>{start}</StartBoundary>"
+            "<Enabled>true</Enabled>"
+            "<ScheduleByMonth>"
+            f"<DaysOfMonth><Day>{dom}</Day></DaysOfMonth>"
+            "<Months>"
+            "<January/><February/><March/><April/><May/><June/><July/>"
+            "<August/><September/><October/><November/><December/>"
+            "</Months>"
+            "</ScheduleByMonth>"
+            "</CalendarTrigger>"
+        )
+    if sched == "ONSTART":
+        rep = _SELF_HEAL_TASKS.get(task["name"])
+        rep_xml = _xml_repetition(rep) if rep else ""
+        return (
+            "<BootTrigger>"
+            "<Enabled>true</Enabled>"
+            f"{rep_xml}"
+            "</BootTrigger>"
+        )
+    raise ValueError(f"Unsupported schedule for XML rendering: {sched!r}")
+
+
+def _render_task_xml(task: dict, python_exe: str, user_id: str) -> str:
+    """Render one spec to a complete Task Scheduler XML document string."""
+    # <Arguments> is one space-joined string; each path is quoted so paths with
+    # spaces survive, mirroring the previous /TR construction.
+    arguments = " ".join(f'"{part}"' for part in task["args"])
+    triggers = _render_trigger_xml(task)
+    esc = _xml_escape
+    return (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        f'<Task version="1.2" xmlns="{_TASK_NS}">'
+        "<RegistrationInfo>"
+        f"<Description>{esc(task['description'])}</Description>"
+        "</RegistrationInfo>"
+        f"<Triggers>{triggers}</Triggers>"
+        "<Principals>"
+        '<Principal id="Author">'
+        f"<UserId>{esc(user_id)}</UserId>"
+        # LeastPrivilege == run as the logged-in user, non-elevated (matches the
+        # prior schtasks default; no elevation is needed by any pass).
+        "<RunLevel>LeastPrivilege</RunLevel>"
+        "<LogonType>InteractiveToken</LogonType>"
+        "</Principal>"
+        "</Principals>"
+        "<Settings>"
+        # IgnoreNew: never stack a second copy while one runs — a slow/stuck run
+        # must not over-dispatch the local LLM, and it makes the self-heal
+        # repetition a no-op when the task is already alive.
+        "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>"
+        "<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>"
+        "<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>"
+        "<AllowStartOnDemand>true</AllowStartOnDemand>"
+        "<Enabled>true</Enabled>"
+        "<StartWhenAvailable>true</StartWhenAvailable>"
+        # ExecutionTimeLimit caps a hung run. The continuous loop must never be
+        # killed mid-flight, so it gets PT0S (no limit); others get PT1H.
+        f"<ExecutionTimeLimit>{'PT0S' if task['schedule'] == 'ONSTART' else 'PT1H'}</ExecutionTimeLimit>"
+        "</Settings>"
+        '<Actions Context="Author">'
+        "<Exec>"
+        f"<Command>{esc(python_exe)}</Command>"
+        f"<Arguments>{esc(arguments)}</Arguments>"
+        "</Exec>"
+        "</Actions>"
+        "</Task>"
+    )
+
+
 def install_windows_tasks(m3_memory_root, selector: str | None = None):
     # pythonw.exe (GUI subsystem) — Task Scheduler draws NO console window for
     # it. python.exe (console subsystem) flashes a window every fire even
@@ -329,64 +508,65 @@ def install_windows_tasks(m3_memory_root, selector: str | None = None):
         _safe_print(f"{FAIL} No schedule matches selector={selector!r}. Try --list to see all.")
         return
 
+    # The task owner (Principal/UserId). Prefer the domain\user form Task
+    # Scheduler records; fall back to the bare username. Never empty — an empty
+    # UserId makes schtasks reject the XML.
+    user_id = (
+        f"{os.environ['USERDOMAIN']}\\{os.environ['USERNAME']}"
+        if os.environ.get("USERDOMAIN") and os.environ.get("USERNAME")
+        else os.environ.get("USERNAME", "")
+    )
+
     success = True
     for task in tasks:
         subprocess.run(["schtasks", "/Delete", "/TN", task["name"], "/F"], capture_output=True)
-        # Task action is python.exe invoked directly — NO cmd.exe wrapper.
-        # The old cmd.exe wrapper existed only to evaluate the `>>` redirect,
-        # and being a console app it drew a focus-stealing window every fire.
-        # Entrypoints now self-log via _task_runtime, so no redirect is needed.
-        # /TR is a single string: each path is quoted individually so paths
-        # with spaces survive. (The historical ERROR_FILE_NOT_FOUND came from
-        # quoting the *whole* command including `>>`, not from quoting argv.)
-        tr = " ".join(f'"{part}"' for part in [python_exe, *task["args"]])
-        schtasks_cmd = [
-            "schtasks", "/Create", "/TN", task["name"],
-            "/TR", tr,
-            "/SC", task["schedule"],
-            "/F",
-        ]
-        # /ST (start time) and /MO (interval modifier) are NOT valid for
-        # event-based schedules — schtasks rejects them for ONSTART/ONLOGON/
-        # ONIDLE/ONEVENT. Only pass them for time/interval-based schedules.
-        event_based = task["schedule"] in ("ONSTART", "ONLOGON", "ONIDLE", "ONEVENT")
-        if not event_based:
-            schtasks_cmd.extend(["/ST", task["time"]])
-        if task["modifier"] and not event_based:
-            # /D for WEEKLY+MONTHLY day-of-week, /MO for interval-based (MINUTE/HOURLY).
-            flag = "/D" if task["schedule"] in ("WEEKLY", "MONTHLY") else "/MO"
-            schtasks_cmd.extend([flag, task["modifier"]])
+        # Register from a full Task Scheduler XML definition. Unlike the CLI
+        # flags, XML can express MultipleInstances=IgnoreNew, ExecutionTimeLimit,
+        # and trigger Repetition in ONE call — so the PowerShell post-hardening
+        # step (and its dependency) is gone. schtasks /Create /XML requires the
+        # file to be UTF-16; Python's "utf-16" codec writes the BOM it needs.
+        try:
+            xml_doc = _render_task_xml(task, python_exe, user_id)
+        except ValueError as e:
+            # An unsupported schedule is a contract violation, not an edge case
+            # (§3 fail-loud): surface it, skip the task, keep going for the rest.
+            _safe_print(f"{FAIL} Cannot render task {task['name']}: {e}")
+            success = False
+            continue
 
-        result = subprocess.run(schtasks_cmd, capture_output=True, text=True)
-        if result.returncode == 0:
-            _safe_print(f"{OK} Created Windows Task: {task['name']}")
-            # Harden: schtasks /Create can't set these, so use PowerShell.
-            # MultipleInstances=IgnoreNew — never start a second copy while one
-            # is running, so a stuck/slow run doesn't STACK every interval and
-            # over-dispatch the local LLM. ExecutionTimeLimit caps a hung run.
-            # Best-effort: a failure here must not fail the install.
-            ps = (
-                f"$t = Get-ScheduledTask -TaskName '{task['name']}' "
-                f"-ErrorAction SilentlyContinue; if ($t) {{ $s = $t.Settings; "
-                f"$s.MultipleInstances = 'IgnoreNew'; "
-                f"$s.ExecutionTimeLimit = 'PT1H'; "
-                f"Set-ScheduledTask -TaskName '{task['name']}' -Settings $s "
-                f"| Out-Null }}"
+        xml_path = None
+        try:
+            fd, xml_path = tempfile.mkstemp(suffix=".xml", prefix=f"m3_{task['name']}_")
+            with os.fdopen(fd, "w", encoding="utf-16") as fh:
+                fh.write(xml_doc)
+            result = subprocess.run(
+                ["schtasks", "/Create", "/TN", task["name"], "/XML", xml_path, "/F"],
+                capture_output=True, text=True,
             )
-            try:
-                subprocess.run(
-                    ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps],
-                    capture_output=True, text=True, timeout=20,
-                )
-            except Exception:
-                pass  # hardening is best-effort; the task still works without it
+        finally:
+            # Always clean up the temp file — no orphaned artifacts (§14).
+            if xml_path and os.path.exists(xml_path):
+                try:
+                    os.unlink(xml_path)
+                except OSError:
+                    pass
+
+        if result.returncode == 0:
+            note = " (+30-min self-heal repetition)" if task["name"] in _SELF_HEAL_TASKS else ""
+            _safe_print(f"{OK} Created Windows Task: {task['name']}{note}")
         else:
-            _safe_print(f"{FAIL} Failed to create task {task['name']}: {result.stderr.strip()}")
+            # Fail loud (§3): print the real schtasks error, don't swallow it.
+            _safe_print(
+                f"{FAIL} Failed to create task {task['name']}: "
+                f"{(result.stderr or result.stdout).strip()}"
+            )
             success = False
 
     if success:
         _safe_print(f"{OK} Finished installing {len(tasks)} Windows scheduled task(s).")
         _safe_print(f"   Logs available in: {log_dir}")
+    else:
+        _safe_print(f"{WARN} One or more Windows tasks failed to install (see above).")
 
 
 def remove_windows_tasks(selector: str | None, m3_memory_root: str):

--- a/tests/test_bypass_surface.py
+++ b/tests/test_bypass_surface.py
@@ -4,7 +4,6 @@ Covers the §11 validation plan items that don't need the full retrieval stack:
 migration up/down + index seek, builder modes + scope gating, scope isolation,
 and gdpr_forget removal via explicit enumeration (NOT cascade-only).
 """
-import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -79,6 +78,7 @@ def test_fk_cascade_removes_surface_on_item_delete():
 def built_db(monkeypatch):
     """A seeded DB with the builder wired to it via monkeypatched _db()."""
     import contextlib
+
     import memory.entity as E
     db = sqlite3.connect(":memory:")
     db.row_factory = sqlite3.Row
@@ -185,6 +185,7 @@ def test_gdpr_forget_removes_surface_rows_by_user(monkeypatch):
     db.commit()
 
     import contextlib
+
     import memory_maintenance as M
 
     @contextlib.contextmanager

--- a/tests/test_embed_server_probe_quiet.py
+++ b/tests/test_embed_server_probe_quiet.py
@@ -7,7 +7,6 @@ inherited stderr these interleave with the probe's stdout and scroll the
 readable summary off-screen. The probe sets GGML_LOG_LEVEL=4 (error-only) in the
 subprocess env to suppress them — while respecting an operator-set value.
 """
-import os
 import sys
 from pathlib import Path
 

--- a/tests/test_entity_graph.py
+++ b/tests/test_entity_graph.py
@@ -673,8 +673,8 @@ async def test_resolution_cosine_stores_and_reuses_candidate_vectors(monkeypatch
     actually calls) and clears the name-embed cache so the stub is always hit —
     see test_entity_resolution_tuning.py for why memory_core._embed isn't enough.
     """
-    import memory.entity as me
     import memory.embed as me_embed
+    import memory.entity as me
 
     db_path = tmp_path / "test.db"
     _create_entity_graph_schema(db_path)
@@ -750,8 +750,8 @@ async def test_store_once_deferred_buffer_flush(monkeypatch, tmp_path):
     Verifies: nothing is written to entity_embeddings during the deferred phase,
     and the flush writes exactly the buffered rows.
     """
-    import memory.entity as me
     import memory.embed as me_embed
+    import memory.entity as me
 
     db_path = tmp_path / "test.db"
     _create_entity_graph_schema(db_path)

--- a/tests/test_setup_upgrade_skips_embedder.py
+++ b/tests/test_setup_upgrade_skips_embedder.py
@@ -7,9 +7,7 @@ _gather_plan now detects active_embedder_tier()["native"] and keeps the embedder
 without prompting. The LLM-endpoint probe is unaffected.
 """
 import argparse
-import importlib.util
 import sys
-import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_windows_schedule_xml.py
+++ b/tests/test_windows_schedule_xml.py
@@ -1,0 +1,189 @@
+"""Hermetic tests for the Windows Task Scheduler XML rendering.
+
+Guards the rewrite where install_windows_tasks stopped shelling out to
+schtasks CLI flags + a PowerShell post-hardening step and instead registers
+each task from a full Task Scheduler XML definition (schtasks /Create /XML).
+The XML is what carries MultipleInstances=IgnoreNew, ExecutionTimeLimit, and —
+for the long-lived cognitive loop — a self-heal Repetition that revives a dead
+loop within 30 minutes instead of waiting for the next boot.
+
+These tests exercise the pure render functions only: no schtasks, no
+PowerShell, no live Task Scheduler. That keeps them hermetic so they pass in
+CI (Linux, no Windows Task Scheduler) — see DESIGN_PHILOSOPHIES §3.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+import pytest
+
+_BIN = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "bin"))
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+import install_schedules as isch  # noqa: E402
+
+# Task Scheduler namespace — every element is namespaced, so ElementTree finds
+# need the {ns}tag form. Bundle it into a helper.
+_NS = {"t": isch._TASK_NS}
+
+
+def _spec(name, schedule, modifier="", time="00:00", args=None, desc="d"):
+    return {
+        "name": name,
+        "schedule": schedule,
+        "modifier": modifier,
+        "time": time,
+        "args": args or [r"C:\bin\x.py", "--log-file", r"C:\logs\x.log"],
+        "description": desc,
+    }
+
+
+def _render(spec):
+    """Render + parse; returns the root Element (asserts well-formedness)."""
+    doc = isch._render_task_xml(spec, r"C:\venv\pythonw.exe", "DOMAIN\\user")
+    return ET.fromstring(doc)
+
+
+# ── Every real spec renders well-formed XML ───────────────────────────────────
+
+def test_all_real_specs_render_valid_xml():
+    specs = isch.get_schedule_specs(os.path.dirname(_BIN))
+    assert specs, "no schedule specs returned"
+    for s in specs:
+        root = _render(s)  # raises ParseError if malformed
+        assert root.tag == f"{{{isch._TASK_NS}}}Task"
+
+
+# ── Trigger mapping per schedule type ─────────────────────────────────────────
+
+def test_minute_schedule_is_timetrigger_with_repetition():
+    root = _render(_spec("AgentOS_X", "MINUTE", modifier="15"))
+    trig = root.find(".//t:Triggers/t:TimeTrigger", _NS)
+    assert trig is not None
+    interval = trig.find("./t:Repetition/t:Interval", _NS)
+    assert interval is not None and interval.text == "PT15M"
+
+
+def test_hourly_schedule_repetition_interval():
+    root = _render(_spec("AgentOS_X", "HOURLY", modifier="1"))
+    interval = root.find(".//t:TimeTrigger/t:Repetition/t:Interval", _NS)
+    assert interval is not None and interval.text == "PT1H"
+
+
+def test_daily_schedule_is_calendar_by_day():
+    root = _render(_spec("AgentOS_X", "DAILY", time="03:00"))
+    assert root.find(".//t:CalendarTrigger/t:ScheduleByDay", _NS) is not None
+    sb = root.find(".//t:CalendarTrigger/t:StartBoundary", _NS)
+    assert sb is not None and sb.text.endswith("T03:00:00")
+
+
+def test_weekly_schedule_maps_day_token():
+    root = _render(_spec("AgentOS_X", "WEEKLY", modifier="FRI", time="16:00"))
+    dow = root.find(".//t:ScheduleByWeek/t:DaysOfWeek", _NS)
+    assert dow is not None
+    assert dow.find("./t:Friday", _NS) is not None
+
+
+def test_weekly_unknown_day_defaults_to_sunday():
+    root = _render(_spec("AgentOS_X", "WEEKLY", modifier="???"))
+    dow = root.find(".//t:ScheduleByWeek/t:DaysOfWeek", _NS)
+    assert dow.find("./t:Sunday", _NS) is not None
+
+
+def test_monthly_schedule_day_of_month():
+    root = _render(_spec("AgentOS_X", "MONTHLY", modifier="1", time="02:00"))
+    day = root.find(".//t:ScheduleByMonth/t:DaysOfMonth/t:Day", _NS)
+    assert day is not None and day.text == "1"
+
+
+def test_onstart_schedule_is_boottrigger():
+    root = _render(_spec("AgentOS_Plain", "ONSTART"))
+    assert root.find(".//t:Triggers/t:BootTrigger", _NS) is not None
+
+
+def test_unsupported_schedule_raises():
+    with pytest.raises(ValueError):
+        isch._render_task_xml(_spec("AgentOS_X", "YEARLY"), "py", "u")
+
+
+# ── Self-heal repetition is scoped to the cognitive loop only ─────────────────
+
+def test_cognitive_loop_boottrigger_has_selfheal_repetition():
+    root = _render(_spec("AgentOS_CognitiveLoop", "ONSTART"))
+    boot = root.find(".//t:BootTrigger", _NS)
+    interval = boot.find("./t:Repetition/t:Interval", _NS)
+    assert interval is not None and interval.text == "PT30M", (
+        "CognitiveLoop must carry the 30-min self-heal repetition"
+    )
+
+
+def test_other_onstart_task_has_no_repetition():
+    root = _render(_spec("AgentOS_SomethingElse", "ONSTART"))
+    boot = root.find(".//t:BootTrigger", _NS)
+    assert boot.find("./t:Repetition", _NS) is None, (
+        "only the cognitive loop should self-heal; others must not repeat"
+    )
+
+
+def test_selfheal_registry_matches_real_loop_name():
+    # Guards a rename drift: the self-heal task name must exist in the real specs.
+    names = {s["name"] for s in isch.get_schedule_specs(os.path.dirname(_BIN))}
+    for heal_name in isch._SELF_HEAL_TASKS:
+        assert heal_name in names, f"{heal_name} not among real specs"
+
+
+# ── Hardening settings present on every task ──────────────────────────────────
+
+def test_settings_ignore_new_and_least_privilege():
+    root = _render(_spec("AgentOS_X", "MINUTE", modifier="5"))
+    pol = root.find(".//t:Settings/t:MultipleInstancesPolicy", _NS)
+    assert pol is not None and pol.text == "IgnoreNew"
+    rl = root.find(".//t:Principals/t:Principal/t:RunLevel", _NS)
+    assert rl is not None and rl.text == "LeastPrivilege"
+
+
+def test_continuous_loop_has_no_execution_time_limit():
+    root = _render(_spec("AgentOS_CognitiveLoop", "ONSTART"))
+    lim = root.find(".//t:Settings/t:ExecutionTimeLimit", _NS)
+    # PT0S == no limit; the continuous loop must never be killed mid-flight.
+    assert lim is not None and lim.text == "PT0S"
+
+
+def test_finite_task_has_one_hour_time_limit():
+    root = _render(_spec("AgentOS_X", "DAILY"))
+    lim = root.find(".//t:Settings/t:ExecutionTimeLimit", _NS)
+    assert lim is not None and lim.text == "PT1H"
+
+
+# ── Action / argument construction ────────────────────────────────────────────
+
+def test_command_and_quoted_arguments():
+    spec = _spec("AgentOS_X", "MINUTE", modifier="5",
+                 args=[r"C:\bin\job.py", "--flag", r"C:\path with space\out.log"])
+    root = _render(spec)
+    cmd = root.find(".//t:Actions/t:Exec/t:Command", _NS)
+    assert cmd is not None and cmd.text == r"C:\venv\pythonw.exe"
+    argu = root.find(".//t:Actions/t:Exec/t:Arguments", _NS)
+    # Each argv element is individually double-quoted so spaced paths survive.
+    assert argu is not None
+    assert '"C:\\path with space\\out.log"' in argu.text
+
+
+def test_description_is_xml_escaped():
+    root = _render(_spec("AgentOS_X", "MINUTE", modifier="5",
+                         desc="a & b <c> \"d\""))
+    # ElementTree round-trips the entities, so a successful parse + exact text
+    # match proves the raw string was escaped (an unescaped & would ParseError).
+    desc = root.find(".//t:RegistrationInfo/t:Description", _NS)
+    assert desc is not None and desc.text == 'a & b <c> "d"'
+
+
+def test_all_five_xml_metacharacters_escaped():
+    # The local escaper must cover & < > " ' — a raw one would break the parse.
+    root = _render(_spec("AgentOS_X", "MINUTE", modifier="5",
+                         desc="""& < > " '"""))
+    desc = root.find(".//t:RegistrationInfo/t:Description", _NS)
+    assert desc is not None and desc.text == """& < > " '"""


### PR DESCRIPTION
## Problem

`AgentOS_CognitiveLoop` is an `ONSTART`-triggered Windows task that runs **one long-lived process** looping internally (`--interval 300`). If that process dies, nothing restarts it until the next boot — silently halting all local-LLM background work (entity extraction, enrichment, consolidation).

Observed live: the loop died mid-run and **nothing re-dispatched to the local LLM for ~19h** (`NextRunTime` empty, no repetition trigger). This surfaced as "the governor isn't working / nothing hitting LM Studio," but the governor was fine — the dispatching process was simply dead.

## Fix

Give the loop a **30-minute self-heal repetition**. `schtasks` CLI flags cannot express trigger `Repetition`, `MultipleInstances`, or `ExecutionTimeLimit` — the old code created the task then shelled out to **PowerShell** to patch those in. This PR renders each task to a full **Task Scheduler XML** document and registers it with `schtasks /Create /XML` in one call:

- 30-min `Repetition` on **`AgentOS_CognitiveLoop` only** (via `_SELF_HEAL_TASKS`). `MultipleInstances=IgnoreNew` makes a re-fire a **no-op while alive** and a **revival when dead**.
- Folds `IgnoreNew` + `ExecutionTimeLimit` (`PT0S` for the continuous loop, `PT1H` for finite tasks) into the definition — **removes the PowerShell dependency**.
- **Fails loud** on an unsupported schedule or a `schtasks` error (no silent skip). Temp XML is UTF-16 (what `schtasks` requires) and always cleaned up.

Other schedules (MINUTE/HOURLY/DAILY/WEEKLY/MONTHLY) already re-fire on their own cadence and are behavior-unchanged. macOS/Linux paths are untouched.

## Tests

`tests/test_windows_schedule_xml.py` — **hermetic**: render + parse the XML for every schedule type with **no dependency on `schtasks` or a live Task Scheduler**, so they pass in CI (Linux). Covers each trigger mapping, the self-heal scoping (loop yes / others no), the `IgnoreNew`/`LeastPrivilege`/time-limit settings, argument quoting, and full XML-metacharacter escaping.

## Notes

- Deploying the repetition onto an already-registered admin-owned task needs an elevated re-register (one-time); a fresh install picks it up automatically.
- Also clears 8 pre-existing tree-wide `ruff` F401/I001 errors (separate `chore(lint)` commit) that would otherwise fail CI.
- Security-scanned (gitleaks/trufflehog/semgrep/bandit): clean on changed files. An initial Bandit **B406** (on `import xml.sax.saxutils`) was resolved by replacing it with a minimal local XML escaper — we only *emit* XML, never parse it.