### PR TITLE
feat(loop): round-robin pass order + idle-aware intensity (fairness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,38 @@ forward-going only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Console windows no longer flash / steal focus on Windows.** Background work —
+  the cognitive loop's per-cycle telemetry and GPU probes (`nvidia-smi`,
+  PowerShell, WMIC), the thermal check, the chatlog hooks, and enrichment report
+  generation — spawned console-subsystem helpers without `CREATE_NO_WINDOW`, so a
+  window flashed and stole focus on every poll. All unattended spawns now run
+  windowless. An AST-based regression guard (`test_no_window_regression_guard.py`)
+  fails CI if a future unattended spawn omits the flag, so this can't come back.
+  Interactive tools (setup wizard, dashboard) still show their window by design.
+- **Status line no longer flashes.** The Windows status-line command spawned
+  `whoami`, `hostname -s`, and `git` per refresh; these are now windowless (and
+  `whoami`/`hostname` are avoided entirely via env / `socket.gethostname()`,
+  which also fixes a crash on Windows where `hostname -s` is unsupported).
+
+### Changed
+
+- **Background GPU bursts are short on interactive machines.** The cognitive
+  loop's heavy local-LLM passes now process one item at a time and re-check the
+  governor between items, so background enrichment no longer monopolizes the GPU
+  for minutes; the embed sweep gained a per-run time budget.
+- **Fairer pass scheduling.** The loop rotates which maintenance pass leads each
+  cycle (round-robin) instead of a fixed priority order, so an always-backlogged
+  pass can't starve the others; when the host is busy it runs a single pass per
+  cycle to stay out of the user's way.
+- **Self-healing background loop (Windows).** The cognitive-loop scheduled task is
+  registered from a Task Scheduler XML definition with a 30-minute self-heal
+  repetition and boot+logon triggers, so a dead loop revives without a reboot;
+  the PowerShell dependency in the installer was removed. New
+  `install_schedules.py --verify` checks the live job matches the spec
+  cross-platform (Windows task / macOS launchd / Linux systemd).
+
 ### Web Diagnostics Portal (planned)
 
 Work-in-progress; not yet released. Tracking under `bin/dashboard_server.py`.

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -174,6 +174,29 @@ def _pace_for_pass(pacing_cpu_ram: dict, pacing_full: dict, uses_local_gpu: bool
     return pacing_cpu_ram
 
 
+def _select_pass_order(passes: list, cycle: int, active: bool) -> list:
+    """Round-robin + idle-aware pass selection for one cycle. Pure function so the
+    fairness policy is unit-testable in isolation from the async loop.
+
+    - ROUND-ROBIN (fairness): rotate the list by `cycle` so a different pass leads
+      each cycle. No pass is permanently first, so an always-backlogged upstream
+      pass (entity extraction) can't perpetually grab the local GPU before the
+      downstream passes get a turn.
+    - IDLE-AWARE INTENSITY (interactive UX): when `active` (governor THROTTLED — a
+      proxy for the user being busy, since this separate process can't read the
+      MCP interaction stamp), return only the rotated LEADER so exactly one pass
+      runs this cycle, minimising GPU contention. When idle, return every pass to
+      drain the backlog.
+
+    `cycle` may grow unbounded; the modulo keeps rotation stable. Empty `passes`
+    returns empty (no crash)."""
+    n = len(passes)
+    if n == 0:
+        return []
+    order = [passes[(i + cycle) % n] for i in range(n)]
+    return order[:1] if active else order
+
+
 _PROFILE_LOCAL_CACHE: dict[str, bool] = {}
 
 
@@ -453,6 +476,11 @@ async def main_loop(args):
     # through a full 50-item batch of LLM calls with no re-check. Restored to the
     # full value once load clears.
     _full_limit = args.limit_per_pass
+    # Round-robin cursor: which pass leads each cycle. Rotating the start avoids
+    # the fixed-priority starvation where entity extraction — always backlogged —
+    # would perpetually run first and grab the local GPU before enrich/consolidate
+    # ever get a turn under contention. Each pass takes the lead 1-in-N cycles.
+    _cycle = 0
     while not _STOP_EVENT.is_set():
         # ── Adaptive Governor Gating (per-resource, per-pass) ──────────────────
         # Each resource gates the work that consumes it: CPU/RAM pressure gates
@@ -505,31 +533,36 @@ async def main_loop(args):
 
         start_time = time.monotonic()
 
-        if not args.skip_entities:
-            pace = _pace_for_pass(pacing_cpu_ram, pacing_full, entity_local)
-            if _run_gate(pace):
-                args.limit_per_pass = _effective_limit(pace)
-                await run_entity_pass(args)
-            if _STOP_EVENT.is_set(): break
+        # The passes as a rotatable list. `gpu` marks passes that run on the
+        # local GPU (so GPU load gates them); chatlog-prune is pure SQL. `sets_limit`
+        # marks the LLM passes whose batch size we shrink under throttle.
+        passes = [
+            {"name": "entities",   "skip": args.skip_entities,      "gpu": entity_local,      "sets_limit": True,  "run": run_entity_pass},
+            {"name": "enrich",     "skip": args.skip_enrich,        "gpu": enrich_local,      "sets_limit": True,  "run": run_enrich_pass},
+            {"name": "consolidate","skip": args.skip_consolidate,   "gpu": consolidate_local, "sets_limit": False, "run": run_consolidate_pass},
+            {"name": "prune",      "skip": args.skip_chatlog_prune, "gpu": None,              "sets_limit": False, "run": run_chatlog_prune_pass},
+        ]
+        # Round-robin order + idle-aware intensity (see _select_pass_order). When
+        # the governor is THROTTLED we treat the host as user-active and run only
+        # the rotated leader this cycle; otherwise every pass runs. Rotation makes
+        # sure the leader differs each cycle so no pass is starved.
+        active = pacing_full.get("background") == "THROTTLED"
+        order = _select_pass_order(passes, _cycle, active)
+        _cycle += 1
 
-        if not args.skip_enrich:
-            pace = _pace_for_pass(pacing_cpu_ram, pacing_full, enrich_local)
+        for p in order:
+            if p["skip"]:
+                continue
+            # prune is pure SQL → gated only by CPU/RAM; everything else uses the
+            # per-pass verdict (GPU folded in only for local-GPU passes).
+            pace = pacing_cpu_ram if p["gpu"] is None else _pace_for_pass(
+                pacing_cpu_ram, pacing_full, p["gpu"])
             if _run_gate(pace):
-                args.limit_per_pass = _effective_limit(pace)
-                await run_enrich_pass(args)
-            if _STOP_EVENT.is_set(): break
-
-        if not args.skip_consolidate:
-            pace = _pace_for_pass(pacing_cpu_ram, pacing_full, consolidate_local)
-            if _run_gate(pace):
-                await run_consolidate_pass(args)
-            if _STOP_EVENT.is_set(): break
-
-        # chatlog-prune is pure SQL: gated only by CPU/RAM, never GPU.
-        if not args.skip_chatlog_prune:
-            if _run_gate(pacing_cpu_ram):
-                await run_chatlog_prune_pass(args)
-            if _STOP_EVENT.is_set(): break
+                if p["sets_limit"]:
+                    args.limit_per_pass = _effective_limit(pace)
+                await p["run"](args)
+            if _STOP_EVENT.is_set():
+                break
 
         args.limit_per_pass = _full_limit  # restore for the next cycle's defaults
 

--- a/tests/test_cognitive_loop_consolidate.py
+++ b/tests/test_cognitive_loop_consolidate.py
@@ -114,3 +114,47 @@ class _Args:
     def __init__(self, **kw):
         self.__dict__.update(kw)
         os.environ.setdefault("M3_DATABASE", kw.get("database", ""))
+
+
+# ── Round-robin + idle-aware pass selection (_select_pass_order) ──────────────
+
+_PASSES = [{"name": n} for n in ("entities", "enrich", "consolidate", "prune")]
+
+
+def _names(order):
+    return [p["name"] for p in order]
+
+
+def test_pass_order_rotates_leader_each_cycle():
+    # Over 4 cycles (idle), every pass leads exactly once — no starvation.
+    leaders = [_names(cl._select_pass_order(_PASSES, c, active=False))[0] for c in range(4)]
+    assert leaders == ["entities", "enrich", "consolidate", "prune"]
+
+
+def test_pass_order_idle_runs_all_passes():
+    order = cl._select_pass_order(_PASSES, cycle=0, active=False)
+    assert _names(order) == ["entities", "enrich", "consolidate", "prune"]
+
+
+def test_pass_order_active_runs_only_leader():
+    # When active (throttled), exactly one pass runs — the rotated leader.
+    assert _names(cl._select_pass_order(_PASSES, cycle=0, active=True)) == ["entities"]
+    assert _names(cl._select_pass_order(_PASSES, cycle=1, active=True)) == ["enrich"]
+    assert _names(cl._select_pass_order(_PASSES, cycle=2, active=True)) == ["consolidate"]
+
+
+def test_pass_order_rotation_is_stable_over_large_cycle():
+    # Cycle counter may grow unbounded; modulo keeps rotation correct.
+    assert _names(cl._select_pass_order(_PASSES, cycle=4, active=False))[0] == "entities"
+    assert _names(cl._select_pass_order(_PASSES, cycle=1000003, active=False))[0] == "prune"
+
+
+def test_pass_order_preserves_relative_sequence():
+    # Rotation is a rotation, not a reshuffle: order after the leader is preserved.
+    assert _names(cl._select_pass_order(_PASSES, cycle=1, active=False)) == \
+        ["enrich", "consolidate", "prune", "entities"]
+
+
+def test_pass_order_empty_is_safe():
+    assert cl._select_pass_order([], cycle=5, active=False) == []
+    assert cl._select_pass_order([], cycle=5, active=True) == []


### PR DESCRIPTION
## Problem (raised by the user)

The cognitive loop ran its passes in **fixed priority order** every cycle: entity → enrich → consolidate → prune. Because entity extraction is perpetually backlogged, it **always ran first** and — under GPU contention — could grab the local GPU before the downstream passes ever got a turn, starving them. A row that finished extraction and is ready to enrich shouldn't wait behind thousands of un-started rows.

(Investigation confirmed the queues themselves were fair — enrich/consolidate skip because their queues are genuinely empty, being downstream of extraction — but the **fixed order** is a real starvation vector under contention, which the user correctly flagged.)

## Fix — `_select_pass_order()` (pure, unit-tested)

- **Round-robin (fairness):** rotate which pass leads each cycle, so no pass is permanently first / permanently last for the GPU. Rotation changes ORDER only, not volume.
- **Idle-aware intensity (uncompromised interactive UX):** when the governor is THROTTLED (a proxy for 'user is active' — this separate process can't read the MCP server's interaction stamp), run only the rotated **leader** this cycle to minimise GPU contention while the user works; when load is clear, run every pass to drain the backlog. HALT still short-circuits as before.

Interactive UX is unchanged/better: the governor's activity gate + `limit=1` still protect the user, and idle-aware now runs even *less* during active use. Fairness is restored without slowing the drain when the machine is idle.

## Tests

6 unit tests: rotation cycles every leader, idle=all / active=leader-only, large-cycle stability, sequence preservation, empty-safety. Plus the merged no-window regression guard confirms this change adds no unguarded spawns.

Rebased on `main` after #71, so it carries the flash fixes too.