### PR TITLE
fix(loop): keep background GPU bursts short on interactive machines

### DIFF
--- a/bin/chatlog_embed_sweeper.py
+++ b/bin/chatlog_embed_sweeper.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sqlite3
 import sys
+import time
 import uuid
 from datetime import datetime, timezone
 from glob import glob
@@ -301,6 +302,16 @@ async def main() -> int:
         help="Max rows per run (default from CHATLOG_EMBED_MAX_PER_RUN env or 10000)",
     )
     parser.add_argument(
+        "--deadline",
+        type=float,
+        default=None,
+        help="Soft wall-clock budget (seconds) for one run. The embed loop stops "
+             "starting new batches once this elapses, so a large backlog is drained "
+             "across several scheduled runs instead of monopolizing the GPU in one "
+             "long run. Default from CHATLOG_EMBED_DEADLINE_S env or 60s; 0 disables "
+             "(unbounded, the old behavior). max-per-run still caps total rows.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Query and log but don't embed",
@@ -331,6 +342,18 @@ async def main() -> int:
         args.max_per_run
         or int(os.environ.get("CHATLOG_EMBED_MAX_PER_RUN", "10000"))
     )
+    # Soft time budget per run. None -> env default (60s). 0 -> unbounded (old
+    # behavior). Keeps a big backlog from pinning the GPU in one long run; the
+    # next scheduled sweep picks up where this one left off (cursor-advanced).
+    _deadline = (
+        args.deadline
+        if args.deadline is not None
+        else float(os.environ.get("CHATLOG_EMBED_DEADLINE_S", "60"))
+    )
+    # run_embed_loop expects an ABSOLUTE time.monotonic() deadline, not a
+    # duration — convert here (a raw duration like 60 would read as "already
+    # elapsed" since the monotonic clock is far past 60 at runtime).
+    deadline_s = None if _deadline <= 0 else time.monotonic() + _deadline
 
     # Open DB connection
     db_path = chatlog_config.chatlog_db_path()
@@ -451,7 +474,7 @@ async def main() -> int:
             batch_size=batch_size,
             concurrency=1,                   # sweeper has historically run sequentially
             timeout_s=300.0,                 # generous for a scheduled background job
-            deadline_s=None,                 # max_per_run handles the budget
+            deadline_s=deadline_s,           # soft per-run wall-clock budget (see --deadline)
             max_consecutive_fails=5,
             max_row_bytes=32_768,
             expected_dim=None,               # don't reject by dim — chatlog has heterogenous models

--- a/bin/install_schedules.py
+++ b/bin/install_schedules.py
@@ -268,8 +268,13 @@ def get_schedule_specs(m3_memory_root):
         },
         {
             "name": "AgentOS_ChatlogEmbedSweep",
+            # --batch 256 is efficient per-batch (embedding is cheap); --deadline
+            # 60 bounds one run's wall-clock so a large backlog drains across
+            # several scheduled runs instead of pinning the GPU in one long run
+            # on an interactive machine. --max-per-run still caps total rows.
             "args": [_script("chatlog_embed_sweeper.py"),
                      "--batch", "256", "--max-per-run", "10000",
+                     "--deadline", "60",
                      "--log-file", _log("chatlog_embed_sweep.log")],
             "schedule": "MINUTE",
             "modifier": "30",
@@ -278,8 +283,12 @@ def get_schedule_specs(m3_memory_root):
         },
         {
             "name": "AgentOS_ObservationDrain",
+            # --drain-batch 200 was a heavy local-LLM burst (enrich_local_qwen):
+            # draining 200 queued observations in one run pins the GPU for a long
+            # stretch. Lowered to 8 so each 15-min run is a short burst; the queue
+            # still drains steadily across runs and interactive use isn't starved.
             "args": [_script("m3_enrich.py"),
-                     "--drain-queue", "--drain-batch", "200",
+                     "--drain-queue", "--drain-batch", "8",
                      "--profile", "enrich_local_qwen",
                      "--log-file", _log("observation_drain.log")],
             "schedule": "MINUTE",

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -562,7 +562,16 @@ def main():
                         help="Append logging to this file (scheduled-task / service mode). "
                              "Survives the Windows pythonw re-exec.")
     parser.add_argument("--concurrency", type=int, default=2, help="SLM concurrency (default: 2)")
-    parser.add_argument("--limit-per-pass", type=int, default=50, help="Max groups/rows per pass (default: 50)")
+    parser.add_argument("--limit-per-pass", type=int, default=1,
+                        help="Max groups/rows per heavy-LLM pass (entity extraction, "
+                             "enrichment, observation drain). Default 1: each pass does "
+                             "one item, then the loop yields and re-checks the governor "
+                             "before the next. This keeps GPU bursts short (sub-second) so "
+                             "background enrichment never monopolizes the GPU on an "
+                             "interactive machine. A single LLM pass of 50 items pinned the "
+                             "GPU for ~17 min because the governor was only re-checked "
+                             "BETWEEN passes, not within a batch. Embedding is a separate "
+                             "scheduled task (ChatlogEmbedSweep) and is unaffected.")
 
     # Database knobs
     parser.add_argument("--database", default=None, help="Core Memory DB path (Env: M3_DATABASE)")


### PR DESCRIPTION
## Problem

A single cognitive-loop pass dispatched up to `--limit-per-pass` (**50**) heavy local-LLM calls (entity extraction / enrichment / observation drain) and only re-checked the governor **between passes, never within the batch**. So one `CONTINUOUS` verdict at pass start pinned the GPU for **~17 minutes straight** — verified in the field on an RTX 5080: Task Manager "3D" engine at 99% for the whole pass, LM Studio's own meter reading ~12% (the two measure different things).

The governor's throttle-to-1 mechanism only engaged when the *pre-pass* verdict was already `THROTTLED`, but the GPU usually reads idle at the instant a pass starts (LM Studio between requests), so it green-lit the full 50 and only saturated *after* committing to the batch.

## Fix (scoped by workload weight)

- **Heavy LLM passes** (`m3_cognitive_loop.py`): `--limit-per-pass` default **50 → 1**. Each pass does one item, then the loop yields and re-consults the governor before the next. Bursts drop from minutes to seconds; the backlog still drains steadily.
- **Observation drain** (`install_schedules.py`): `--drain-batch` **200 → 8** (same heavy-LLM class, separate task).
- **Embedding sweep** (`chatlog_embed_sweeper.py`): add `--deadline` (soft per-run wall-clock, default **60s**) so a large embed backlog drains across several scheduled runs instead of one long GPU-pinning run. Batch stays **256** (embedding is cheap per-batch); `--max-per-run` still caps total rows. `run_embed_loop` expects an **absolute** `time.monotonic()` deadline, so the duration is converted (a raw duration would read as already-elapsed).

Embedding is a separate scheduled task from the loop, so its cost was never gated by `--limit-per-pass` — the deadline is the correct lever there.

## Verification (measured, not just compiled)

Reproduced the original symptom and its fix live:
- Killing the running (limit=50) loop dropped GPU **100% → 0%**, power **92W → 40W** — confirming the loop was the consumer.
- A single real entity extraction with the GPU idle: **~16s** (vs ~17 min for the old 50-item pass). So limit=1 = short, yieldable bursts.

Lint/type/tests green (ruff whole-tree, mypy, `test_windows_schedule_xml`, `test_embed_sweep_lib`, `test_cognitive_loop_consolidate`, `test_governor_pacing`).