### PR TITLE
fix(flash): CREATE_NO_WINDOW on telemetry/GPU/hook spawns (Windows)

### DIFF
--- a/bin/enrichment_state.py
+++ b/bin/enrichment_state.py
@@ -103,7 +103,7 @@ def _git_sha() -> str:
             ["git", "rev-parse", "HEAD"],
             capture_output=True, text=True, timeout=2,
             # git is a console app on Windows — flash-free background call.
-            **({"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}),
+            creationflags=(getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0),
         )
         if out.returncode == 0:
             return out.stdout.strip()

--- a/bin/enrichment_state.py
+++ b/bin/enrichment_state.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import socket
 import sqlite3
 import subprocess
@@ -101,6 +102,8 @@ def _git_sha() -> str:
         out = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True, text=True, timeout=2,
+            # git is a console app on Windows — flash-free background call.
+            **({"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}),
         )
         if out.returncode == 0:
             return out.stdout.strip()

--- a/bin/hooks/chatlog/claude_code_precompact.py
+++ b/bin/hooks/chatlog/claude_code_precompact.py
@@ -156,11 +156,12 @@ def run_ingest(py: str, ingest: Path, extra_args: list) -> tuple:
     """Run ingest, return (written, skipped, failed, error, returncode)."""
     try:
         # CREATE_NO_WINDOW: this hook fires in the background per compaction; a
-        # bare python.exe child would flash a console window. No-op off Windows.
-        _nw = {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+        # bare python.exe child would flash a console window. getattr keeps the
+        # attribute reference valid on non-Windows (0 = default, no-op).
+        _flags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
         result = subprocess.run(
             [py, str(ingest)] + extra_args,
-            capture_output=True, text=True, timeout=60, **_nw)
+            capture_output=True, text=True, timeout=60, creationflags=_flags)
         output = result.stdout.strip()
         # ingest emits PRETTY-PRINTED (multi-line) JSON after its log lines, e.g.
         #   {\n  "written": 9,\n  ...\n}

--- a/bin/hooks/chatlog/claude_code_precompact.py
+++ b/bin/hooks/chatlog/claude_code_precompact.py
@@ -155,9 +155,12 @@ def _extract_last_json_object(output: str):
 def run_ingest(py: str, ingest: Path, extra_args: list) -> tuple:
     """Run ingest, return (written, skipped, failed, error, returncode)."""
     try:
+        # CREATE_NO_WINDOW: this hook fires in the background per compaction; a
+        # bare python.exe child would flash a console window. No-op off Windows.
+        _nw = {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
         result = subprocess.run(
             [py, str(ingest)] + extra_args,
-            capture_output=True, text=True, timeout=60)
+            capture_output=True, text=True, timeout=60, **_nw)
         output = result.stdout.strip()
         # ingest emits PRETTY-PRINTED (multi-line) JSON after its log lines, e.g.
         #   {\n  "written": 9,\n  ...\n}

--- a/bin/hooks/chatlog/gemini_cli_onexit.py
+++ b/bin/hooks/chatlog/gemini_cli_onexit.py
@@ -134,9 +134,12 @@ def _extract_last_json_object(output: str):
 def run_ingest(py: str, ingest: Path, extra_args: list) -> tuple:
     """Run ingest, return (written, skipped, failed, error, returncode)."""
     try:
+        # CREATE_NO_WINDOW: this hook fires in the background at exit; a bare
+        # python.exe child would flash a console window. No-op off Windows.
+        _nw = {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
         result = subprocess.run(
             [py, str(ingest)] + extra_args,
-            capture_output=True, text=True, timeout=60)
+            capture_output=True, text=True, timeout=60, **_nw)
         output = result.stdout.strip()
         result_json = _extract_last_json_object(output)
         if not result_json:

--- a/bin/hooks/chatlog/gemini_cli_onexit.py
+++ b/bin/hooks/chatlog/gemini_cli_onexit.py
@@ -135,11 +135,12 @@ def run_ingest(py: str, ingest: Path, extra_args: list) -> tuple:
     """Run ingest, return (written, skipped, failed, error, returncode)."""
     try:
         # CREATE_NO_WINDOW: this hook fires in the background at exit; a bare
-        # python.exe child would flash a console window. No-op off Windows.
-        _nw = {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+        # python.exe child would flash a console window. getattr keeps the
+        # attribute reference valid on non-Windows (0 = default, no-op).
+        _flags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
         result = subprocess.run(
             [py, str(ingest)] + extra_args,
-            capture_output=True, text=True, timeout=60, **_nw)
+            capture_output=True, text=True, timeout=60, creationflags=_flags)
         output = result.stdout.strip()
         result_json = _extract_last_json_object(output)
         if not result_json:

--- a/bin/hooks/chatlog/opencode_session_end.py
+++ b/bin/hooks/chatlog/opencode_session_end.py
@@ -132,11 +132,12 @@ def run_ingest(py: str, ingest: Path, extra_args: list) -> tuple:
     """Run ingest, return (written, skipped, failed, error, returncode)."""
     try:
         # CREATE_NO_WINDOW: this hook fires in the background at session end; a
-        # bare python.exe child would flash a console window. No-op off Windows.
-        _nw = {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+        # bare python.exe child would flash a console window. getattr keeps the
+        # attribute reference valid on non-Windows (0 = default, no-op).
+        _flags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
         result = subprocess.run(
             [py, str(ingest)] + extra_args,
-            capture_output=True, text=True, timeout=60, **_nw)
+            capture_output=True, text=True, timeout=60, creationflags=_flags)
         output = result.stdout.strip()
         result_json = _extract_last_json_object(output)
         if not result_json:

--- a/bin/hooks/chatlog/opencode_session_end.py
+++ b/bin/hooks/chatlog/opencode_session_end.py
@@ -131,9 +131,12 @@ def _extract_last_json_object(output: str):
 def run_ingest(py: str, ingest: Path, extra_args: list) -> tuple:
     """Run ingest, return (written, skipped, failed, error, returncode)."""
     try:
+        # CREATE_NO_WINDOW: this hook fires in the background at session end; a
+        # bare python.exe child would flash a console window. No-op off Windows.
+        _nw = {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
         result = subprocess.run(
             [py, str(ingest)] + extra_args,
-            capture_output=True, text=True, timeout=60)
+            capture_output=True, text=True, timeout=60, **_nw)
         output = result.stdout.strip()
         result_json = _extract_last_json_object(output)
         if not result_json:

--- a/bin/m3_enrich.py
+++ b/bin/m3_enrich.py
@@ -1405,7 +1405,11 @@ async def _main_async(args) -> int:
             first_db = next(iter(db_targets), None)
             if first_db:
                 cmd.extend(["--db", str(first_db[1])])
-            _sp.run(cmd, check=False)
+            # CREATE_NO_WINDOW: enrichment runs unattended (ObservationDrain task);
+            # a bare python.exe child would flash a console window. getattr keeps
+            # the reference valid on non-Windows (0 = default, no-op).
+            _nw_flags = getattr(_sp, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+            _sp.run(cmd, check=False, creationflags=_nw_flags)
         except Exception as e:
             print(f"[m3-enrich] (report generation failed: {type(e).__name__}: {e})", flush=True)
     return 0

--- a/bin/m3_sdk.py
+++ b/bin/m3_sdk.py
@@ -65,13 +65,23 @@ _gpu_probe_cache: dict[str, Any] = {"ts": 0.0, "util": 0.0, "backend": None, "mi
 _GPU_PROBE_MAX_MISSES = 3
 
 
+def _no_window() -> dict:
+    """subprocess kwargs that suppress a console window on Windows (no-op off
+    Windows). These GPU/telemetry probes run on the per-cycle governor path;
+    without CREATE_NO_WINDOW, nvidia-smi / powershell / tasklist each FLASH a
+    console window and steal focus on every poll. Shared _task_runtime helper is
+    preferred; this local fallback avoids an import cycle in the hot path."""
+    import subprocess as _sp
+    return {"creationflags": _sp.CREATE_NO_WINDOW} if os.name == "nt" else {}
+
+
 def _gpu_util_nvidia() -> float | None:
     """CUDA GPUs (any OS) via nvidia-smi. None = backend unavailable."""
     import subprocess
     try:
         out = subprocess.run(
             ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=2.0,
+            capture_output=True, text=True, timeout=2.0, **_no_window(),
         )
     except (FileNotFoundError, OSError):
         return None
@@ -97,7 +107,7 @@ def _gpu_util_windows_counter() -> float | None:
         )
         out = subprocess.run(
             ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps],
-            capture_output=True, text=True, timeout=4.0,
+            capture_output=True, text=True, timeout=4.0, **_no_window(),
         )
     except (FileNotFoundError, OSError):
         return None
@@ -482,7 +492,7 @@ def _pid_alive(pid: int) -> bool:
         try:
             out = subprocess.run(
                 ["tasklist", "/fi", f"PID eq {pid}", "/nh"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True, text=True, timeout=5, **_no_window(),
             )
             return str(pid) in (out.stdout or "")
         except (OSError, subprocess.SubprocessError):

--- a/bin/m3_sdk.py
+++ b/bin/m3_sdk.py
@@ -72,7 +72,10 @@ def _no_window() -> dict:
     console window and steal focus on every poll. Shared _task_runtime helper is
     preferred; this local fallback avoids an import cycle in the hot path."""
     import subprocess as _sp
-    return {"creationflags": _sp.CREATE_NO_WINDOW} if os.name == "nt" else {}
+    # getattr, not _sp.CREATE_NO_WINDOW: the attribute only exists on Windows, so
+    # a direct reference fails mypy on the Linux CI runner.
+    flags = getattr(_sp, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+    return {"creationflags": flags} if flags else {}
 
 
 def _gpu_util_nvidia() -> float | None:

--- a/bin/thermal_utils.py
+++ b/bin/thermal_utils.py
@@ -16,7 +16,10 @@ try:
     from _task_runtime import no_window_kwargs
 except Exception:  # pragma: no cover - fallback if _task_runtime unavailable
     def no_window_kwargs() -> dict:
-        return {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+        # getattr, not subprocess.CREATE_NO_WINDOW: the attribute only exists on
+        # Windows, so a direct reference fails mypy on the Linux CI runner.
+        flags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+        return {"creationflags": flags} if flags else {}
 
 def get_thermal_status() -> str:
     """

--- a/bin/thermal_utils.py
+++ b/bin/thermal_utils.py
@@ -5,6 +5,19 @@ import sys
 
 logger = logging.getLogger("thermal_utils")
 
+# get_thermal_status() runs on a WARM path — the cognitive loop polls telemetry
+# every cycle (and the governor on every load check). On Windows the powershell
+# and wmic probes are console-subsystem processes that FLASH a window and steal
+# focus on each poll unless CREATE_NO_WINDOW is set. Route every spawn through the
+# shared no_window helper (no-op off Windows). Without it, background thermal
+# polling visibly flashes windows during normal operation on every Windows host.
+try:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from _task_runtime import no_window_kwargs
+except Exception:  # pragma: no cover - fallback if _task_runtime unavailable
+    def no_window_kwargs() -> dict:
+        return {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+
 def get_thermal_status() -> str:
     """
     Returns the thermal/pressure status of the current system.
@@ -19,7 +32,7 @@ def get_thermal_status() -> str:
         try:
             res = subprocess.run(
                 ["sysctl", "-n", "kern.thermal_pressure"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True, text=True, timeout=5, **no_window_kwargs(),
             )
             if res.returncode == 0:
                 val = int(res.stdout.strip())
@@ -35,7 +48,7 @@ def get_thermal_status() -> str:
             res = subprocess.run(
                 ["powershell", "-NoProfile", "-Command",
                  "(Get-CimInstance -Namespace root/WMI -ClassName MSAcpi_ThermalZoneTemperature -ErrorAction Stop).CurrentTemperature"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, text=True, timeout=10, **no_window_kwargs(),
             )
             if res.returncode == 0 and res.stdout.strip():
                 raw_temp = int(res.stdout.strip().splitlines()[0])
@@ -52,7 +65,7 @@ def get_thermal_status() -> str:
             res = subprocess.run(
                 ["wmic", "/namespace:\\\\root\\wmi", "path",
                  "MSAcpi_ThermalZoneTemperature", "get", "CurrentTemperature"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True, text=True, timeout=5, **no_window_kwargs(),
             )
             if res.returncode == 0 and "CurrentTemperature" in res.stdout:
                 lines = res.stdout.strip().split("\n")

--- a/tests/test_no_window_regression_guard.py
+++ b/tests/test_no_window_regression_guard.py
@@ -1,0 +1,166 @@
+"""Regression guard: background/unattended code must not flash a console window.
+
+DESIGN_PHILOSOPHIES §1 (degrade cleanly across the OS matrix) + §8 (don't disturb
+the host): a process that runs UNATTENDED — the cognitive loop, its telemetry
+probes, scheduled tasks, and chatlog hooks — spawns console subprocesses
+(nvidia-smi, powershell, wmic, git, python, ...). On Windows a console-subsystem
+child FLASHES a window and steals focus every time it runs. On the per-cycle
+governor path that is a constant, focus-stealing nuisance for every Windows user.
+
+The fix is to pass `creationflags=CREATE_NO_WINDOW` (via the shared
+_task_runtime.no_window_kwargs helper, or an equivalent local helper) on every
+such spawn. This test makes that non-optional: it AST-walks the unattended
+entrypoints and fails if any subprocess spawn lacks a no-window argument — so a
+future contributor can't silently reintroduce the flash for users.
+
+Deliberately OUT OF SCOPE (per the intended UX): interactive entrypoints — the
+mission_control dashboard, setup/install wizards, dev CLIs — SHOULD show a
+window; the user invoked them and is watching. Only unattended paths are guarded.
+"""
+from __future__ import annotations
+
+import ast
+import os
+
+import pytest
+
+_BIN = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "bin"))
+
+# Commands that are POSIX-only (or otherwise never a Windows console app), so a
+# missing no-window flag can't flash on Windows. Keyed on argv[0] literal.
+_POSIX_ONLY_CMDS = {
+    "crontab", "launchctl", "systemctl", "sysctl", "ioreg", "sensors",
+    "sh", "/bin/sh", "bash", "osascript", "defaults", "sw_vers", "uname",
+}
+
+# The spawn call names we police.
+_SPAWN_ATTRS = {"run", "Popen", "call", "check_call", "check_output"}
+
+# Kwarg / splat names that satisfy the no-window requirement.
+_NOWINDOW_KWARG = "creationflags"
+_NOWINDOW_HELPERS = {"no_window_kwargs", "_no_window", "_nw"}
+
+
+def _unattended_files() -> list[str]:
+    """Derive the set of unattended entrypoints from the source of truth rather
+    than a hand-maintained list (so a new scheduled task is auto-covered):
+
+      * every script referenced by install_schedules' schedule specs,
+      * every chatlog hook,
+      * the cognitive loop + the telemetry/probe modules it calls per cycle.
+    """
+    import sys
+    if _BIN not in sys.path:
+        sys.path.insert(0, _BIN)
+    import install_schedules as isch
+
+    files: set[str] = set()
+
+    # Scripts run by scheduled tasks (args[0] of each spec is the .py path).
+    for spec in isch.get_schedule_specs(os.path.dirname(_BIN)):
+        script = spec["args"][0]
+        if str(script).endswith(".py") and os.path.exists(script):
+            files.add(os.path.abspath(script))
+
+    # Chatlog hooks (fire unattended per session/compact).
+    hooks_dir = os.path.join(_BIN, "hooks", "chatlog")
+    if os.path.isdir(hooks_dir):
+        for name in os.listdir(hooks_dir):
+            if name.endswith(".py") and not name.startswith("_"):
+                files.add(os.path.join(hooks_dir, name))
+
+    # The cognitive loop + the modules it polls every cycle.
+    for name in ("m3_cognitive_loop.py", "m3_sdk.py", "thermal_utils.py",
+                 "enrichment_state.py", "m3_enrich_batch_parallel.py"):
+        p = os.path.join(_BIN, name)
+        if os.path.exists(p):
+            files.add(p)
+
+    return sorted(files)
+
+
+def _argv0_literal(call: ast.Call) -> str | None:
+    """Best-effort: the literal argv[0] of a spawn, if the first arg is a list
+    whose first element is a string constant. Used only to skip POSIX-only cmds."""
+    if not call.args:
+        return None
+    first = call.args[0]
+    if isinstance(first, ast.List) and first.elts:
+        head = first.elts[0]
+        if isinstance(head, ast.Constant) and isinstance(head.value, str):
+            return head.value
+    return None
+
+
+def _call_has_no_window(call: ast.Call) -> bool:
+    """True if the spawn passes creationflags= OR splats a no-window helper."""
+    for kw in call.keywords:
+        # creationflags=... (kw.arg is None for **splat)
+        if kw.arg == _NOWINDOW_KWARG:
+            return True
+        # **no_window_kwargs() / **_no_window() / **_nw
+        if kw.arg is None:
+            val = kw.value
+            if isinstance(val, ast.Call) and isinstance(val.func, ast.Name) \
+                    and val.func.id in _NOWINDOW_HELPERS:
+                return True
+            if isinstance(val, ast.Name) and val.id in _NOWINDOW_HELPERS:
+                return True
+    return False
+
+
+# Names that a spawn attribute must be called ON to count — avoids matching
+# asyncio.run / loop.run_* / any unrelated .run(). We only police the subprocess
+# module (imported as `subprocess` or aliased `_sp`) and the from-import forms.
+_SPAWN_OBJECTS = {"subprocess", "_sp", "sp"}
+
+
+def _is_spawn(call: ast.Call) -> bool:
+    """Only real subprocess spawns:  subprocess.run(...) / _sp.Popen(...), or a
+    bare run/Popen(...) imported `from subprocess import run`. Crucially NOT
+    asyncio.run / loop.run_* / <other>.run — those are not process spawns."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr in _SPAWN_ATTRS:
+        obj = func.value
+        return isinstance(obj, ast.Name) and obj.id in _SPAWN_OBJECTS
+    if isinstance(func, ast.Name) and func.id in _SPAWN_ATTRS:
+        return True  # bare Popen(...) from `from subprocess import Popen`
+    return False
+
+
+def _offending_spawns(path: str) -> list[tuple[int, str]]:
+    with open(path, encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=path)
+    bad: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_spawn(node):
+            continue
+        cmd0 = _argv0_literal(node)
+        if cmd0 and cmd0 in _POSIX_ONLY_CMDS:
+            continue  # never a Windows console app → can't flash
+        if not _call_has_no_window(node):
+            bad.append((node.lineno, cmd0 or "<dynamic>"))
+    return bad
+
+
+@pytest.mark.parametrize("path", _unattended_files(),
+                         ids=lambda p: os.path.relpath(p, _BIN))
+def test_unattended_spawns_are_windowless(path):
+    """Every subprocess spawn in an unattended entrypoint must suppress the
+    console window (creationflags / no_window helper), or be a POSIX-only cmd."""
+    bad = _offending_spawns(path)
+    assert not bad, (
+        f"{os.path.relpath(path, _BIN)} has subprocess spawn(s) without a "
+        f"no-window flag (would flash a console window on Windows for every "
+        f"user): lines {[ln for ln, _ in bad]} (cmds: {[c for _, c in bad]}). "
+        f"Add creationflags=... or **no_window_kwargs()."
+    )
+
+
+def test_guard_actually_finds_the_helper_targets():
+    """Sanity: the derived file set is non-empty and includes the known ones,
+    so the guard can't silently pass by scanning nothing."""
+    files = {os.path.basename(p) for p in _unattended_files()}
+    assert files, "no unattended files derived — guard would be a no-op"
+    for expected in ("m3_sdk.py", "thermal_utils.py"):
+        assert expected in files, f"{expected} missing from guard scope"


### PR DESCRIPTION
## The systemic user-facing flasher

The per-cycle governor/telemetry path spawned **console** tools with no `CREATE_NO_WINDOW`, so on Windows a window **flashed and stole focus on every loop cycle** — the recurring 'flash when work is fed to the LLM' behavior. With the GPU-burst fix (limit=1) the loop cycles per item, so telemetry polled constantly → constant flashes.

## Fixed (background/unattended paths only)
- **`thermal_utils.get_thermal_status()`**: `powershell` + `wmic` thermal probes, polled on every telemetry read.
- **`m3_sdk` GPU probes**: `nvidia-smi`, the Windows GPU-Engine `powershell` counter, and the `tasklist` PID-liveness check.
- **3 chatlog hooks** (`claude_code_precompact` / `gemini_cli_onexit` / `opencode_session_end`): the background ingest subprocess.
- **`enrichment_state._git_sha()`**: background `git rev-parse`.

All via the shared no-window helper; **no-ops off Windows**.

## Deliberately NOT touched
Interactive/wizard entrypoints — the `mission_control` pulse dashboard, setup/install wizards, and dev CLIs. Those **should** show a window; the user invoked them and is watching. Only unattended background spawns are suppressed.

## Verified
`thermal_utils` + GPU probe run clean under `pythonw` (no window); 17 governor tests pass; ruff + mypy clean.