### PR TITLE
fix(cognitive-loop): drain backlog on idle instead of 1 item / interval

### DIFF
--- a/bin/install_schedules.py
+++ b/bin/install_schedules.py
@@ -300,8 +300,14 @@ def get_schedule_specs(m3_memory_root):
             "name": "AgentOS_CognitiveLoop",
             # --background re-execs under pythonw.exe (no console at all) on
             # Windows. macOS/Linux use a launchd/systemd service instead.
+            # --interval 60: on an idle host the loop re-ticks fast to drain a
+            # backlog (backlog-aware wait in the loop), so 60s is the ceiling
+            # between passes, not a fixed trickle. --limit-per-pass inherits the
+            # loop's default (2): a short GPU burst per pass, shrunk to 1 under
+            # THROTTLED load. (Previously --interval 300 with the old default-1
+            # ceiling drained ~1 item / 5 min even while idle.)
             "args": [_script("m3_cognitive_loop.py"),
-                     "--interval", "300", "--background",
+                     "--interval", "60", "--background",
                      "--log-file", _log("cognitive_loop.log")],
             "schedule": "ONSTART",
             "modifier": "",

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -575,6 +575,22 @@ async def main_loop(args):
             delay = float(pacing_full.get("background_delay",
                           pacing_cpu_ram.get("background_delay", 10.0)))
             wait_time = min(wait_time, delay)
+        else:
+            # IDLE BACKLOG DRAIN (§5/§8): each heavy-LLM pass processes at most
+            # --limit-per-pass items, so a real backlog needs many cycles. When
+            # the host is idle (not throttled) and work remains, re-tick after a
+            # short floor instead of sleeping the full --interval — otherwise an
+            # idle machine trickles one small batch per interval (the "1 item /
+            # 5 min" symptom) while CPU/GPU/RAM sit unused. The batch ceiling
+            # still bounds each burst, so the governor stays responsive; only
+            # the between-pass idle wait is shortened while there's a backlog.
+            more_work = (
+                (not args.skip_entities and has_entity_work(args.database, args.chatlog_db))
+                or (not args.skip_enrich and has_enrich_work(args.database))
+            )
+            if more_work:
+                floor = float(pacing_full.get("background_delay", 0.1))
+                wait_time = min(wait_time, max(floor, 1.0))
 
         if _STOP_EVENT.is_set():
             break
@@ -595,16 +611,19 @@ def main():
                         help="Append logging to this file (scheduled-task / service mode). "
                              "Survives the Windows pythonw re-exec.")
     parser.add_argument("--concurrency", type=int, default=2, help="SLM concurrency (default: 2)")
-    parser.add_argument("--limit-per-pass", type=int, default=1,
+    parser.add_argument("--limit-per-pass", type=int, default=2,
                         help="Max groups/rows per heavy-LLM pass (entity extraction, "
-                             "enrichment, observation drain). Default 1: each pass does "
-                             "one item, then the loop yields and re-checks the governor "
-                             "before the next. This keeps GPU bursts short (sub-second) so "
-                             "background enrichment never monopolizes the GPU on an "
-                             "interactive machine. A single LLM pass of 50 items pinned the "
-                             "GPU for ~17 min because the governor was only re-checked "
-                             "BETWEEN passes, not within a batch. Embedding is a separate "
-                             "scheduled task (ChatlogEmbedSweep) and is unaffected.")
+                             "enrichment, observation drain). Default 2: small enough that "
+                             "one pass is a few-second GPU burst (the governor is only "
+                             "re-checked BETWEEN passes, not within a batch — a 50-item pass "
+                             "once pinned the GPU for ~17 min), large enough that an idle "
+                             "host drains the backlog at a useful rate instead of one item "
+                             "per cycle. Under THROTTLED load this is shrunk to "
+                             "M3_GOVERNOR_THROTTLED_LIMIT (default 1); when idle the loop "
+                             "also re-ticks immediately if a backlog remains (see the "
+                             "backlog-aware wait below) rather than sleeping the full "
+                             "--interval. Embedding is a separate scheduled task "
+                             "(ChatlogEmbedSweep) and is unaffected.")
 
     # Database knobs
     parser.add_argument("--database", default=None, help="Core Memory DB path (Env: M3_DATABASE)")


### PR DESCRIPTION
## Problem
On an idle host the cognitive loop trickled **~1 item every 5 minutes** even with CPU, GPU, and RAM all low. The governor was not at fault — it correctly reported `CONTINUOUS`. Two causes:

1. `--limit-per-pass` **defaulted to 1**, so each heavy-LLM pass processed a single item regardless of free resources.
2. The between-pass wait only short-circuited the full `--interval` sleep when a pass ran `THROTTLED` (under load). When **idle** with a real backlog, the loop slept the entire interval (300s) → backlog drained one small batch per interval.

## Fix
- Raise `--limit-per-pass` default **1 → 2**. Kept small on purpose: the governor is only re-checked *between* passes, not within a batch, and a 50-item pass once pinned the GPU ~17 min. `2` is a short burst that drains ~2× faster; `THROTTLED` still shrinks it to 1.
- **Backlog-aware idle wait**: when *not* throttled and `has_entity_work`/`has_enrich_work` still report work, re-tick after a ~1s floor instead of sleeping the full interval. The batch ceiling still bounds each burst, so the governor stays responsive.
- `install_schedules` `AgentOS_CognitiveLoop` `--interval 300 → 60`.

## Verification
Restarted the live loop on the new code and watched cadence go from rigid 5-min gaps to variable sub-interval spacing (fast with backlog, relaxed when drained). Existing loop tests (`test_cognitive_loop_consolidate.py`, `test_windows_schedule_xml.py`) green.

## Follow-up (out of scope)
The real ceiling on `--limit-per-pass` is that the governor isn't re-checked *within* a batch. Intra-batch re-checks would let the ceiling go higher safely — noted, not done here.