### PR TITLE
fix(test): restore memory.* modules in cascade-order fixture (root-cause of zero-lag flake)

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -173,7 +173,9 @@ async def test_doctor_cold_cascade_slo(monkeypatch):
     # instead of getting a fast ECONNREFUSED.
     monkeypatch.setenv("M3_EMBED_FALLBACK_URL", "http://198.51.100.1:8082")
 
-    # Force fresh module so M3_EMBED_FALLBACK_URL is picked up
+    # Force fresh module so M3_EMBED_FALLBACK_URL is picked up. The autouse
+    # _isolate_env fixture snapshots + restores memory.* around every test in
+    # this file, so this eviction does not leak to later tests.
     for mod in list(sys.modules):
         if mod.startswith("memory."):
             del sys.modules[mod]

--- a/tests/test_embed_cascade_order.py
+++ b/tests/test_embed_cascade_order.py
@@ -51,9 +51,18 @@ def _isolate_env(monkeypatch, tmp_path):
     monkeypatch.setenv("M3_SKIP_MIGRATIONS", "1")
     # Force a fresh module load so module-level constants (e.g. _EMBED_GGUF_PATH)
     # and config.m3_core_rs see the env set above.
-    for mod in list(sys.modules):
-        if mod.startswith("memory."):
-            del sys.modules[mod]
+    #
+    # CRITICAL: snapshot and RESTORE the evicted modules on teardown. Evicting
+    # memory.* without restoring corrupts LATER tests — a downstream test that
+    # re-imports memory.embed gets a NEW object, while modules still loaded from
+    # before (memory.write caches `from . import embed as _embed_mod`) keep the
+    # OLD one. A test then patching memory.embed can't reach the object the code
+    # under test dereferences. This is precisely how test_zero_lag_write flaked
+    # under `pytest tests/` (cascade_order sorts before zero_lag). test_doctor's
+    # sibling fixture already does this save/restore; this one silently didn't.
+    saved = {m: sys.modules[m] for m in list(sys.modules) if m.startswith("memory.")}
+    for mod in saved:
+        del sys.modules[mod]
     # Belt-and-suspenders: a sibling test that imported memory.embed earlier in
     # the session may have INITIALIZED and cached the in-process embedder in the
     # module globals (_embedded_embedder / _embedded_embed_checked). Deleting the
@@ -67,6 +76,14 @@ def _isolate_env(monkeypatch, tmp_path):
     embed = importlib.import_module("memory.embed")
     embed._embedded_embedder = None
     embed._embedded_embed_checked = False
+
+    yield
+
+    # Restore: drop the fresh re-imports this test created, then put the
+    # originals back so later tests see a consistent memory.* module graph.
+    for mod in [m for m in sys.modules if m.startswith("memory.")]:
+        del sys.modules[mod]
+    sys.modules.update(saved)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause

Follow-up to #76. That PR made `test_zero_lag_write` *immune* to a module-identity split under `pytest tests/`; this PR fixes the **test that caused the split**.

`tests/test_embed_cascade_order.py::_isolate_env` (autouse) evicted every `memory.*` module from `sys.modules` and re-imported `memory.embed` fresh — **without restoring the originals**. That corrupts later tests:

1. Some earlier test imports `memory.write`, which caches `from . import embed as _embed_mod` → object **e1**.
2. cascade_order's fixture evicts `memory.*` and re-imports `memory.embed` → **e2** now in `sys.modules`; `memory.write` (still loaded) keeps stale **e1**.
3. `test_zero_lag_write` patches `sys.modules['memory.embed']` (e2), but the write path reads `write._embed_mod` (e1) → patch misses → real `fast_embedder_available()` runs → attempts a (failing) embed instead of deferring.

cascade_order sorts before zero_lag alphabetically, matching the CI failure order. Proven in isolation: after evict+reimport, `write._embed_mod is not sys.modules['memory.embed']`.

## Fix

Convert the fixture to `snapshot → evict → yield → restore`, matching the save/restore that `test_doctor.py`'s sibling fixture already does correctly. No production code changes.

The defensive patch added to `test_zero_lag_write` in #76 (patching both `embed_mod` and `write._embed_mod`) is kept as belt-and-suspenders against any future polluter.

## Verification

- Isolated reproduction confirms the split before the fix and its absence after.
- Affected suites green locally (cascade_order, zero_lag, doctor, belief_consolidation, tier2 contract).
- Full `pytest tests/` validated by CI on this PR.