### PR TITLE
ci(publish): publish to PyPI on version-tag push (release 2026.7.7.2)

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m3",
-  "version": "2026.7.7.1",
+  "version": "2026.7.7.2",
   "description": "Local-first persistent memory for Antigravity — 101 MCP tools, hybrid search (FTS5 + vector + MMR), bitemporal contradictions, GDPR primitives, chatlog auto-capture, multi-agent handoffs.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m3",
-  "version": "2026.7.7.1",
+  "version": "2026.7.7.2",
   "description": "Local-first persistent memory for Claude Code — 101 MCP tools, hybrid search (FTS5 + vector + MMR), bitemporal contradictions, GDPR primitives, chatlog auto-capture, multi-agent handoffs.",
   "keywords": [
     "memory",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,23 @@ name: Publish to PyPI
 # checkov:skip=CKV_GHA_7: dry_run is a constrained choice input used to route
 # between TestPyPI and PyPI; no value flows into build/publish commands beyond
 # an equality check.
-# checkov:skip=CKV2_GHA_1: publish.yml is release-triggered (`on: release`) or
-# manually invoked (`workflow_dispatch`). There is no PR/push trigger whose
-# permissions we could further constrain at the top level. The two publish
-# jobs each declare `permissions: id-token: write` and nothing else (trusted
-# publishing to PyPI/TestPyPI); the build job runs with the default
-# `contents: read` set at the workflow level.
+# checkov:skip=CKV2_GHA_1: publish.yml is triggered by a published release, a
+# version-tag push (`push: tags: v*`), or a manual `workflow_dispatch`. The
+# tag-push trigger is scoped to `v*` tags only (not arbitrary branch pushes).
+# The two publish jobs each declare `permissions: id-token: write` and nothing
+# else (trusted publishing to PyPI/TestPyPI); the build job runs with the
+# default `contents: read` set at the workflow level.
 
 on:
   release:
     types: [published]
+  # Also publish when a version tag is pushed, so `git push origin vX.Y.Z`
+  # ships to PyPI without a separate GitHub Release step. (Historically only
+  # `release: published` fired this, so tag-only pushes silently skipped PyPI —
+  # PyPI drifted several releases behind the tags.)
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -61,7 +68,7 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+    if: github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
     environment:
       name: pypi
       url: https://pypi.org/project/m3-memory/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ the policy is forward-going only.
 
 ### Fixed
 
+- **Version-tag pushes now publish to PyPI automatically.** `publish.yml` fired
+  only on a published GitHub *Release*, so releases pushed as tags (without a
+  GitHub Release) silently skipped PyPI — PyPI drifted several versions behind
+  the tags. The workflow now also triggers on `push: tags: v*` (scoped to version
+  tags), routing to the real-PyPI publish job. Fresh `pip install m3-memory` will
+  no longer lag the tagged releases.
+
 - **The governor NAG now says up front that removal needs an elevated shell on
   Windows.** Previously `m3 doctor` said only "run `m3 governor migrate`", and
   `m3 governor migrate` revealed the privilege requirement *after* failing with

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.7.7.1",
+  "version": "2026.7.7.2",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.7.7.1"
+version = "2026.7.7.2"
 description = "Local-first Memory Framework for AI Agents · 99.2% LongMemEval-S retrieval @ k=10 · Supports Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · MCP-native and plugins · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first agentic memory — 100+ tools, 89% LongMemEval, hybrid search, GDPR, zero cloud.",
-  "version": "2026.7.7.1",
+  "version": "2026.7.7.2",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.7.7.1",
+      "version": "2026.7.7.2",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Problem (real, not cosmetic)

Investigating the "plugin version lag" surfaced a bigger gap: **PyPI is stuck at `2026.7.3.0`** while tags reached `2026.7.7.1`. `publish.yml` triggers `on: release` (a *published GitHub Release*), but releases were shipped as **tag pushes** (`git push origin vX.Y.Z`) without creating a GitHub Release — so every one silently skipped PyPI. The entire shared-embedder hang-proof line (.5.0 → .7.1) never published; a fresh `pip install m3-memory` gets none of it.

## Fix

- Add `push: tags: [v*]` trigger to `publish.yml` (scoped to version tags, not branch pushes).
- Route `push` events to the real-PyPI publish job (`event_name == 'push'`).
- Update the checkov skip comment to describe the new trigger accurately.

This release's own tag push (`v2026.7.7.2`) is the first to auto-publish — verifying the fix end to end.

## Note on the plugin marketplace

Separately confirmed: the Claude Code "marketplace" **is this git repo** (`/plugin marketplace add skynetcmd/m3-memory`), so the plugin manifests are already "published" the moment they merge to main. The `plugin: 2026.7.4.0` doctor line is a purely *local* cache lag, cleared by `/plugin marketplace update skynetcmd` — no publish step needed.

YAML validated; drift + version_drift clean. Release 2026.7.7.2.