### PR TITLE
fix(doctor): pinpoint M3_EMBED_GGUF leak to file:line and stop the --fix dead-end loop

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m3",
-  "version": "2026.7.7.2",
+  "version": "2026.7.7.3",
   "description": "Local-first persistent memory for Antigravity — 101 MCP tools, hybrid search (FTS5 + vector + MMR), bitemporal contradictions, GDPR primitives, chatlog auto-capture, multi-agent handoffs.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m3",
-  "version": "2026.7.7.2",
+  "version": "2026.7.7.3",
   "description": "Local-first persistent memory for Claude Code — 101 MCP tools, hybrid search (FTS5 + vector + MMR), bitemporal contradictions, GDPR primitives, chatlog auto-capture, multi-agent handoffs.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ the policy is forward-going only.
 
 ### Fixed
 
+- **`m3 doctor` now pinpoints an `M3_EMBED_GGUF` leak and stops sending you in a
+  circle.** When the shared-embedder probe found `M3_EMBED_GGUF` set in the
+  environment (the per-process-GPU hang footgun), it localized only to the
+  category "shell rc" and — for the one thing `--fix` provably cannot remove (a
+  persistent User/shell-rc var) — the summary still said "run `m3 doctor --fix`",
+  so a user ran `--fix` and was told to run `--fix` again: a dead-end loop. Now
+  the probe (1) greps the shell rc files / reads the Windows User-env registry
+  and reports the exact **`file:line`**, (2) prints the precise copy-pasteable
+  removal command under **`--verbose`** (not only under `--fix`, which had merely
+  *claimed* it), and (3) when the only remaining issue is a manual-only env leak,
+  guides to the manual step and does **not** re-emit "run `--fix`". Settings.json
+  env blocks are still auto-scrubbed by `--fix` as before.
+
 - **Version-tag pushes now publish to PyPI automatically.** `publish.yml` fired
   only on a published GitHub *Release*, so releases pushed as tags (without a
   GitHub Release) silently skipped PyPI — PyPI drifted several versions behind

--- a/bin/doctor/shared_embedder_probe.py
+++ b/bin/doctor/shared_embedder_probe.py
@@ -74,14 +74,107 @@ def _known_agent_settings() -> "list[tuple[str, str]]":
     ]
 
 
+def _shell_rc_candidates() -> "list[str]":
+    """Standard POSIX shell rc / profile files that commonly `export` env vars.
+    Order matters only for reporting; we scan all that exist."""
+    home = os.path.expanduser("~")
+    j = os.path.join
+    return [j(home, name) for name in (
+        ".zshrc", ".zshenv", ".zprofile", ".bashrc", ".bash_profile", ".profile",
+    )]
+
+
+def _find_env_in_shell_rc(var: str) -> "list[str]":
+    """Return 'path:line' for every uncommented `export VAR=`/`VAR=` occurrence
+    of `var` in the user's shell rc files. Localizes the category 'shell rc' down
+    to the exact file:line the user must edit. Empty when nothing matches."""
+    hits: list[str] = []
+    needle = f"{var}="
+    for path in _shell_rc_candidates():
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                for lineno, raw in enumerate(f, start=1):
+                    stripped = raw.lstrip()
+                    if stripped.startswith("#"):
+                        continue  # commented-out — not live
+                    # match `VAR=` or `export VAR=` (VAR at a word boundary)
+                    body = stripped[len("export "):].lstrip() if stripped.startswith("export ") else stripped
+                    if body.startswith(needle):
+                        hits.append(f"{path}:{lineno}")
+        except Exception:  # noqa: BLE001 — an unreadable rc file just yields no hit
+            continue
+    return hits
+
+
+def _windows_user_env_has(var: str) -> bool:
+    """True if `var` is set in the Windows *User* environment (persists across
+    shells / MCP restarts), read from the registry so it reflects the persisted
+    value, not just this process's inherited copy."""
+    if sys.platform != "win32":
+        return False
+    try:
+        import winreg
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment") as key:
+            value, _ = winreg.QueryValueEx(key, var)
+            return bool((value or "").strip())
+    except FileNotFoundError:
+        return False
+    except Exception:  # noqa: BLE001 — registry unreadable: fall back to process-env signal
+        return False
+
+
+def _manual_env_leak_remains() -> bool:
+    """True if a MANUAL-ONLY M3_EMBED_GGUF leak is present — a process/User/shell
+    var that --fix provably cannot remove (as opposed to a settings.json env block,
+    which it can auto-scrub). This is the signal that lets the doctor print manual
+    instructions and STOP, instead of looping 'run --fix' forever."""
+    return bool((os.environ.get("M3_EMBED_GGUF") or "").strip()) or \
+        _windows_user_env_has("M3_EMBED_GGUF") or \
+        bool(_find_env_in_shell_rc("M3_EMBED_GGUF"))
+
+
+def _manual_removal_command() -> "list[str]":
+    """The exact, copy-pasteable command(s) to remove a persistent M3_EMBED_GGUF
+    from the User/shell environment — the ONE thing --fix cannot do for the user.
+    Localized to file:line where we can find it. Returned as printable lines so
+    BOTH --verbose and --fix render identical guidance (single source of truth)."""
+    lines: list[str] = []
+    if sys.platform == "win32":
+        lines.append("Remove it from the Windows User environment (persists across shells):")
+        lines.append("  PowerShell:  [Environment]::SetEnvironmentVariable('M3_EMBED_GGUF', $null, 'User')")
+        lines.append("Then open a NEW terminal and restart the MCP client.")
+    else:
+        rc_hits = _find_env_in_shell_rc("M3_EMBED_GGUF")
+        if rc_hits:
+            lines.append("Remove the M3_EMBED_GGUF export at:")
+            for hit in rc_hits:
+                lines.append(f"  {hit}")
+            lines.append("e.g.  sed -i.bak '/M3_EMBED_GGUF/d' <file>   (or delete the line by hand),")
+        else:
+            lines.append("Remove the `export M3_EMBED_GGUF=...` line from your shell rc")
+            lines.append("  (~/.zshrc / ~/.zshenv / ~/.bashrc / ~/.profile),")
+        lines.append("then start a NEW shell and restart the MCP client.")
+    return lines
+
+
 def _detect_inproc_env_leak() -> "list[str]":
     """Locations where M3_EMBED_GGUF is set — each forces a per-process CUDA
     embedder (the hang footgun) when shared mode is on. Returns human-readable
-    location strings (empty when clean). Checks the process env AND every client
-    settings file's m3 MCP-server env block."""
+    location strings (empty when clean). Checks the process env (localized to the
+    exact shell-rc file:line / Windows User-env key where possible) AND every
+    client settings file's m3 MCP-server env block."""
     hits: list[str] = []
-    if (os.environ.get("M3_EMBED_GGUF") or "").strip():
-        hits.append("process env (M3_EMBED_GGUF) — persists via User env / shell rc")
+    if (os.environ.get("M3_EMBED_GGUF") or "").strip() or _windows_user_env_has("M3_EMBED_GGUF"):
+        rc_hits = _find_env_in_shell_rc("M3_EMBED_GGUF")
+        if rc_hits:
+            for hit in rc_hits:
+                hits.append(f"shell rc — {hit}")
+        elif _windows_user_env_has("M3_EMBED_GGUF"):
+            hits.append("Windows User env (HKCU\\Environment\\M3_EMBED_GGUF)")
+        else:
+            hits.append("process env (M3_EMBED_GGUF) — persists via User env / shell rc")
     for label, path in _known_agent_settings():
         if not os.path.exists(path):
             continue
@@ -135,18 +228,14 @@ def _fix_scrub_env_leak() -> tuple[bool, bool]:
                 settings_scrubbed = True
             except Exception as e:  # noqa: BLE001
                 print(f"  [fix] could not rewrite {path}: {e}")
-    process_env_remains = bool((os.environ.get("M3_EMBED_GGUF") or "").strip())
+    process_env_remains = bool((os.environ.get("M3_EMBED_GGUF") or "").strip()) or \
+        _windows_user_env_has("M3_EMBED_GGUF")
     if process_env_remains:
         print("  [fix] M3_EMBED_GGUF is ALSO set in the process/User env — that cannot")
         print("        be removed from here. Remove it so new shells + MCP servers stop")
         print("        inheriting it:")
-        if sys.platform == "win32":
-            print("          PowerShell:  [Environment]::SetEnvironmentVariable("
-                  "'M3_EMBED_GGUF', $null, 'User')")
-        else:
-            print("          remove the `export M3_EMBED_GGUF=...` line from your shell rc "
-                  "(~/.zshrc / ~/.bashrc / ~/.profile)")
-        print("        then start a NEW shell and restart the MCP client.")
+        for line in _manual_removal_command():
+            print(f"        {line}")
     return settings_scrubbed, process_env_remains
 
 
@@ -355,9 +444,18 @@ def run(brief: bool = False, fix: bool = False) -> int:
 
     healthy = not problems
 
+    # Manual-only state: the sole remaining issue is an M3_EMBED_GGUF leak that
+    # --fix provably cannot remove (process/User/shell-rc var). Re-emitting
+    # "run --fix" here is the dead-end loop — the user runs --fix and is told to
+    # run --fix. When this is the case, guide to the actual manual step instead.
+    manual_only = (problems == ["inproc-env-leak"]) and _manual_env_leak_remains()
+
     if brief:
         if healthy:
             print("✅ shared-embedder: OK (config + server + keep-alive)")
+        elif manual_only:
+            print("⚠️  shared-embedder: M3_EMBED_GGUF set in your environment — "
+                  "remove it by hand (`m3 doctor --verbose` shows the exact command).")
         else:
             print(f"⚠️  shared-embedder: {len(problems)} issue(s) — run `m3 doctor --fix`")
         return 0 if healthy else 1
@@ -403,14 +501,27 @@ def run(brief: bool = False, fix: bool = False) -> int:
         print("             (the read/write HANG risk). Locations:")
         for loc in leak_locations:
             print(f"               - {loc}")
-        print("             fix: `m3 doctor --fix` scrubs the settings blocks (backs")
-        print("                  them up). A persistent User/shell env var must be")
-        print("                  removed by hand — the fix prints the exact command.")
+        # A settings.json env block CAN be auto-scrubbed; a User/shell-rc var
+        # cannot. Print the exact removal command HERE (not only under --fix) so
+        # --verbose actually delivers the fix it references.
+        if _manual_env_leak_remains():
+            print("             fix: `m3 doctor --fix` scrubs any settings.json blocks; the")
+            print("                  persistent User/shell var must be removed by hand:")
+            for line in _manual_removal_command():
+                print(f"                  {line}")
+        else:
+            print("             fix: `m3 doctor --fix` scrubs the settings blocks (backs them up).")
     else:
         print("  inproc   : OK — no M3_EMBED_GGUF leak (clients defer to the server).")
 
     if healthy:
         print("  status   : OK — shared mode fully configured and serving.")
+    elif manual_only:
+        # Don't tell the user to run --fix for the one thing it can't fix; the
+        # exact manual command is printed in the inproc block above.
+        print()
+        print("  Remove M3_EMBED_GGUF by hand (command above), then open a new shell")
+        print("  and restart the MCP client. `m3 doctor --fix` cannot remove it for you.")
     elif not fix:
         print()
         print("  Run `m3 doctor --fix` to repair the above automatically.")

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.7.7.2",
+  "version": "2026.7.7.3",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.7.7.2"
+version = "2026.7.7.3"
 description = "Local-first Memory Framework for AI Agents · 99.2% LongMemEval-S retrieval @ k=10 · Supports Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · MCP-native and plugins · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first agentic memory — 100+ tools, 89% LongMemEval, hybrid search, GDPR, zero cloud.",
-  "version": "2026.7.7.2",
+  "version": "2026.7.7.3",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.7.7.2",
+      "version": "2026.7.7.3",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"

--- a/tests/test_shared_embedder_probe.py
+++ b/tests/test_shared_embedder_probe.py
@@ -136,3 +136,102 @@ def test_brief_healthy_and_unhealthy(monkeypatch, cfg_root, capsys):
     _patch(monkeypatch, health="ok", rust=True)
     assert P.run(brief=True, fix=False) == 1
     assert "⚠️" in capsys.readouterr().out
+
+
+# ── M3_EMBED_GGUF leak: localization + loop-termination + verbose command ──────
+#
+# These pin the three UX fixes: the probe must (1) localize a shell-rc leak to
+# file:line, (2) NOT re-emit "run --fix" for a manual-only leak (the dead-end
+# loop), and (3) print the exact removal command under --verbose, not only --fix.
+# All hermetic: rc scan is pointed at tmp_path, the Windows registry read is
+# stubbed, so no real HOME / registry is touched (CI-safe, §2 hermetic).
+
+
+@pytest.fixture
+def no_env_leak(monkeypatch, tmp_path):
+    """Baseline clean environment: no process var, no Windows User-env var, and
+    the shell-rc scan pointed at an empty tmp dir so a CI runner's real ~/.zshrc
+    can never leak into the assertion."""
+    monkeypatch.delenv("M3_EMBED_GGUF", raising=False)
+    monkeypatch.setattr(P, "_windows_user_env_has", lambda var: False)
+    monkeypatch.setattr(P, "_shell_rc_candidates", lambda: [])
+    return tmp_path
+
+
+def test_shell_rc_leak_localizes_to_file_line(monkeypatch, tmp_path):
+    rc = tmp_path / ".zshrc"
+    rc.write_text(
+        "# a comment\n"
+        'export PATH="$PATH:/x"\n'
+        'export M3_EMBED_GGUF="/models/bge-m3.gguf"\n'
+    )
+    monkeypatch.setattr(P, "_shell_rc_candidates", lambda: [str(rc)])
+    hits = P._find_env_in_shell_rc("M3_EMBED_GGUF")
+    assert hits == [f"{rc}:3"]  # exact file:line, not just "shell rc"
+
+
+def test_commented_export_is_not_a_leak(monkeypatch, tmp_path):
+    rc = tmp_path / ".zshrc"
+    rc.write_text('# export M3_EMBED_GGUF="/old.gguf"\n')
+    monkeypatch.setattr(P, "_shell_rc_candidates", lambda: [str(rc)])
+    assert P._find_env_in_shell_rc("M3_EMBED_GGUF") == []
+
+
+def test_detect_leak_reports_rc_file_line(monkeypatch, no_env_leak):
+    rc = no_env_leak / ".zshrc"
+    rc.write_text('export M3_EMBED_GGUF="/models/bge-m3.gguf"\n')
+    monkeypatch.setenv("M3_EMBED_GGUF", "/models/bge-m3.gguf")  # process sees it too
+    monkeypatch.setattr(P, "_shell_rc_candidates", lambda: [str(rc)])
+    locs = P._detect_inproc_env_leak()
+    assert any(str(rc) in loc and ":1" in loc for loc in locs)
+
+
+def test_manual_only_brief_does_not_loop_to_fix(monkeypatch, cfg_root, capsys, no_env_leak):
+    # Shared config + live server + keep-alive: the ONLY problem is a process-env
+    # leak that --fix can't remove. Brief output must guide to the manual step,
+    # NOT re-print "run `m3 doctor --fix`" (the dead-end loop).
+    _write_shared_config(cfg_root)
+    _patch(monkeypatch, health="ok", rust=True)
+    monkeypatch.setenv("M3_EMBED_GGUF", "/models/bge-m3.gguf")
+    rc = P.run(brief=True, fix=False)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "remove it by hand" in out.lower()
+    assert "run `m3 doctor --fix`" not in out  # the loop is broken
+
+
+def test_manual_only_verbose_prints_removal_command(monkeypatch, cfg_root, capsys, no_env_leak):
+    # --verbose (fix=False) must print the actual removal command, not merely
+    # claim "the fix prints the exact command".
+    _write_shared_config(cfg_root)
+    _patch(monkeypatch, health="ok", rust=True)
+    monkeypatch.setattr(P.sys, "platform", "darwin")
+    rc_file = no_env_leak / ".zshrc"
+    rc_file.write_text('export M3_EMBED_GGUF="/models/bge-m3.gguf"\n')
+    monkeypatch.setenv("M3_EMBED_GGUF", "/models/bge-m3.gguf")
+    monkeypatch.setattr(P, "_shell_rc_candidates", lambda: [str(rc_file)])
+    rc = P.run(brief=False, fix=False)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert str(rc_file) in out  # the exact file is named
+    assert "new shell" in out.lower() and "restart the mcp client" in out.lower()
+
+
+def test_manual_only_verbose_prints_windows_command(monkeypatch, cfg_root, capsys, no_env_leak):
+    _write_shared_config(cfg_root)
+    _patch(monkeypatch, health="ok", rust=True)
+    monkeypatch.setattr(P.sys, "platform", "win32")
+    monkeypatch.setattr(P, "_windows_user_env_has", lambda var: True)
+    rc = P.run(brief=False, fix=False)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "SetEnvironmentVariable('M3_EMBED_GGUF', $null, 'User')" in out
+
+
+def test_no_leak_verbose_stays_clean(monkeypatch, cfg_root, capsys, no_env_leak):
+    _write_shared_config(cfg_root)
+    _patch(monkeypatch, health="ok", rust=True)
+    rc = P.run(brief=False, fix=False)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no M3_EMBED_GGUF leak" in out


### PR DESCRIPTION
## What

`m3 doctor`'s shared-embedder probe correctly detects an `M3_EMBED_GGUF` env leak (the per-process-GPU hang footgun) but its **remediation UX** had three gaps that left users stuck. Found in a real macOS support session; verified against current source.

### The three gaps (all fixed)

1. **Category, not location.** The probe reported only "shell rc", never the exact line — a user had to grep their rc files by hand to find the offending `export`. Now it greps the standard shell rc files (and reads the Windows User-env registry) and reports the exact **`file:line`**.

2. **Dead-end `--fix` loop.** For the one class `--fix` provably cannot repair (a persistent process/User/shell-rc var), the summary still said "run `m3 doctor --fix`" — so running `--fix` told the user to run `--fix` again. Now, when the sole remaining issue is a manual-only leak, the doctor prints the manual step and does **not** re-emit "run `--fix`".

3. **`--verbose` didn't deliver what it promised.** The verbose block *claimed* "the fix prints the exact command" but only `--fix` actually printed it. Now the exact, copy-pasteable removal command renders under `--verbose` too, from a single shared `_manual_removal_command()` helper (one source of truth for both paths).

Settings.json env blocks are still auto-scrubbed by `--fix` as before — only the process/User/shell-rc class is manual, and that's exactly the class these fixes make actionable.

## Tests

New hermetic tests in `test_shared_embedder_probe.py` (rc scan pointed at tmp, Windows registry read stubbed — no real HOME/registry touched): file:line localization, commented-export-is-not-a-leak, no-loop on manual-only leak, `--verbose` prints the removal command (POSIX + Windows), clean-state stays clean. Full doctor+embed suite green; ruff + mypy (py3.11) clean.

Bumps version to `2026.7.7.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)