### PR TITLE
fix(governor): warn that legacy-task removal needs an elevated shell up front (2026.7.7.1)

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m3",
-  "version": "2026.7.7.0",
+  "version": "2026.7.7.1",
   "description": "Local-first persistent memory for Antigravity — 101 MCP tools, hybrid search (FTS5 + vector + MMR), bitemporal contradictions, GDPR primitives, chatlog auto-capture, multi-agent handoffs.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m3",
-  "version": "2026.7.7.0",
+  "version": "2026.7.7.1",
   "description": "Local-first persistent memory for Claude Code — 101 MCP tools, hybrid search (FTS5 + vector + MMR), bitemporal contradictions, GDPR primitives, chatlog auto-capture, multi-agent handoffs.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ the policy is forward-going only.
 
 ### Fixed
 
+- **The governor NAG now says up front that removal needs an elevated shell on
+  Windows.** Previously `m3 doctor` said only "run `m3 governor migrate`", and
+  `m3 governor migrate` revealed the privilege requirement *after* failing with
+  "Access is denied" — a runaround. The doctor NAG line (brief and verbose) and
+  the migrate pre-flight now state the Administrator-shell requirement before any
+  delete is attempted, on Windows; the per-failure message is a definite "needs
+  an elevated shell", not a tentative "(insufficient privilege?)".
+
 - **`m3 doctor` no longer shows a scary warning for a perfectly healthy
   shared-embedder setup.** On the shipped-default shared-embedder topology,
   per-process tier-1 is intentionally off (the shared server owns the single GPU

--- a/bin/doctor/governor_probe.py
+++ b/bin/doctor/governor_probe.py
@@ -58,7 +58,14 @@ def run(brief: bool = False) -> int:
 
     if brief:
         if eligible:
-            print(f"⚠️  governor: NAG ({len(eligible)} legacy task(s); run `m3 governor migrate`)")
+            # State the elevation requirement up front on Windows — deleting
+            # scheduled tasks needs an Administrator shell, and without this hint
+            # the user runs `m3 governor migrate`, hits "Access is denied", and
+            # only THEN learns they needed elevation (the runaround we want to
+            # spare them). §3: fail-loud/never-silent applies to the remedy too.
+            _elev = " from an ELEVATED shell" if sys.platform == "win32" else ""
+            print(f"⚠️  governor: NAG ({len(eligible)} legacy task(s); run "
+                  f"`m3 governor migrate`{_elev})")
         else:
             print("✅ governor: OK (no legacy scheduled tasks)")
         return 0
@@ -80,7 +87,12 @@ def run(brief: bool = False) -> int:
     print("             embedding / maintenance can fire mid-session and contend for")
     print("             CPU/GPU/WAL — exactly what the governor exists to prevent.")
     print()
-    print("  fix      : run the migration (removes them with your current privileges):")
+    if sys.platform == "win32":
+        print("  fix      : run the migration FROM AN ELEVATED (Administrator) shell —")
+        print("             deleting scheduled tasks needs admin rights; a normal shell")
+        print("             fails with 'Access is denied':")
+    else:
+        print("  fix      : run the migration (may need sudo / the task owner to remove):")
     print("               m3 governor migrate")
     print("             or via the setup wizard:")
     print("               m3 setup")

--- a/bin/governor_cli.py
+++ b/bin/governor_cli.py
@@ -63,6 +63,15 @@ def cmd_migrate(*, yes: bool) -> int:
     for name in eligible:
         print(f"  - {name}")
 
+    # Tell the user UP FRONT that deletion needs elevation on Windows, before they
+    # confirm — otherwise they say yes, hit "Access is denied", and only then learn
+    # they needed an Administrator shell. Stating it here saves the round trip.
+    if sys.platform == "win32":
+        print("\nNOTE: removing scheduled tasks requires an ELEVATED (Administrator)")
+        print("shell. If this session is not elevated, the deletes below will fail")
+        print("with 'Access is denied' and the exact commands to run as admin will")
+        print("be printed.")
+
     if not yes:
         try:
             ans = input("\nRemove these and let the governor own them? [Y/n] ").strip().lower()
@@ -76,7 +85,9 @@ def cmd_migrate(*, yes: bool) -> int:
     for name in removed:
         print(f"  [OK] removed {name}")
     for name in failed:
-        print(f"  [WARN] could not remove {name} (insufficient privilege?)")
+        _hint = "needs an elevated shell" if sys.platform == "win32" else \
+            "needs sudo / the task owner"
+        print(f"  [WARN] could not remove {name} ({_hint})")
 
     if failed:
         print("\nRun these PRIVILEGED, OS-specific commands to remove the rest")

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.7.7.0",
+  "version": "2026.7.7.1",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.7.7.0"
+version = "2026.7.7.1"
 description = "Local-first Memory Framework for AI Agents · 99.2% LongMemEval-S retrieval @ k=10 · Supports Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · MCP-native and plugins · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first agentic memory — 100+ tools, 89% LongMemEval, hybrid search, GDPR, zero cloud.",
-  "version": "2026.7.7.0",
+  "version": "2026.7.7.1",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.7.7.0",
+      "version": "2026.7.7.1",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"

--- a/tests/test_governor_probe_and_cli.py
+++ b/tests/test_governor_probe_and_cli.py
@@ -42,6 +42,58 @@ def test_probe_nags_with_fix_command(monkeypatch, capsys):
     assert 'schtasks /Delete /TN "AgentOS_HourlySync" /F' in out  # privileged cmd
 
 
+def test_probe_brief_nag_mentions_elevation_on_windows(monkeypatch, capsys):
+    """The brief NAG line (what most users see in `m3 doctor`) must state up front
+    that migration needs an elevated shell on Windows — without it, the user hits
+    'Access is denied' only after running migrate."""
+    monkeypatch.setattr(
+        gm, "detect_scheduled_tasks",
+        lambda: {"eligible": ["AgentOS_HourlySync"], "not_migratable_present": []},
+    )
+    monkeypatch.setattr(governor_probe.sys, "platform", "win32")
+    governor_probe.run(brief=True)
+    out = capsys.readouterr().out
+    assert "NAG" in out
+    assert "ELEVATED" in out
+
+
+def test_probe_brief_nag_no_elevation_note_on_unix(monkeypatch, capsys):
+    """On non-Windows the brief line stays clean (no Windows-only elevation text)."""
+    monkeypatch.setattr(
+        gm, "detect_scheduled_tasks",
+        lambda: {"eligible": ["AgentOS_HourlySync"], "not_migratable_present": []},
+    )
+    monkeypatch.setattr(governor_probe.sys, "platform", "linux")
+    governor_probe.run(brief=True)
+    out = capsys.readouterr().out
+    assert "NAG" in out
+    assert "ELEVATED shell" not in out
+
+
+def test_migrate_warns_about_elevation_before_prompt_on_windows(monkeypatch, capsys):
+    """`m3 governor migrate` must warn about the elevation requirement BEFORE the
+    deletes are attempted (headless mode skips the prompt but still prints it)."""
+    monkeypatch.setattr(
+        gm, "detect_scheduled_tasks",
+        lambda: {"eligible": ["AgentOS_Maintenance"], "not_migratable_present": []},
+    )
+    # simulate a non-elevated Windows session: every remove fails
+    monkeypatch.setattr(
+        gm, "try_remove_scheduled_tasks",
+        lambda names: ([], list(names)),
+    )
+    monkeypatch.setattr(
+        gm, "privileged_removal_commands",
+        lambda names: [f'schtasks /Delete /TN "{n}" /F' for n in names],
+    )
+    monkeypatch.setattr(governor_cli.sys, "platform", "win32")
+    rc = governor_cli.cmd_migrate(yes=True)
+    out = capsys.readouterr().out
+    assert "ELEVATED" in out            # up-front notice
+    assert "needs an elevated shell" in out  # per-failure hint (not a vague guess)
+    assert rc == 1                       # pure permission failure
+
+
 def test_cli_status_returns_zero(monkeypatch, capsys):
     monkeypatch.setattr(
         gm, "detect_scheduled_tasks",


### PR DESCRIPTION
## Problem (UX friction)

Deleting the governor's legacy `AgentOS_*` scheduled tasks requires an Administrator shell on Windows — but the user only discovered this *after* the fact:
- `m3 doctor` said only "run `m3 governor migrate`" (no elevation hint).
- `m3 governor migrate` failed with "Access is denied" before it mentioned elevation, phrasing it as a tentative "(insufficient privilege?)".

So the path was: doctor → run migrate → fail on privilege → *then* learn you need admin. (Hit live while verifying 2026.7.7.0.)

## Fix

- **Doctor governor NAG** (brief + verbose): state the elevated/Administrator-shell requirement on Windows, before the user runs migrate. Brief line now reads `⚠️ governor: NAG (N legacy task(s); run 'm3 governor migrate' from an ELEVATED shell)`.
- **`m3 governor migrate`**: prints an up-front NOTE about the elevation requirement *before* attempting deletes; the per-failure message is now a definite "needs an elevated shell" (Windows) / "needs sudo / the task owner" (Unix), not "(insufficient privilege?)".

Windows-only guidance is `sys.platform`-gated; Unix output stays clean.

## Tests

- brief NAG mentions elevation on Windows, stays clean on Unix;
- migrate prints the up-front notice + definite failure hint and returns 1 on a pure permission failure.

41 governor/doctor tests green; ruff/mypy/drift/version_drift clean. Release 2026.7.7.1.