### PR TITLE
fix(test): make test_shared_config_is_read_by_embed_cascade order-independent (#83)

### DIFF
--- a/tests/test_embedder_shared.py
+++ b/tests/test_embedder_shared.py
@@ -63,11 +63,18 @@ def test_shared_config_is_read_by_embed_cascade(monkeypatch, tmp_path):
     monkeypatch.delenv("M3_EMBED_GGUF", raising=False)
     monkeypatch.delenv("M3_EMBED_GGUF_AUTODETECT", raising=False)
     EA.cmd_shared(types.SimpleNamespace(port=8082))
-    # import embed.py fresh with bin/ on path so it reads the just-written config
+    # Import embed.py FRESH so its module-level config (read at import time) reflects
+    # the file we just wrote. Purge-then-import instead of importlib.reload(): a
+    # sibling test's fixture (test_doctor.py::_isolate_env) evicts all `memory.*`
+    # from sys.modules on teardown, and under py3.14 reload() of an absent module
+    # raises `ImportError: module memory.embed not in sys.modules`. Dropping the
+    # cached entry and re-importing is state-independent — it works whether or not
+    # `memory.embed` was previously loaded, so this test no longer depends on run
+    # order (§3 hermetic tests).
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "bin"))
     import importlib
 
-    from memory import embed as E
-    importlib.reload(E)
+    sys.modules.pop("memory.embed", None)
+    E = importlib.import_module("memory.embed")
     assert E._EMBED_GGUF_AUTODETECT is False
     assert E._EMBED_FALLBACK_URL == "http://127.0.0.1:8082"


### PR DESCRIPTION
Fixes #83.

## Problem

`tests/test_embedder_shared.py::test_shared_config_is_read_by_embed_cascade` passed in isolation but **failed when run after certain tests** (`ImportError: module memory.embed not in sys.modules`), making the full suite order-dependent.

- **Victim:** did `from memory import embed as E` then `importlib.reload(E)`.
- **Polluter:** `test_doctor.py`'s autouse `_isolate_env` fixture evicts every `memory.*` module from `sys.modules` on teardown. When doctor tests run first, `memory.embed` is absent, and Python 3.14's strict `importlib.reload()` raises instead of re-importing.

Minimal deterministic repro (before this change):
```
python -m pytest tests/test_doctor.py tests/test_gguf_autodetect.py \
  tests/test_embedder_shared.py::test_shared_config_is_read_by_embed_cascade -p no:cacheprovider
# -> 1 failed, 20 passed
```

## Fix

Make the victim **state-independent**: pop the cached `memory.embed` entry and import fresh via `importlib.import_module()`, which achieves the same "read the just-written config" intent whether or not the module was previously loaded — no dependency on another test's cleanup (§3 hermetic tests). Assertions are unchanged; the test still verifies the shared config disables tier-1 autodetect and pins the fallback URL.

## Verification

| Scenario | Before | After |
|---|---|---|
| victim in isolation | pass | pass |
| `test_doctor + test_gguf_autodetect + victim` | **fail** | **pass** (21) |
| whole `test_embedder_shared.py` | pass | pass (7) |
| full deploy batch (8 files, 85 tests) | **1 failed** | **85 passed** |

ruff + mypy (py3.11) clean.

## Scope

Deliberately a single-file victim fix (§1 one feature per PR). The `_isolate_env` fixture that leaves `sys.modules` inconsistent is a broader, shared-fixture concern touching many tests; not folded in here. The durable fix is that this test no longer relies on module-cache state, so hardening the fixture is optional follow-up rather than a prerequisite.

Note: this flake is **Windows-local batch ordering** — it does not fail on the Linux/py3.12 CI job (that job already passes 1580 tests), so CI was green throughout; this restores local-suite trustworthiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)