### PR TITLE
feat(doctor): detect dangling scheduled-job interpreters (cross-platform)

### DIFF
--- a/bin/doctor/schedule_probe.py
+++ b/bin/doctor/schedule_probe.py
@@ -1,0 +1,194 @@
+"""Dangling scheduled-task probe — do the AgentOS_* tasks still point at a
+real interpreter and script?
+
+The Windows ``AgentOS_*`` scheduled tasks (see bin/install_schedules.py) bake an
+ABSOLUTE interpreter path (``…\\.venv\\Scripts\\pythonw.exe``) and script path
+into their Task Scheduler XML. If the code install is deleted or moved — e.g.
+``rmdir ~/pipx`` wipes the venv, or the repo clone is relocated — the tasks stay
+registered but their interpreter/script no longer exists. They fire on schedule
+and fail silently: ``LastTaskResult`` goes non-zero and the background governor
+(``AgentOS_CognitiveLoop``) never resurrects, because self-heal can restart a
+crashed loop but not a deleted interpreter.
+
+Nothing surfaces this today: ``installer._path_is_stale`` only covers MCP-config
+paths, and ``governor_probe`` only flags *legacy* (pre-governor) schedules, not
+*dangling* ones.
+
+This probe makes the state visible (DESIGN §3 fail-loud): if a registered task
+points at a missing interpreter or script, it nags and prints the one-command
+fix. It is report-only — a broken task is a recoverable state, not a doctor
+failure — so it always returns 0 and never crashes the doctor run.
+
+Windows-only: on macOS/Linux the cognitive loop is a launchd/systemd service and
+the periodic tasks are crontab entries; dangling-detection for those is a
+separate future check. Here we print a one-line "n/a" and return 0.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+logger = logging.getLogger("memory.doctor.schedule_probe")
+
+# Task Scheduler XML namespace (all AgentOS_* tasks are registered under it).
+_TASK_NS = "{http://schemas.microsoft.com/windows/2004/02/mit/task}"
+
+# schtasks /Query returns this rc when the named task does not exist. A
+# not-installed task is NOT dangling (that's "never set up" — a different,
+# silent state), so we distinguish it from a real query failure.
+_SCHTASKS_NOT_FOUND_RC = 1
+
+
+def _expected_task_names(m3_memory_root: str) -> list[str]:
+    """The AgentOS_* task names this install would register. Sourced from
+    install_schedules.get_schedule_specs so the names stay single-sourced."""
+    bin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if bin_dir not in sys.path:
+        sys.path.insert(0, bin_dir)
+    import install_schedules as sched  # noqa: E402
+
+    return [t["name"] for t in sched.get_schedule_specs(m3_memory_root)]
+
+
+def _query_task_xml(name: str) -> str | None:
+    """Return the Task Scheduler XML for ``name``, or None if the task is not
+    installed. Raises on an unexpected schtasks failure (caught by run())."""
+    proc = subprocess.run(
+        ["schtasks", "/Query", "/TN", name, "/XML"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        # Task-not-found is the common, benign case; anything else is a real
+        # failure we let bubble so run() can report "could not query".
+        stderr = (proc.stderr or "").upper()
+        if proc.returncode == _SCHTASKS_NOT_FOUND_RC or "ERROR:" in stderr:
+            return None
+        raise RuntimeError(f"schtasks /Query {name} failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _parse_action_paths(task_xml: str) -> tuple[str | None, str | None]:
+    """Extract (interpreter_path, script_path) from a task's XML.
+
+    interpreter = <Command> of the first <Exec> action.
+    script      = first <Arguments> token (quotes stripped). None if absent.
+    """
+    root = ET.fromstring(task_xml)
+    exec_el = root.find(f".//{_TASK_NS}Actions/{_TASK_NS}Exec")
+    if exec_el is None:
+        return None, None
+    cmd_el = exec_el.find(f"{_TASK_NS}Command")
+    # <Command> may be quoted (schtasks registers some tasks with a quoted
+    # interpreter path). Strip surrounding quotes so os.path.exists() sees the
+    # real path — an unstripped '"…pythonw.exe"' is a false "missing" positive.
+    interpreter = cmd_el.text.strip().strip('"') if cmd_el is not None and cmd_el.text else None
+
+    args_el = exec_el.find(f"{_TASK_NS}Arguments")
+    script = None
+    if args_el is not None and args_el.text:
+        first = args_el.text.strip().split(" ")[0] if args_el.text.strip() else ""
+        script = first.strip('"') or None
+    return interpreter, script
+
+
+def find_dangling(m3_memory_root: str) -> list[dict]:
+    """Return one dict per REGISTERED task whose interpreter or script is missing.
+
+    Each dict: {name, interpreter, script, missing: ["interpreter"|"script", ...]}.
+    Not-installed tasks are skipped (not dangling). Query/parse errors for a
+    single task are recorded with missing=["query-error"] rather than aborting
+    the whole probe.
+    """
+    dangling: list[dict] = []
+    for name in _expected_task_names(m3_memory_root):
+        try:
+            task_xml = _query_task_xml(name)
+        except Exception as e:  # noqa: BLE001 — one bad task must not sink the probe
+            dangling.append({"name": name, "interpreter": None, "script": None,
+                             "missing": ["query-error"], "error": str(e)})
+            continue
+        if task_xml is None:
+            continue  # not installed — not dangling
+
+        interpreter, script = _parse_action_paths(task_xml)
+        missing: list[str] = []
+        if not interpreter or not os.path.exists(interpreter):
+            missing.append("interpreter")
+        # Only flag a missing script when the task actually declares one.
+        if script and not os.path.exists(script):
+            missing.append("script")
+        if missing:
+            dangling.append({"name": name, "interpreter": interpreter,
+                             "script": script, "missing": missing})
+    return dangling
+
+
+def run(brief: bool = False) -> int:
+    """Report registered AgentOS_* tasks that point at a missing interpreter or
+    script. Always returns 0 (report-only). Never crashes the doctor."""
+    if sys.platform != "win32":
+        if brief:
+            print("schedules: n/a (Windows-only check)")
+        else:
+            print()
+            print("=== scheduled-task interpreters ===")
+            print("  status   : n/a — this check covers Windows AgentOS_* tasks only.")
+            print("             macOS/Linux use launchd/systemd/crontab (not checked here).")
+        return 0
+
+    # m3_memory_root is the code install root (parent of bin/). The scheduled
+    # tasks were registered against whatever root install_schedules ran under;
+    # here we only need the task NAMES, which are root-independent, so the exact
+    # root value doesn't affect detection — the live XML carries the real paths.
+    m3_memory_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    try:
+        dangling = find_dangling(m3_memory_root)
+    except Exception as e:  # noqa: BLE001 — probe must never crash the doctor
+        if brief:
+            print("schedules: unknown (probe failed)")
+        else:
+            print()
+            print("=== scheduled-task interpreters ===")
+            print(f"  status   : could not run schedule probe: {type(e).__name__}: {e}")
+        return 0
+
+    if brief:
+        if dangling:
+            print(f"⚠️  schedules: {len(dangling)} dangling task(s); run `m3 setup`")
+        else:
+            print("✅ schedules: OK (registered tasks resolve to a real interpreter)")
+        return 0
+
+    print()
+    print("=== scheduled-task interpreters ===")
+    if not dangling:
+        print("  status   : OK — every registered AgentOS_* task points at an")
+        print("             interpreter and script that still exist on disk.")
+        return 0
+
+    print(f"  status   : NAG — {len(dangling)} registered task(s) point at a missing")
+    print("             interpreter/script. They fire on schedule but cannot launch:")
+    for d in dangling:
+        if "query-error" in d["missing"]:
+            print(f"             - {d['name']} → could not query: {d.get('error', '')}")
+            continue
+        bits = []
+        if "interpreter" in d["missing"]:
+            bits.append(f"interpreter {d['interpreter']!r} (missing)")
+        if "script" in d["missing"]:
+            bits.append(f"script {d['script']!r} (missing)")
+        print(f"             - {d['name']} → " + "; ".join(bits))
+    print()
+    print("  why      : the code install moved or was deleted (e.g. the venv/pipx")
+    print("             dir was removed). The task stays registered but its baked-in")
+    print("             absolute path no longer resolves, so the run fails silently —")
+    print("             the background governor never comes back until re-registered.")
+    print()
+    print("  fix      : re-register the tasks against the current install:")
+    print("               m3 setup")
+    return 0

--- a/bin/doctor/schedule_probe.py
+++ b/bin/doctor/schedule_probe.py
@@ -1,49 +1,77 @@
-"""Dangling scheduled-task probe — do the AgentOS_* tasks still point at a
-real interpreter and script?
+"""Dangling scheduled-task probe — do the installed background jobs still point
+at a real interpreter and script?
 
-The Windows ``AgentOS_*`` scheduled tasks (see bin/install_schedules.py) bake an
-ABSOLUTE interpreter path (``…\\.venv\\Scripts\\pythonw.exe``) and script path
-into their Task Scheduler XML. If the code install is deleted or moved — e.g.
-``rmdir ~/pipx`` wipes the venv, or the repo clone is relocated — the tasks stay
-registered but their interpreter/script no longer exists. They fire on schedule
-and fail silently: ``LastTaskResult`` goes non-zero and the background governor
-(``AgentOS_CognitiveLoop``) never resurrects, because self-heal can restart a
-crashed loop but not a deleted interpreter.
+m3 installs its background work as OS-native scheduled jobs whose definitions
+bake an ABSOLUTE interpreter path (``…/.venv/…/python``) and script path:
 
-Nothing surfaces this today: ``installer._path_is_stale`` only covers MCP-config
+  * **Windows** — ``schtasks`` tasks ``AgentOS_*`` (XML ``<Command>`` + ``<Arguments>``).
+  * **macOS**   — a launchd agent ``~/Library/LaunchAgents/com.m3memory.cognitiveloop.plist``
+                  (``ProgramArguments[0]`` = interpreter, ``[1]`` = script), plus
+                  ``install_unix_crontab`` entries.
+  * **Linux**   — a ``systemd --user`` unit ``~/.config/systemd/user/m3-cognitive-loop.service``
+                  (``ExecStart=<interp> <script> …``), plus crontab entries.
+
+If the code install is deleted or moved (e.g. ``rm -rf ~/.local/pipx`` wipes the
+venv, or the repo clone is relocated), those definitions stay registered but
+point at a path that no longer resolves. The job fires on schedule and fails
+silently: the background governor never resurrects, because self-heal restarts a
+crashed loop but not a missing interpreter.
+
+Nothing else surfaces this: ``installer._path_is_stale`` only covers MCP-config
 paths, and ``governor_probe`` only flags *legacy* (pre-governor) schedules, not
-*dangling* ones.
+*dangling* ones. This probe checks — on ALL THREE OSes (DESIGN §1) — that every
+installed job's interpreter and script still exist on disk, and nags with the
+one-command fix when they don't.
 
-This probe makes the state visible (DESIGN §3 fail-loud): if a registered task
-points at a missing interpreter or script, it nags and prints the one-command
-fix. It is report-only — a broken task is a recoverable state, not a doctor
-failure — so it always returns 0 and never crashes the doctor run.
-
-Windows-only: on macOS/Linux the cognitive loop is a launchd/systemd service and
-the periodic tasks are crontab entries; dangling-detection for those is a
-separate future check. Here we print a one-line "n/a" and return 0.
+Report-only (DESIGN §3): always returns 0 and never crashes the doctor — a
+dangling job is a recoverable state (re-register via ``m3 setup``), not a doctor
+failure. Detection is per-OS backends behind a common ``find_dangling`` shape so
+the check degrades gracefully rather than going blind on 2 of 3 platforms.
 """
 from __future__ import annotations
 
 import logging
 import os
+import plistlib
+import posixpath
+import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
 
 logger = logging.getLogger("memory.doctor.schedule_probe")
 
-# Task Scheduler XML namespace (all AgentOS_* tasks are registered under it).
+# ── Windows: Task Scheduler ────────────────────────────────────────────────
 _TASK_NS = "{http://schemas.microsoft.com/windows/2004/02/mit/task}"
+_SCHTASKS_NOT_FOUND_RC = 1  # schtasks /Query rc when the named task doesn't exist
 
-# schtasks /Query returns this rc when the named task does not exist. A
-# not-installed task is NOT dangling (that's "never set up" — a different,
-# silent state), so we distinguish it from a real query failure.
-_SCHTASKS_NOT_FOUND_RC = 1
+# ── Unix: fixed install destinations (mirror install_schedules.py) ─────────
+_LAUNCHD_PLIST = "~/Library/LaunchAgents/com.m3memory.cognitiveloop.plist"
+_SYSTEMD_UNIT = "~/.config/systemd/user/m3-cognitive-loop.service"
 
+
+# A dangling record is a dict: {job, interpreter, script, missing:[...]}. `job`
+# is a human label (task name / plist label / unit name / crontab line-N).
+
+
+def _flag_missing(job: str, interpreter: str | None, script: str | None) -> dict | None:
+    """Return a dangling record iff the interpreter or a declared script is
+    missing on disk; else None. Shared by every backend so the 'what counts as
+    dangling' rule lives in exactly one place."""
+    missing: list[str] = []
+    if not interpreter or not os.path.exists(interpreter):
+        missing.append("interpreter")
+    if script and not os.path.exists(script):  # only flag a script the job declares
+        missing.append("script")
+    if not missing:
+        return None
+    return {"job": job, "interpreter": interpreter, "script": script, "missing": missing}
+
+
+# ── Windows backend ────────────────────────────────────────────────────────
 
 def _expected_task_names(m3_memory_root: str) -> list[str]:
-    """The AgentOS_* task names this install would register. Sourced from
+    """AgentOS_* task names this install registers — sourced from
     install_schedules.get_schedule_specs so the names stay single-sourced."""
     bin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if bin_dir not in sys.path:
@@ -54,96 +82,196 @@ def _expected_task_names(m3_memory_root: str) -> list[str]:
 
 
 def _query_task_xml(name: str) -> str | None:
-    """Return the Task Scheduler XML for ``name``, or None if the task is not
-    installed. Raises on an unexpected schtasks failure (caught by run())."""
+    """Task Scheduler XML for ``name``, or None if not installed. Raises on an
+    unexpected schtasks failure (caught by the backend)."""
     proc = subprocess.run(
-        ["schtasks", "/Query", "/TN", name, "/XML"],
-        capture_output=True,
-        text=True,
+        ["schtasks", "/Query", "/TN", name, "/XML"], capture_output=True, text=True
     )
     if proc.returncode != 0:
-        # Task-not-found is the common, benign case; anything else is a real
-        # failure we let bubble so run() can report "could not query".
         stderr = (proc.stderr or "").upper()
         if proc.returncode == _SCHTASKS_NOT_FOUND_RC or "ERROR:" in stderr:
-            return None
+            return None  # not-installed is benign, not dangling
         raise RuntimeError(f"schtasks /Query {name} failed (rc={proc.returncode}): {proc.stderr.strip()}")
     return proc.stdout
 
 
-def _parse_action_paths(task_xml: str) -> tuple[str | None, str | None]:
-    """Extract (interpreter_path, script_path) from a task's XML.
-
-    interpreter = <Command> of the first <Exec> action.
-    script      = first <Arguments> token (quotes stripped). None if absent.
-    """
+def _parse_exec_paths(task_xml: str) -> tuple[str | None, str | None]:
+    """(interpreter, script) from a task's <Exec>. <Command> may be quoted;
+    the first <Arguments> token is the script (quotes stripped)."""
     root = ET.fromstring(task_xml)
     exec_el = root.find(f".//{_TASK_NS}Actions/{_TASK_NS}Exec")
     if exec_el is None:
         return None, None
     cmd_el = exec_el.find(f"{_TASK_NS}Command")
-    # <Command> may be quoted (schtasks registers some tasks with a quoted
-    # interpreter path). Strip surrounding quotes so os.path.exists() sees the
-    # real path — an unstripped '"…pythonw.exe"' is a false "missing" positive.
     interpreter = cmd_el.text.strip().strip('"') if cmd_el is not None and cmd_el.text else None
-
     args_el = exec_el.find(f"{_TASK_NS}Arguments")
     script = None
-    if args_el is not None and args_el.text:
-        first = args_el.text.strip().split(" ")[0] if args_el.text.strip() else ""
-        script = first.strip('"') or None
+    if args_el is not None and args_el.text and args_el.text.strip():
+        script = args_el.text.strip().split(" ")[0].strip('"') or None
     return interpreter, script
 
 
-def find_dangling(m3_memory_root: str) -> list[dict]:
-    """Return one dict per REGISTERED task whose interpreter or script is missing.
-
-    Each dict: {name, interpreter, script, missing: ["interpreter"|"script", ...]}.
-    Not-installed tasks are skipped (not dangling). Query/parse errors for a
-    single task are recorded with missing=["query-error"] rather than aborting
-    the whole probe.
-    """
+def _dangling_windows(m3_memory_root: str) -> list[dict]:
     dangling: list[dict] = []
     for name in _expected_task_names(m3_memory_root):
         try:
             task_xml = _query_task_xml(name)
         except Exception as e:  # noqa: BLE001 — one bad task must not sink the probe
-            dangling.append({"name": name, "interpreter": None, "script": None,
+            dangling.append({"job": name, "interpreter": None, "script": None,
                              "missing": ["query-error"], "error": str(e)})
             continue
         if task_xml is None:
-            continue  # not installed — not dangling
-
-        interpreter, script = _parse_action_paths(task_xml)
-        missing: list[str] = []
-        if not interpreter or not os.path.exists(interpreter):
-            missing.append("interpreter")
-        # Only flag a missing script when the task actually declares one.
-        if script and not os.path.exists(script):
-            missing.append("script")
-        if missing:
-            dangling.append({"name": name, "interpreter": interpreter,
-                             "script": script, "missing": missing})
+            continue
+        interpreter, script = _parse_exec_paths(task_xml)
+        rec = _flag_missing(name, interpreter, script)
+        if rec:
+            dangling.append(rec)
     return dangling
 
 
-def run(brief: bool = False) -> int:
-    """Report registered AgentOS_* tasks that point at a missing interpreter or
-    script. Always returns 0 (report-only). Never crashes the doctor."""
-    if sys.platform != "win32":
-        if brief:
-            print("schedules: n/a (Windows-only check)")
-        else:
-            print()
-            print("=== scheduled-task interpreters ===")
-            print("  status   : n/a — this check covers Windows AgentOS_* tasks only.")
-            print("             macOS/Linux use launchd/systemd/crontab (not checked here).")
-        return 0
+# ── macOS backend (launchd plist + crontab) ────────────────────────────────
 
-    # m3_memory_root is the code install root (parent of bin/). The scheduled
-    # tasks were registered against whatever root install_schedules ran under;
-    # here we only need the task NAMES, which are root-independent, so the exact
-    # root value doesn't affect detection — the live XML carries the real paths.
+def _dangling_darwin(m3_memory_root: str) -> list[dict]:
+    dangling: list[dict] = []
+    plist_path = os.path.expanduser(_LAUNCHD_PLIST)
+    if os.path.exists(plist_path):
+        try:
+            with open(plist_path, "rb") as f:
+                data = plistlib.load(f)
+            args = data.get("ProgramArguments", [])
+            interpreter = args[0] if len(args) >= 1 else None
+            script = args[1] if len(args) >= 2 else None
+            label = data.get("Label", "com.m3memory.cognitiveloop")
+            rec = _flag_missing(f"launchd:{label}", interpreter, script)
+            if rec:
+                dangling.append(rec)
+        except Exception as e:  # noqa: BLE001
+            dangling.append({"job": f"launchd:{plist_path}", "interpreter": None,
+                             "script": None, "missing": ["parse-error"], "error": str(e)})
+    dangling.extend(_dangling_crontab())
+    return dangling
+
+
+# ── Linux backend (systemd --user unit + crontab) ──────────────────────────
+
+_EXECSTART_RE = re.compile(r"^\s*ExecStart\s*=\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _parse_execstart(unit_text: str) -> tuple[str | None, str | None]:
+    """(interpreter, script) from a systemd ExecStart= line. systemd allows a
+    leading '-'/'@'/'+' prefix on the command; strip it before splitting."""
+    m = _EXECSTART_RE.search(unit_text)
+    if not m:
+        return None, None
+    cmd = m.group(1).lstrip("-@+!:").strip()
+    toks = cmd.split()
+    interpreter = toks[0] if toks else None
+    script = toks[1] if len(toks) >= 2 else None
+    return interpreter, script
+
+
+def _dangling_linux(m3_memory_root: str) -> list[dict]:
+    dangling: list[dict] = []
+    unit_path = os.path.expanduser(_SYSTEMD_UNIT)
+    if os.path.exists(unit_path):
+        try:
+            with open(unit_path, encoding="utf-8") as f:
+                interpreter, script = _parse_execstart(f.read())
+            rec = _flag_missing("systemd:m3-cognitive-loop.service", interpreter, script)
+            if rec:
+                dangling.append(rec)
+        except Exception as e:  # noqa: BLE001
+            dangling.append({"job": f"systemd:{unit_path}", "interpreter": None,
+                             "script": None, "missing": ["parse-error"], "error": str(e)})
+    dangling.extend(_dangling_crontab())
+    return dangling
+
+
+# ── Shared Unix crontab backend ────────────────────────────────────────────
+
+def _read_crontab() -> str | None:
+    """Current user's crontab text, or None if there is none / crontab absent."""
+    try:
+        proc = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return None  # no crontab binary — nothing scheduled that way
+    if proc.returncode != 0:
+        return None  # "no crontab for user" also returns non-zero
+    return proc.stdout
+
+
+def _dangling_crontab() -> list[dict]:
+    """Flag crontab lines that invoke a now-missing m3 interpreter/script.
+
+    Only inspects lines that reference m3's bin/ scripts or venv python, so a
+    user's unrelated cron jobs are never touched. A cron line is
+    ``<m h dom mon dow> <command…>``; we scan the command tokens for the first
+    absolute path that looks like m3's interpreter or a bin/ script.
+    """
+    text = _read_crontab()
+    if not text:
+        return []
+    dangling: list[dict] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Consider only m3-OWNED lines, so a user's unrelated cron jobs are
+        # never touched. m3's cron entries either invoke the m3 venv python
+        # (…/.venv/bin/python …/bin/<script>.py) or the pg_sync.sh wrapper — a
+        # generic "*.sh under some bin/" gate would wrongly catch /usr/bin/*.sh.
+        is_venv_python = re.search(r"/\.venv/(bin|Scripts)/python", line)
+        is_pg_sync = re.search(r"/bin/pg_sync\.sh\b", line)
+        if not (is_venv_python or is_pg_sync):
+            continue
+        toks = line.split()
+        interpreter = None
+        script = None
+        for tok in toks:
+            path = tok.strip('"')
+            # crontab paths are always POSIX — use posixpath.isabs so the parse
+            # is correct even when `m3 doctor` runs on Windows (os.path.isabs
+            # would reject every '/'-rooted token there).
+            if not posixpath.isabs(path):
+                continue
+            if interpreter is None and re.search(r"/\.venv/(bin|Scripts)/python", path):
+                interpreter = path
+            elif script is None and re.search(r"/bin/[\w.-]+\.(py|sh)$", path):
+                script = path
+        # pg_sync.sh lines invoke the .sh directly (no python interpreter token);
+        # treat the .sh itself as the interpreter that must exist.
+        rec = _flag_missing(f"crontab:line-{lineno}", interpreter or script, script if interpreter else None)
+        if rec:
+            dangling.append(rec)
+    return dangling
+
+
+# ── Dispatcher ─────────────────────────────────────────────────────────────
+
+def find_dangling(m3_memory_root: str) -> list[dict]:
+    """Return one record per installed background job whose interpreter or
+    script is missing on disk, using the backend for the current OS.
+
+    Not-installed jobs are skipped (not dangling). Query/parse errors for a
+    single job are recorded (missing=["query-error"|"parse-error"]) rather than
+    aborting the whole probe.
+    """
+    if sys.platform == "win32":
+        return _dangling_windows(m3_memory_root)
+    if sys.platform == "darwin":
+        return _dangling_darwin(m3_memory_root)
+    return _dangling_linux(m3_memory_root)  # linux / other posix
+
+
+def _platform_label() -> str:
+    return {"win32": "Windows Task Scheduler", "darwin": "launchd + crontab"}.get(
+        sys.platform, "systemd --user + crontab"
+    )
+
+
+def run(brief: bool = False) -> int:
+    """Report installed background jobs that point at a missing interpreter or
+    script. Always returns 0 (report-only). Never crashes the doctor."""
     m3_memory_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
     try:
@@ -153,42 +281,44 @@ def run(brief: bool = False) -> int:
             print("schedules: unknown (probe failed)")
         else:
             print()
-            print("=== scheduled-task interpreters ===")
+            print("=== scheduled-job interpreters ===")
             print(f"  status   : could not run schedule probe: {type(e).__name__}: {e}")
         return 0
 
     if brief:
         if dangling:
-            print(f"⚠️  schedules: {len(dangling)} dangling task(s); run `m3 setup`")
+            print(f"⚠️  schedules: {len(dangling)} dangling job(s); run `m3 setup`")
         else:
-            print("✅ schedules: OK (registered tasks resolve to a real interpreter)")
+            print("✅ schedules: OK (installed jobs resolve to a real interpreter)")
         return 0
 
     print()
-    print("=== scheduled-task interpreters ===")
+    print("=== scheduled-job interpreters ===")
+    print(f"  backend  : {_platform_label()}")
     if not dangling:
-        print("  status   : OK — every registered AgentOS_* task points at an")
+        print("  status   : OK — every installed background job points at an")
         print("             interpreter and script that still exist on disk.")
         return 0
 
-    print(f"  status   : NAG — {len(dangling)} registered task(s) point at a missing")
+    print(f"  status   : NAG — {len(dangling)} installed job(s) point at a missing")
     print("             interpreter/script. They fire on schedule but cannot launch:")
     for d in dangling:
-        if "query-error" in d["missing"]:
-            print(f"             - {d['name']} → could not query: {d.get('error', '')}")
+        err = d.get("missing", [])
+        if "query-error" in err or "parse-error" in err:
+            print(f"             - {d['job']} → could not read: {d.get('error', '')}")
             continue
         bits = []
-        if "interpreter" in d["missing"]:
+        if "interpreter" in err:
             bits.append(f"interpreter {d['interpreter']!r} (missing)")
-        if "script" in d["missing"]:
+        if "script" in err:
             bits.append(f"script {d['script']!r} (missing)")
-        print(f"             - {d['name']} → " + "; ".join(bits))
+        print(f"             - {d['job']} → " + "; ".join(bits))
     print()
     print("  why      : the code install moved or was deleted (e.g. the venv/pipx")
-    print("             dir was removed). The task stays registered but its baked-in")
+    print("             dir was removed). The job stays registered but its baked-in")
     print("             absolute path no longer resolves, so the run fails silently —")
     print("             the background governor never comes back until re-registered.")
     print()
-    print("  fix      : re-register the tasks against the current install:")
+    print("  fix      : re-register the jobs against the current install:")
     print("               m3 setup")
     return 0

--- a/bin/memory_doctor.py
+++ b/bin/memory_doctor.py
@@ -67,6 +67,10 @@ def main() -> int:
         help="Skip the governor scheduled-task migration check.",
     )
     parser.add_argument(
+        "--skip-schedule", action="store_true",
+        help="Skip the dangling scheduled-task interpreter check.",
+    )
+    parser.add_argument(
         "--verbose", action="store_true",
         help="Show the full detail (DB-repair steps + each probe's expanded "
              "report + model-load logs). Default is a compact one-line-per-check "
@@ -137,6 +141,13 @@ def main() -> int:
         # supported state, so this never bumps the exit code — it nags and
         # prints the fix command when the governor should own scheduled work.
         governor_probe.run(brief=brief)
+
+    if not args.skip_schedule:
+        from doctor import schedule_probe
+        # Report-only: a task pointing at a deleted interpreter is a recoverable
+        # state (re-register via `m3 setup`), so this never bumps the exit code —
+        # it nags and prints the fix when a registered AgentOS_* task is dangling.
+        schedule_probe.run(brief=brief)
 
     # On a failure in brief mode, point the user at the full detail (§3: an
     # error should tell you how to see more, not dead-end).

--- a/tests/test_doctor_schedule_probe.py
+++ b/tests/test_doctor_schedule_probe.py
@@ -1,8 +1,14 @@
-"""Tests for the doctor dangling-scheduled-task probe (bin/doctor/schedule_probe.py).
+"""Tests for the doctor dangling-scheduled-job probe (bin/doctor/schedule_probe.py).
 
-The schtasks query and on-disk path checks are mocked so the tests are
-deterministic across OSes and never touch the real host scheduler or filesystem.
-The probe is report-only: every path must return rc 0 and never raise.
+All OS scheduler access (schtasks XML, launchd plist, systemd unit, crontab) is
+mocked so the tests are deterministic across OSes and never touch the real host
+scheduler or filesystem (DESIGN §3: a test that only passes because a live
+service is reachable is not hermetic). The probe is report-only: every path must
+return rc 0 and never raise.
+
+Cross-platform coverage (DESIGN §1) — the dangling failure exists on all three
+OSes, so each backend is exercised: Windows (schtasks), macOS (launchd plist +
+crontab), Linux (systemd unit + crontab).
 """
 from __future__ import annotations
 
@@ -16,207 +22,268 @@ from doctor import schedule_probe  # noqa: E402
 _NS = "http://schemas.microsoft.com/windows/2004/02/mit/task"
 
 
+# ===========================================================================
+# Windows backend — schtasks XML
+# ===========================================================================
+
 def _task_xml(interpreter: str, script: str, extra_args: str = '"--flag"') -> str:
-    """Minimal but faithful AgentOS-style task XML (matches the real namespace,
-    <Exec><Command>/<Arguments> shape, and quoted-arg convention)."""
     args = f'"{script}" {extra_args}'.strip()
     return (
         f'<?xml version="1.0" encoding="UTF-16"?>'
         f'<Task version="1.2" xmlns="{_NS}">'
         f'<Actions Context="Author"><Exec>'
-        f'<Command>{interpreter}</Command>'
-        f'<Arguments>{args}</Arguments>'
+        f'<Command>{interpreter}</Command><Arguments>{args}</Arguments>'
         f'</Exec></Actions></Task>'
     )
 
 
-# ---------------------------------------------------------------------------
-# _parse_action_paths
-# ---------------------------------------------------------------------------
-
-def test_parse_action_paths_extracts_interpreter_and_script():
-    xml = _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py")
-    interpreter, script = schedule_probe._parse_action_paths(xml)
-    assert interpreter == r"C:\venv\pythonw.exe"
-    assert script == r"C:\repo\bin\loop.py"  # surrounding quotes stripped
+def test_win_parse_extracts_interpreter_and_script():
+    interp, script = schedule_probe._parse_exec_paths(
+        _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"))
+    assert interp == r"C:\venv\pythonw.exe"
+    assert script == r"C:\repo\bin\loop.py"
 
 
-def test_parse_action_paths_strips_quoted_interpreter():
-    # schtasks registers some tasks (e.g. AgentOS_SecretRotator) with a QUOTED
-    # <Command>. The quotes must be stripped or os.path.exists() false-flags it.
+def test_win_parse_strips_quoted_command():
+    # AgentOS_SecretRotator registers a QUOTED <Command>; quotes must be stripped
+    # or os.path.exists() false-flags it (the live-run bug this test guards).
     xml = (
         f'<Task version="1.2" xmlns="{_NS}"><Actions><Exec>'
         f'<Command>"C:\\venv\\pythonw.exe"</Command>'
         f'<Arguments>"C:\\repo\\bin\\rotate.py"</Arguments>'
         f'</Exec></Actions></Task>'
     )
-    interpreter, script = schedule_probe._parse_action_paths(xml)
-    assert interpreter == r"C:\venv\pythonw.exe"
+    interp, script = schedule_probe._parse_exec_paths(xml)
+    assert interp == r"C:\venv\pythonw.exe"
     assert script == r"C:\repo\bin\rotate.py"
 
 
-def test_parse_action_paths_no_exec_returns_none():
-    xml = f'<?xml version="1.0"?><Task xmlns="{_NS}"><Actions/></Task>'
-    assert schedule_probe._parse_action_paths(xml) == (None, None)
+def test_win_parse_no_exec_returns_none():
+    assert schedule_probe._parse_exec_paths(
+        f'<Task xmlns="{_NS}"><Actions/></Task>') == (None, None)
 
 
-def test_parse_action_paths_no_arguments_gives_none_script():
-    xml = (
-        f'<Task version="1.2" xmlns="{_NS}"><Actions><Exec>'
-        f'<Command>C:\\venv\\pythonw.exe</Command></Exec></Actions></Task>'
-    )
-    interpreter, script = schedule_probe._parse_action_paths(xml)
-    assert interpreter == r"C:\venv\pythonw.exe"
-    assert script is None
-
-
-# ---------------------------------------------------------------------------
-# find_dangling
-# ---------------------------------------------------------------------------
-
-def _stub_names(monkeypatch, names):
+def _win_env(monkeypatch, names, xml_for, exists):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
     monkeypatch.setattr(schedule_probe, "_expected_task_names", lambda root: names)
+    monkeypatch.setattr(schedule_probe, "_query_task_xml", xml_for)
+    monkeypatch.setattr(schedule_probe.os.path, "exists", exists)
 
 
-def test_find_dangling_healthy_when_all_paths_exist(monkeypatch):
-    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
-    monkeypatch.setattr(
-        schedule_probe, "_query_task_xml",
-        lambda name: _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"),
-    )
-    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: True)
+def test_win_healthy_when_all_paths_exist(monkeypatch):
+    _win_env(monkeypatch, ["AgentOS_CognitiveLoop"],
+             lambda n: _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"),
+             lambda p: True)
     assert schedule_probe.find_dangling("root") == []
 
 
-def test_find_dangling_flags_missing_interpreter(monkeypatch):
-    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
-    interp = r"C:\deleted-pipx\pythonw.exe"
-    script = r"C:\repo\bin\loop.py"
-    monkeypatch.setattr(schedule_probe, "_query_task_xml",
-                        lambda name: _task_xml(interp, script))
-    # Only the script exists; the interpreter was wiped with the venv.
-    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: p == script)
-
-    result = schedule_probe.find_dangling("root")
-    assert len(result) == 1
-    d = result[0]
-    assert d["name"] == "AgentOS_CognitiveLoop"
-    assert d["missing"] == ["interpreter"]
-    assert d["interpreter"] == interp
+def test_win_flags_missing_interpreter(monkeypatch):
+    interp, script = r"C:\gone\pythonw.exe", r"C:\repo\bin\loop.py"
+    _win_env(monkeypatch, ["AgentOS_CognitiveLoop"],
+             lambda n: _task_xml(interp, script), lambda p: p == script)
+    d = schedule_probe.find_dangling("root")
+    assert d[0]["job"] == "AgentOS_CognitiveLoop"
+    assert d[0]["missing"] == ["interpreter"]
 
 
-def test_find_dangling_flags_missing_script(monkeypatch):
-    _stub_names(monkeypatch, ["AgentOS_HourlySync"])
-    interp = r"C:\venv\pythonw.exe"
-    script = r"C:\moved-repo\bin\sync_all.py"
-    monkeypatch.setattr(schedule_probe, "_query_task_xml",
-                        lambda name: _task_xml(interp, script))
-    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: p == interp)
-
-    result = schedule_probe.find_dangling("root")
-    assert result[0]["missing"] == ["script"]
-
-
-def test_find_dangling_flags_both_missing(monkeypatch):
-    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
-    monkeypatch.setattr(schedule_probe, "_query_task_xml",
-                        lambda name: _task_xml(r"C:\gone\pythonw.exe", r"C:\gone\loop.py"))
-    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: False)
-    assert schedule_probe.find_dangling("root")[0]["missing"] == ["interpreter", "script"]
-
-
-def test_find_dangling_skips_not_installed_tasks(monkeypatch):
-    # A task that isn't installed (query returns None) is NOT dangling.
-    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop", "AgentOS_HourlySync"])
-    monkeypatch.setattr(
-        schedule_probe, "_query_task_xml",
-        lambda name: None if name == "AgentOS_HourlySync"
-        else _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"),
-    )
-    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: True)
-    # HourlySync absent -> skipped; CognitiveLoop healthy -> nothing dangling.
+def test_win_skips_not_installed(monkeypatch):
+    _win_env(monkeypatch, ["AgentOS_CognitiveLoop", "AgentOS_HourlySync"],
+             lambda n: None if n == "AgentOS_HourlySync"
+             else _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"),
+             lambda p: True)
     assert schedule_probe.find_dangling("root") == []
 
 
-def test_find_dangling_query_error_is_recorded_not_raised(monkeypatch):
-    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
-
-    def _boom(name):
+def test_win_query_error_recorded_not_raised(monkeypatch):
+    def _boom(n):
         raise RuntimeError("schtasks blew up")
+    _win_env(monkeypatch, ["AgentOS_CognitiveLoop"], _boom, lambda p: True)
+    d = schedule_probe.find_dangling("root")
+    assert d[0]["missing"] == ["query-error"]
+    assert "schtasks blew up" in d[0]["error"]
 
-    monkeypatch.setattr(schedule_probe, "_query_task_xml", _boom)
-    result = schedule_probe.find_dangling("root")
-    assert result[0]["missing"] == ["query-error"]
-    assert "schtasks blew up" in result[0]["error"]
+
+# ===========================================================================
+# macOS backend — launchd plist
+# ===========================================================================
+
+def _write_plist(path, interpreter, script):
+    import plistlib
+    with open(path, "wb") as f:
+        plistlib.dump({
+            "Label": "com.m3memory.cognitiveloop",
+            "ProgramArguments": [interpreter, script, "--interval", "300"],
+        }, f)
 
 
-# ---------------------------------------------------------------------------
-# run()  — always rc 0, report-only
-# ---------------------------------------------------------------------------
+def _darwin_env(monkeypatch, plist_path):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "darwin")
+    monkeypatch.setattr(schedule_probe, "_LAUNCHD_PLIST", plist_path)
+    monkeypatch.setattr(schedule_probe, "_read_crontab", lambda: None)  # isolate plist
 
-def test_run_non_windows_is_na(monkeypatch, capsys):
+
+def test_darwin_healthy(tmp_path, monkeypatch):
+    interp = tmp_path / "python3"; interp.write_text("")
+    script = tmp_path / "loop.py"; script.write_text("")
+    plist = tmp_path / "agent.plist"
+    _write_plist(plist, str(interp), str(script))
+    _darwin_env(monkeypatch, str(plist))
+    assert schedule_probe.find_dangling("root") == []
+
+
+def test_darwin_flags_missing_interpreter(tmp_path, monkeypatch):
+    script = tmp_path / "loop.py"; script.write_text("")
+    plist = tmp_path / "agent.plist"
+    _write_plist(plist, str(tmp_path / "deleted-venv" / "python3"), str(script))
+    _darwin_env(monkeypatch, str(plist))
+    d = schedule_probe.find_dangling("root")
+    assert d[0]["job"] == "launchd:com.m3memory.cognitiveloop"
+    assert d[0]["missing"] == ["interpreter"]
+
+
+def test_darwin_no_plist_is_not_dangling(tmp_path, monkeypatch):
+    _darwin_env(monkeypatch, str(tmp_path / "nonexistent.plist"))
+    assert schedule_probe.find_dangling("root") == []
+
+
+# ===========================================================================
+# Linux backend — systemd unit
+# ===========================================================================
+
+_UNIT_TMPL = (
+    "[Service]\nType=simple\n"
+    "ExecStart={interp} {script} --interval 300 --log-file /x/y.log\n"
+    "Restart=always\n"
+)
+
+
+def _linux_env(monkeypatch, unit_path):
     monkeypatch.setattr(schedule_probe.sys, "platform", "linux")
-    assert schedule_probe.run() == 0
-    assert "n/a" in capsys.readouterr().out.lower()
+    monkeypatch.setattr(schedule_probe, "_SYSTEMD_UNIT", unit_path)
+    monkeypatch.setattr(schedule_probe, "_read_crontab", lambda: None)  # isolate unit
 
+
+def test_linux_parse_execstart_strips_prefix():
+    interp, script = schedule_probe._parse_execstart(
+        "[Service]\nExecStart=-/opt/venv/bin/python /opt/m3/bin/loop.py --interval 300\n")
+    assert interp == "/opt/venv/bin/python"   # leading '-' prefix stripped
+    assert script == "/opt/m3/bin/loop.py"
+
+
+def test_linux_healthy(tmp_path, monkeypatch):
+    interp = tmp_path / "python"; interp.write_text("")
+    script = tmp_path / "loop.py"; script.write_text("")
+    unit = tmp_path / "m3.service"
+    unit.write_text(_UNIT_TMPL.format(interp=interp, script=script))
+    _linux_env(monkeypatch, str(unit))
+    assert schedule_probe.find_dangling("root") == []
+
+
+def test_linux_flags_missing_script(tmp_path, monkeypatch):
+    interp = tmp_path / "python"; interp.write_text("")
+    unit = tmp_path / "m3.service"
+    unit.write_text(_UNIT_TMPL.format(interp=interp, script=tmp_path / "moved" / "loop.py"))
+    _linux_env(monkeypatch, str(unit))
+    d = schedule_probe.find_dangling("root")
+    assert d[0]["job"] == "systemd:m3-cognitive-loop.service"
+    assert d[0]["missing"] == ["script"]
+
+
+def test_linux_no_unit_is_not_dangling(tmp_path, monkeypatch):
+    _linux_env(monkeypatch, str(tmp_path / "nonexistent.service"))
+    assert schedule_probe.find_dangling("root") == []
+
+
+# ===========================================================================
+# Shared crontab backend (macOS + Linux)
+# ===========================================================================
+
+def test_crontab_flags_missing_m3_python(monkeypatch):
+    cron = ("# m3\n"
+            "*/30 * * * * /opt/m3/.venv/bin/python /opt/m3/bin/sweep.py --batch 256\n"
+            "0 9 * * * /usr/bin/backup.sh\n")  # unrelated line — must be ignored
+    monkeypatch.setattr(schedule_probe, "_read_crontab", lambda: cron)
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: False)
+    d = schedule_probe._dangling_crontab()
+    assert len(d) == 1                       # only the m3 line, not backup.sh
+    assert d[0]["job"] == "crontab:line-2"
+
+
+def test_crontab_ignores_unrelated_jobs(monkeypatch):
+    monkeypatch.setattr(schedule_probe, "_read_crontab",
+                        lambda: "0 9 * * * /usr/bin/rsync -a /a /b\n")
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: False)
+    assert schedule_probe._dangling_crontab() == []
+
+
+def test_crontab_healthy_when_paths_exist(monkeypatch):
+    monkeypatch.setattr(schedule_probe, "_read_crontab",
+                        lambda: "0 3 * * * /opt/m3/.venv/bin/python /opt/m3/bin/maint.py\n")
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: True)
+    assert schedule_probe._dangling_crontab() == []
+
+
+def test_crontab_none_when_no_crontab(monkeypatch):
+    monkeypatch.setattr(schedule_probe, "_read_crontab", lambda: None)
+    assert schedule_probe._dangling_crontab() == []
+
+
+# ===========================================================================
+# run() — always rc 0, report-only, on every OS
+# ===========================================================================
 
 def test_run_ok_when_nothing_dangling(monkeypatch, capsys):
-    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
     monkeypatch.setattr(schedule_probe, "find_dangling", lambda root: [])
     assert schedule_probe.run() == 0
     out = capsys.readouterr().out
-    assert "OK" in out
-    assert "NAG" not in out
+    assert "OK" in out and "NAG" not in out
 
 
 def test_run_nags_with_fix_command(monkeypatch, capsys):
-    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
     monkeypatch.setattr(
         schedule_probe, "find_dangling",
-        lambda root: [{"name": "AgentOS_CognitiveLoop",
-                       "interpreter": r"C:\gone\pythonw.exe",
-                       "script": r"C:\repo\bin\loop.py",
+        lambda root: [{"job": "systemd:m3-cognitive-loop.service",
+                       "interpreter": "/gone/python", "script": "/repo/bin/loop.py",
                        "missing": ["interpreter"]}],
     )
-    rc = schedule_probe.run()
+    assert schedule_probe.run() == 0  # report-only, never fails the doctor run
     out = capsys.readouterr().out
-    assert rc == 0  # report-only, never fails the doctor run
     assert "NAG" in out
-    assert "AgentOS_CognitiveLoop" in out
-    assert "m3 setup" in out               # the fix command
+    assert "systemd:m3-cognitive-loop.service" in out
+    assert "m3 setup" in out
 
 
 def test_run_brief_dangling_one_liner(monkeypatch, capsys):
-    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
     monkeypatch.setattr(
         schedule_probe, "find_dangling",
-        lambda root: [{"name": "AgentOS_CognitiveLoop", "interpreter": None,
+        lambda root: [{"job": "launchd:com.m3memory.cognitiveloop", "interpreter": None,
                        "script": None, "missing": ["interpreter"]}],
     )
     assert schedule_probe.run(brief=True) == 0
     out = capsys.readouterr().out
-    assert "1 dangling" in out
-    assert "m3 setup" in out
+    assert "1 dangling" in out and "m3 setup" in out
 
 
 def test_run_never_raises_when_find_dangling_throws(monkeypatch, capsys):
-    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
-
     def _boom(root):
         raise RuntimeError("unexpected")
-
     monkeypatch.setattr(schedule_probe, "find_dangling", _boom)
     assert schedule_probe.run() == 0  # swallowed, reported
     assert "could not run schedule probe" in capsys.readouterr().out
 
 
-# ---------------------------------------------------------------------------
-# integration: names come from install_schedules (single-sourced)
-# ---------------------------------------------------------------------------
+def test_run_reports_backend_label(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "linux")
+    monkeypatch.setattr(schedule_probe, "find_dangling", lambda root: [])
+    schedule_probe.run()
+    assert "systemd" in capsys.readouterr().out
+
+
+# ===========================================================================
+# integration: Windows task names single-sourced from install_schedules
+# ===========================================================================
 
 def test_expected_task_names_sourced_from_install_schedules():
     names = schedule_probe._expected_task_names(os.path.expanduser("~/.m3"))
-    # Sanity: the continuous governor loop and a periodic task must be present,
-    # proving we read the real spec rather than a hardcoded list.
     assert "AgentOS_CognitiveLoop" in names
     assert any(n.startswith("AgentOS_") for n in names)

--- a/tests/test_doctor_schedule_probe.py
+++ b/tests/test_doctor_schedule_probe.py
@@ -1,0 +1,222 @@
+"""Tests for the doctor dangling-scheduled-task probe (bin/doctor/schedule_probe.py).
+
+The schtasks query and on-disk path checks are mocked so the tests are
+deterministic across OSes and never touch the real host scheduler or filesystem.
+The probe is report-only: every path must return rc 0 and never raise.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
+
+from doctor import schedule_probe  # noqa: E402
+
+_NS = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+
+
+def _task_xml(interpreter: str, script: str, extra_args: str = '"--flag"') -> str:
+    """Minimal but faithful AgentOS-style task XML (matches the real namespace,
+    <Exec><Command>/<Arguments> shape, and quoted-arg convention)."""
+    args = f'"{script}" {extra_args}'.strip()
+    return (
+        f'<?xml version="1.0" encoding="UTF-16"?>'
+        f'<Task version="1.2" xmlns="{_NS}">'
+        f'<Actions Context="Author"><Exec>'
+        f'<Command>{interpreter}</Command>'
+        f'<Arguments>{args}</Arguments>'
+        f'</Exec></Actions></Task>'
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_action_paths
+# ---------------------------------------------------------------------------
+
+def test_parse_action_paths_extracts_interpreter_and_script():
+    xml = _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py")
+    interpreter, script = schedule_probe._parse_action_paths(xml)
+    assert interpreter == r"C:\venv\pythonw.exe"
+    assert script == r"C:\repo\bin\loop.py"  # surrounding quotes stripped
+
+
+def test_parse_action_paths_strips_quoted_interpreter():
+    # schtasks registers some tasks (e.g. AgentOS_SecretRotator) with a QUOTED
+    # <Command>. The quotes must be stripped or os.path.exists() false-flags it.
+    xml = (
+        f'<Task version="1.2" xmlns="{_NS}"><Actions><Exec>'
+        f'<Command>"C:\\venv\\pythonw.exe"</Command>'
+        f'<Arguments>"C:\\repo\\bin\\rotate.py"</Arguments>'
+        f'</Exec></Actions></Task>'
+    )
+    interpreter, script = schedule_probe._parse_action_paths(xml)
+    assert interpreter == r"C:\venv\pythonw.exe"
+    assert script == r"C:\repo\bin\rotate.py"
+
+
+def test_parse_action_paths_no_exec_returns_none():
+    xml = f'<?xml version="1.0"?><Task xmlns="{_NS}"><Actions/></Task>'
+    assert schedule_probe._parse_action_paths(xml) == (None, None)
+
+
+def test_parse_action_paths_no_arguments_gives_none_script():
+    xml = (
+        f'<Task version="1.2" xmlns="{_NS}"><Actions><Exec>'
+        f'<Command>C:\\venv\\pythonw.exe</Command></Exec></Actions></Task>'
+    )
+    interpreter, script = schedule_probe._parse_action_paths(xml)
+    assert interpreter == r"C:\venv\pythonw.exe"
+    assert script is None
+
+
+# ---------------------------------------------------------------------------
+# find_dangling
+# ---------------------------------------------------------------------------
+
+def _stub_names(monkeypatch, names):
+    monkeypatch.setattr(schedule_probe, "_expected_task_names", lambda root: names)
+
+
+def test_find_dangling_healthy_when_all_paths_exist(monkeypatch):
+    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
+    monkeypatch.setattr(
+        schedule_probe, "_query_task_xml",
+        lambda name: _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"),
+    )
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: True)
+    assert schedule_probe.find_dangling("root") == []
+
+
+def test_find_dangling_flags_missing_interpreter(monkeypatch):
+    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
+    interp = r"C:\deleted-pipx\pythonw.exe"
+    script = r"C:\repo\bin\loop.py"
+    monkeypatch.setattr(schedule_probe, "_query_task_xml",
+                        lambda name: _task_xml(interp, script))
+    # Only the script exists; the interpreter was wiped with the venv.
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: p == script)
+
+    result = schedule_probe.find_dangling("root")
+    assert len(result) == 1
+    d = result[0]
+    assert d["name"] == "AgentOS_CognitiveLoop"
+    assert d["missing"] == ["interpreter"]
+    assert d["interpreter"] == interp
+
+
+def test_find_dangling_flags_missing_script(monkeypatch):
+    _stub_names(monkeypatch, ["AgentOS_HourlySync"])
+    interp = r"C:\venv\pythonw.exe"
+    script = r"C:\moved-repo\bin\sync_all.py"
+    monkeypatch.setattr(schedule_probe, "_query_task_xml",
+                        lambda name: _task_xml(interp, script))
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: p == interp)
+
+    result = schedule_probe.find_dangling("root")
+    assert result[0]["missing"] == ["script"]
+
+
+def test_find_dangling_flags_both_missing(monkeypatch):
+    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
+    monkeypatch.setattr(schedule_probe, "_query_task_xml",
+                        lambda name: _task_xml(r"C:\gone\pythonw.exe", r"C:\gone\loop.py"))
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: False)
+    assert schedule_probe.find_dangling("root")[0]["missing"] == ["interpreter", "script"]
+
+
+def test_find_dangling_skips_not_installed_tasks(monkeypatch):
+    # A task that isn't installed (query returns None) is NOT dangling.
+    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop", "AgentOS_HourlySync"])
+    monkeypatch.setattr(
+        schedule_probe, "_query_task_xml",
+        lambda name: None if name == "AgentOS_HourlySync"
+        else _task_xml(r"C:\venv\pythonw.exe", r"C:\repo\bin\loop.py"),
+    )
+    monkeypatch.setattr(schedule_probe.os.path, "exists", lambda p: True)
+    # HourlySync absent -> skipped; CognitiveLoop healthy -> nothing dangling.
+    assert schedule_probe.find_dangling("root") == []
+
+
+def test_find_dangling_query_error_is_recorded_not_raised(monkeypatch):
+    _stub_names(monkeypatch, ["AgentOS_CognitiveLoop"])
+
+    def _boom(name):
+        raise RuntimeError("schtasks blew up")
+
+    monkeypatch.setattr(schedule_probe, "_query_task_xml", _boom)
+    result = schedule_probe.find_dangling("root")
+    assert result[0]["missing"] == ["query-error"]
+    assert "schtasks blew up" in result[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# run()  — always rc 0, report-only
+# ---------------------------------------------------------------------------
+
+def test_run_non_windows_is_na(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "linux")
+    assert schedule_probe.run() == 0
+    assert "n/a" in capsys.readouterr().out.lower()
+
+
+def test_run_ok_when_nothing_dangling(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
+    monkeypatch.setattr(schedule_probe, "find_dangling", lambda root: [])
+    assert schedule_probe.run() == 0
+    out = capsys.readouterr().out
+    assert "OK" in out
+    assert "NAG" not in out
+
+
+def test_run_nags_with_fix_command(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
+    monkeypatch.setattr(
+        schedule_probe, "find_dangling",
+        lambda root: [{"name": "AgentOS_CognitiveLoop",
+                       "interpreter": r"C:\gone\pythonw.exe",
+                       "script": r"C:\repo\bin\loop.py",
+                       "missing": ["interpreter"]}],
+    )
+    rc = schedule_probe.run()
+    out = capsys.readouterr().out
+    assert rc == 0  # report-only, never fails the doctor run
+    assert "NAG" in out
+    assert "AgentOS_CognitiveLoop" in out
+    assert "m3 setup" in out               # the fix command
+
+
+def test_run_brief_dangling_one_liner(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
+    monkeypatch.setattr(
+        schedule_probe, "find_dangling",
+        lambda root: [{"name": "AgentOS_CognitiveLoop", "interpreter": None,
+                       "script": None, "missing": ["interpreter"]}],
+    )
+    assert schedule_probe.run(brief=True) == 0
+    out = capsys.readouterr().out
+    assert "1 dangling" in out
+    assert "m3 setup" in out
+
+
+def test_run_never_raises_when_find_dangling_throws(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_probe.sys, "platform", "win32")
+
+    def _boom(root):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(schedule_probe, "find_dangling", _boom)
+    assert schedule_probe.run() == 0  # swallowed, reported
+    assert "could not run schedule probe" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# integration: names come from install_schedules (single-sourced)
+# ---------------------------------------------------------------------------
+
+def test_expected_task_names_sourced_from_install_schedules():
+    names = schedule_probe._expected_task_names(os.path.expanduser("~/.m3"))
+    # Sanity: the continuous governor loop and a periodic task must be present,
+    # proving we read the real spec rather than a hardcoded list.
+    assert "AgentOS_CognitiveLoop" in names
+    assert any(n.startswith("AgentOS_") for n in names)


### PR DESCRIPTION
## Problem
m3 installs its background work as OS-native scheduled jobs whose definitions bake an **absolute interpreter + script path**. If the code install is deleted or moved (e.g. `rm -rf ~/.local/pipx` wipes the venv, or the repo clone is relocated), the job stays registered but can't launch — it fails silently and the background governor never resurrects (self-heal restarts a *crashed* loop, not a *missing* interpreter). Nothing surfaced this: `installer._path_is_stale` only covers MCP config, and `governor_probe` only flags *legacy* schedules.

## Fix
A new `bin/doctor/schedule_probe.py`, wired into `m3 doctor` (with `--skip-schedule`), that verifies each installed job's interpreter and script still exist on disk and nags with `m3 setup` when they don't. **Report-only** (always rc 0, never crashes the doctor).

Cross-platform per DESIGN §1 — the failure exists on all three OSes, so each has a backend behind a common `find_dangling` shape:
- **Windows** — `schtasks` XML `<Command>`/`<Arguments>` (quoted `<Command>` stripped — `AgentOS_SecretRotator` registers one).
- **macOS** — `~/Library/LaunchAgents/com.m3memory.cognitiveloop.plist` (`ProgramArguments[0/1]`) + crontab.
- **Linux** — `~/.config/systemd/user/m3-cognitive-loop.service` (`ExecStart=`, systemd `-/@/+` prefix stripped) + crontab.
- **Shared crontab** — only m3-owned lines (venv python or `pg_sync.sh`), so unrelated user cron jobs are never touched.

## Two cross-platform bugs caught by the tests and fixed
- crontab paths are POSIX; `os.path.isabs` rejects `/`-rooted tokens when the doctor runs on Windows → use `posixpath.isabs`.
- the m3-owned gate matched any `*.sh` under `bin/`, wrongly flagging `/usr/bin/backup.sh` → require the m3 venv python or `pg_sync.sh`.

## Tests
24 tests across all three backends + crontab + `run()`, fully hermetic (mocked schtasks/plist/unit/crontab; no real `launchctl`/`systemctl`, per §3). Verified live on Windows against the real tasks (reports OK; earlier flagged the quoted-`<Command>` false positive, now fixed).