### PR TITLE
feat(schedule): cross-platform --verify + generalized deploy wrapper

### DIFF
--- a/bin/deploy_cognitive_loop.ps1
+++ b/bin/deploy_cognitive_loop.ps1
@@ -1,0 +1,49 @@
+# Reinstall + verify the AgentOS_CognitiveLoop scheduled task on Windows.
+#
+# Re-registering an admin-owned task requires an ELEVATED shell (a non-elevated
+# schtasks /Create returns "Access denied"). Run this from an elevated terminal
+# (or right-click > Run as administrator) after pulling a new m3-memory.
+#
+# It delegates BOTH install and verification to install_schedules.py (the single
+# source of truth) — the only Windows-specific thing left here is elevation.
+# macOS/Linux don't need this script: `install_schedules.py --add cognitive-loop`
+# installs the launchd/systemd service directly (no elevation quirk).
+#
+# Compatible with Windows PowerShell 5.1 and PowerShell 7+ (no 7-only syntax).
+
+param(
+    # Repo root. Auto-resolves from this script's location (bin/..), overridable.
+    [string]$Repo = (Split-Path -Parent $PSScriptRoot),
+    # Which schedule to (re)install. 'cognitive-loop' by default; 'all' for every task.
+    [string]$Task = 'cognitive-loop'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$installer = Join-Path $Repo 'bin\install_schedules.py'
+if (-not (Test-Path $installer)) {
+    throw "install_schedules.py not found under $Repo — pass -Repo <path-to-m3-memory>."
+}
+
+# Prefer the repo venv; fall back to whatever 'python' resolves to.
+$py = Join-Path $Repo '.venv\Scripts\python.exe'
+if (-not (Test-Path $py)) {
+    $cmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $cmd) { throw "No python found (no venv at $py and no 'python' on PATH)." }
+    $py = $cmd.Source
+}
+
+Write-Host "Installing scheduled task '$Task'..." -ForegroundColor Cyan
+& $py $installer --add $Task
+if ($LASTEXITCODE -ne 0) { throw "installer exited $LASTEXITCODE" }
+
+Write-Host "`nVerifying..." -ForegroundColor Cyan
+& $py $installer --verify $Task
+$verifyExit = $LASTEXITCODE
+
+if ($verifyExit -eq 0) {
+    Write-Host "`nPASS: task registered and matches spec." -ForegroundColor Green
+} else {
+    Write-Host "`nFAIL: verification did not pass (see above)." -ForegroundColor Red
+}
+exit $verifyExit

--- a/bin/install_schedules.py
+++ b/bin/install_schedules.py
@@ -605,6 +605,107 @@ def remove_windows_tasks(selector: str | None, m3_memory_root: str):
         else:
             _safe_print(f"{WARN} Could not remove {task['name']} (may not exist): {r.stderr.strip()}")
 
+def _verify_windows_task(name: str) -> bool:
+    """Read the registered Windows task's XML and confirm the properties the
+    installer set actually took (self-heal Repetition where expected,
+    MultipleInstances=IgnoreNew). Cross-checks the LIVE task, not the spec, so it
+    catches a task that was created but silently lost a setting. Returns True on
+    match. Never raises — a missing task is a clean False."""
+    r = subprocess.run(
+        ["schtasks", "/Query", "/TN", name, "/XML", "ONE"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        _safe_print(f"{FAIL} {name}: not registered ({(r.stderr or '').strip() or 'no such task'})")
+        return False
+
+    xml = r.stdout
+    ok = True
+    # MultipleInstances=IgnoreNew — guards against the loop stacking copies.
+    if "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>" not in xml:
+        _safe_print(f"{WARN} {name}: MultipleInstancesPolicy is not IgnoreNew")
+        ok = False
+    # Self-heal Repetition — only the tasks in _SELF_HEAL_TASKS must have it.
+    expected_rep = _SELF_HEAL_TASKS.get(name)
+    if expected_rep:
+        if f"<Interval>{expected_rep}</Interval>" in xml:
+            _safe_print(f"{OK} {name}: self-heal Repetition {expected_rep} present")
+        else:
+            _safe_print(f"{FAIL} {name}: expected self-heal Repetition {expected_rep} is MISSING")
+            ok = False
+    if ok:
+        _safe_print(f"{OK} {name}: registered and matches spec")
+    return ok
+
+
+def _verify_unix_cognitive_loop() -> bool:
+    """Confirm the launchd agent (macOS) / systemd --user unit (Linux) for the
+    cognitive loop is installed AND loaded. KeepAlive/Restart is the Unix
+    self-heal analogue of the Windows repetition, so being *loaded* is the
+    property that matters. Never raises."""
+    osn = _os_name()
+    if osn == "Darwin":
+        dest = os.path.expanduser("~/Library/LaunchAgents/com.m3memory.cognitiveloop.plist")
+        if not os.path.exists(dest):
+            _safe_print(f"{FAIL} launchd agent not installed: {dest}")
+            return False
+        loaded = subprocess.run(["launchctl", "list"], capture_output=True, text=True)
+        if "com.m3memory.cognitiveloop" in (loaded.stdout or ""):
+            _safe_print(f"{OK} launchd agent installed and loaded: {dest}")
+            # KeepAlive is the self-heal knob — warn loudly if the plist lacks it.
+            try:
+                with open(dest, encoding="utf-8") as f:
+                    plist = f.read()
+                if "KeepAlive" not in plist:
+                    _safe_print(f"{WARN} plist has no <key>KeepAlive</key> — loop won't self-heal on crash")
+            except OSError:
+                pass
+            return True
+        _safe_print(f"{WARN} launchd agent installed but not loaded (run: launchctl load {dest})")
+        return False
+    if osn == "Linux":
+        unit = "m3-cognitive-loop.service"
+        dest = os.path.expanduser(f"~/.config/systemd/user/{unit}")
+        if not os.path.exists(dest):
+            _safe_print(f"{FAIL} systemd --user unit not installed: {dest}")
+            return False
+        active = subprocess.run(
+            ["systemctl", "--user", "is-active", unit], capture_output=True, text=True
+        )
+        state = (active.stdout or "").strip()
+        if state == "active":
+            _safe_print(f"{OK} systemd --user unit installed and active: {unit}")
+            return True
+        _safe_print(f"{WARN} systemd --user unit installed but {state or 'inactive'}")
+        return False
+    _safe_print(f"{WARN} verify: unsupported OS {osn}")
+    return False
+
+
+def verify_schedules(selector: str | None, m3_memory_root: str) -> bool:
+    """Verify the registered scheduled job(s) match what the installer intends.
+    Cross-platform: Windows tasks, macOS launchd, Linux systemd. Returns True if
+    everything verified. Replaces the old ad-hoc PowerShell verify helper."""
+    osn = _os_name()
+    if osn == "Windows":
+        tasks = _filter_tasks(get_schedule_specs(m3_memory_root), selector)
+        if not tasks:
+            _safe_print(f"{FAIL} No schedule matches selector={selector!r}.")
+            return False
+        # Check EVERY task (don't short-circuit) so all failures are reported at
+        # once, not just the first — a verify tool should surface the full picture.
+        results = [_verify_windows_task(t["name"]) for t in tasks]
+        return all(results)
+    # On Unix only the cognitive loop is a managed service; the rest are cron
+    # lines. Verify the loop (the one with the self-heal semantics).
+    if selector is None or selector.lower().replace("-", "").replace("_", "") in (
+        "cognitiveloop", "agentoscognitiveloop"
+    ):
+        return _verify_unix_cognitive_loop()
+    _safe_print(f"{WARN} verify on {osn} currently covers only the cognitive loop.")
+    return True
+
+
 def list_schedules(m3_memory_root):
     """List all configured schedules."""
     specs = get_schedule_specs(m3_memory_root)
@@ -633,11 +734,20 @@ def main():
                        help="Remove one schedule by name, or 'all'.")
     group.add_argument("--repair", action="store_true",
                        help="Re-install every configured schedule in place (alias for --add all).")
+    group.add_argument("--verify", metavar="NAME", nargs="?", const="all",
+                       help="Verify the registered job(s) match the spec (Windows task / "
+                            "macOS launchd / Linux systemd). NAME or 'all' (default). "
+                            "Exit code is non-zero if verification fails.")
     args = parser.parse_args()
 
     if args.list:
         list_schedules(m3_memory_root)
         return
+
+    if args.verify:
+        sel = None if args.verify == "all" else args.verify
+        ok = verify_schedules(sel, m3_memory_root)
+        sys.exit(0 if ok else 1)
 
     os_name = _os_name()
     _safe_print(f"M3 Memory: Detecting platform... {os_name}")

--- a/tests/test_windows_schedule_xml.py
+++ b/tests/test_windows_schedule_xml.py
@@ -200,3 +200,84 @@ def test_all_five_xml_metacharacters_escaped():
                          desc="""& < > " '"""))
     desc = root.find(".//t:RegistrationInfo/t:Description", _NS)
     assert desc is not None and desc.text == """& < > " '"""
+
+
+# ── --verify mode (hermetic: mock schtasks /Query output) ─────────────────────
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _query_xml(*, ignore_new=True, repetition="PT30M"):
+    """Minimal registered-task XML as schtasks /Query /XML ONE would emit."""
+    rep = f"<Repetition><Interval>{repetition}</Interval></Repetition>" if repetition else ""
+    multi = "IgnoreNew" if ignore_new else "Parallel"
+    return (
+        f'<?xml version="1.0"?><Task xmlns="{isch._TASK_NS}">'
+        f"<Triggers><BootTrigger>{rep}</BootTrigger></Triggers>"
+        f"<Settings><MultipleInstancesPolicy>{multi}</MultipleInstancesPolicy></Settings>"
+        "</Task>"
+    )
+
+
+def test_verify_windows_pass(monkeypatch):
+    # CognitiveLoop is a self-heal task: verify passes when the live XML carries
+    # the PT30M repetition + IgnoreNew.
+    monkeypatch.setattr(isch, "_os_name", lambda: "Windows")
+    monkeypatch.setattr(
+        isch.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, _query_xml(ignore_new=True, repetition="PT30M")),
+    )
+    assert isch._verify_windows_task("AgentOS_CognitiveLoop") is True
+
+
+def test_verify_windows_missing_repetition_fails(monkeypatch):
+    monkeypatch.setattr(isch, "_os_name", lambda: "Windows")
+    monkeypatch.setattr(
+        isch.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, _query_xml(ignore_new=True, repetition="")),
+    )
+    assert isch._verify_windows_task("AgentOS_CognitiveLoop") is False
+
+
+def test_verify_windows_not_registered_fails(monkeypatch):
+    monkeypatch.setattr(isch, "_os_name", lambda: "Windows")
+    monkeypatch.setattr(
+        isch.subprocess, "run",
+        lambda *a, **k: _FakeProc(1, "", "ERROR: The system cannot find the file specified."),
+    )
+    assert isch._verify_windows_task("AgentOS_CognitiveLoop") is False
+
+
+def test_verify_windows_non_selfheal_task_needs_no_repetition(monkeypatch):
+    # A task NOT in _SELF_HEAL_TASKS passes with IgnoreNew and no repetition.
+    monkeypatch.setattr(isch, "_os_name", lambda: "Windows")
+    monkeypatch.setattr(
+        isch.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, _query_xml(ignore_new=True, repetition="")),
+    )
+    assert isch._verify_windows_task("AgentOS_SecretRotator") is True
+
+
+def test_verify_schedules_reports_all_not_short_circuit(monkeypatch, capsys):
+    # verify_schedules must check every task even after one fails.
+    monkeypatch.setattr(isch, "_os_name", lambda: "Windows")
+
+    def fake_run(cmd, *a, **k):
+        # Fail only WeeklyAuditor; everything else is a clean IgnoreNew task.
+        name = cmd[cmd.index("/TN") + 1] if "/TN" in cmd else ""
+        if "WeeklyAuditor" in name:
+            return _FakeProc(1, "", "not found")
+        rep = "PT30M" if name in isch._SELF_HEAL_TASKS else ""
+        return _FakeProc(0, _query_xml(ignore_new=True, repetition=rep))
+
+    monkeypatch.setattr(isch.subprocess, "run", fake_run)
+    root = os.path.dirname(_BIN)
+    ok = isch.verify_schedules(None, root)
+    out = capsys.readouterr().out
+    assert ok is False                          # one failure -> overall False
+    assert "WeeklyAuditor" in out               # the failure is reported
+    assert "CognitiveLoop" in out               # AND later tasks still checked


### PR DESCRIPTION
## What

Adds `install_schedules.py --verify [NAME]` — reads back the **live registered job** and confirms it matches the spec, cross-platform:

- **Windows:** `schtasks /Query /XML` — checks `MultipleInstancesPolicy=IgnoreNew` and, for `_SELF_HEAL_TASKS`, that the expected `Repetition` interval is present.
- **macOS:** launchd agent installed **and** loaded (warns if the plist lacks `KeepAlive` — the Unix self-heal analogue of the Windows repetition).
- **Linux:** systemd `--user` unit installed **and** active.

Reports **every** task (no short-circuit) so all failures surface at once; exits non-zero if any fails.

Also adds `bin/deploy_cognitive_loop.ps1`: a thin, **PowerShell-5.1-compatible** wrapper that delegates both install and verify to `install_schedules.py` (single source of truth). It exists only to carry **elevation** on Windows (re-registering an admin-owned task needs an elevated shell). macOS/Linux install the launchd/systemd service directly with no elevation quirk. Paths auto-resolve from the script location, overridable via `-Repo`.

## Why

The previous verify step was an ad-hoc, hardcoded, PowerShell-7-only script living in a scratchpad — it broke twice (7-only ternary on a 5.1 host; wrong repo path). Folding verification into the canonical installer makes it correct, tested, and shared by all three OSes.

## Bonus finding

Running `--verify` on the dev machine revealed only **2 of 7** m3 tasks are actually registered — the tool makes that drift visible instead of silent.

## Tests

Hermetic (mock `schtasks` output, no live Task Scheduler — pass in CI): verify pass/fail, missing repetition, unregistered task, non-self-heal tasks, and the report-all-not-short-circuit behavior. Whole-tree ruff + mypy clean; 57 tests pass locally.