### PR TITLE
fix(schedule): restore the logon trigger dropped from the cognitive loop

### DIFF
--- a/bin/install_schedules.py
+++ b/bin/install_schedules.py
@@ -433,6 +433,14 @@ def _render_trigger_xml(task: dict) -> str:
             "</CalendarTrigger>"
         )
     if sched == "ONSTART":
+        # Original schtasks-era task registered BOTH a boot trigger and a logon
+        # trigger. A BootTrigger fires before interactive logon, but the task
+        # runs as InteractiveToken (see _render_task_xml), so on a boot-before-
+        # logon machine the boot start can be deferred until the user logs in.
+        # Emitting ONLY a BootTrigger therefore risks the loop not starting until
+        # a real logon/reboot — a regression from the original. Keep both so the
+        # loop comes up at whichever event happens first. Both carry the same
+        # self-heal repetition (IgnoreNew makes the duplicate a harmless no-op).
         rep = _SELF_HEAL_TASKS.get(task["name"])
         rep_xml = _xml_repetition(rep) if rep else ""
         return (
@@ -440,6 +448,10 @@ def _render_trigger_xml(task: dict) -> str:
             "<Enabled>true</Enabled>"
             f"{rep_xml}"
             "</BootTrigger>"
+            "<LogonTrigger>"
+            "<Enabled>true</Enabled>"
+            f"{rep_xml}"
+            "</LogonTrigger>"
         )
     raise ValueError(f"Unsupported schedule for XML rendering: {sched!r}")
 

--- a/tests/test_windows_schedule_xml.py
+++ b/tests/test_windows_schedule_xml.py
@@ -104,6 +104,14 @@ def test_onstart_schedule_is_boottrigger():
     assert root.find(".//t:Triggers/t:BootTrigger", _NS) is not None
 
 
+def test_onstart_has_both_boot_and_logon_triggers():
+    # The original schtasks-era task had BOTH; emitting only BootTrigger would
+    # regress boot-before-logon start under InteractiveToken. Guard both.
+    root = _render(_spec("AgentOS_Plain", "ONSTART"))
+    assert root.find(".//t:Triggers/t:BootTrigger", _NS) is not None
+    assert root.find(".//t:Triggers/t:LogonTrigger", _NS) is not None
+
+
 def test_unsupported_schedule_raises():
     with pytest.raises(ValueError):
         isch._render_task_xml(_spec("AgentOS_X", "YEARLY"), "py", "u")
@@ -111,21 +119,26 @@ def test_unsupported_schedule_raises():
 
 # ── Self-heal repetition is scoped to the cognitive loop only ─────────────────
 
-def test_cognitive_loop_boottrigger_has_selfheal_repetition():
+def test_cognitive_loop_selfheal_repetition_on_both_triggers():
+    # The loop can come up at boot OR logon (whichever is first); both triggers
+    # must carry the 30-min self-heal repetition so a dead loop revives from
+    # either path.
     root = _render(_spec("AgentOS_CognitiveLoop", "ONSTART"))
-    boot = root.find(".//t:BootTrigger", _NS)
-    interval = boot.find("./t:Repetition/t:Interval", _NS)
-    assert interval is not None and interval.text == "PT30M", (
-        "CognitiveLoop must carry the 30-min self-heal repetition"
-    )
+    for trig in ("BootTrigger", "LogonTrigger"):
+        node = root.find(f".//t:{trig}", _NS)
+        interval = node.find("./t:Repetition/t:Interval", _NS)
+        assert interval is not None and interval.text == "PT30M", (
+            f"CognitiveLoop {trig} must carry the 30-min self-heal repetition"
+        )
 
 
 def test_other_onstart_task_has_no_repetition():
     root = _render(_spec("AgentOS_SomethingElse", "ONSTART"))
-    boot = root.find(".//t:BootTrigger", _NS)
-    assert boot.find("./t:Repetition", _NS) is None, (
-        "only the cognitive loop should self-heal; others must not repeat"
-    )
+    for trig in ("BootTrigger", "LogonTrigger"):
+        node = root.find(f".//t:{trig}", _NS)
+        assert node.find("./t:Repetition", _NS) is None, (
+            f"only the cognitive loop should self-heal; {trig} must not repeat"
+        )
 
 
 def test_selfheal_registry_matches_real_loop_name():


### PR DESCRIPTION
## Follow-up to #64 — restores a dropped trigger

The XML rewrite in #64 emitted **only a `BootTrigger`** for the `ONSTART` cognitive loop. The original `schtasks`-era task registered **both** a `BootTrigger` **and** a `LogonTrigger` (confirmed from the live task definition).

### Why it matters
The task runs as `InteractiveToken` (non-elevated, as the logged-in user). A `BootTrigger` fires at system startup — *before* interactive logon — so under `InteractiveToken` a boot start can be deferred. With **only** a `BootTrigger`, on a boot-before-logon machine the loop could fail to start until an actual reboot. The 30-min self-heal repetition partly masks this (it'd fire within 30 min), but it's still a reliability regression from the original two-trigger setup.

### Fix
Restore the `LogonTrigger` on the `ONSTART` path so the loop comes up at **whichever event happens first** (boot or logon). Both triggers carry the same 30-min self-heal repetition; `MultipleInstances=IgnoreNew` makes the overlap a harmless no-op.

Tests updated to assert both triggers exist and that each carries the self-heal repetition (and that non-self-heal ONSTART tasks carry neither).

Found during a post-merge footgun sweep of #64.