### PR TITLE
test: fix leaked embedder thread + add thread-leak guard (contributes to #85)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,62 @@ def _restore_memory_modules():
 
 
 @pytest.fixture(autouse=True)
+def _guard_thread_leaks():
+    """Fail fast when a test leaks a live worker thread into the session.
+
+    A test that spawns a background thread which never exits (e.g. a simulated
+    wedged native init, `threading.Event().wait()` with no release) leaves that
+    thread alive for the rest of the run. Beyond hiding a real bug, a lingering
+    NATIVE-touching thread can race a later test that reloads a C-extension
+    module and crash the whole run (that is exactly what happened with the
+    m3-embed-init thread and the crypto_provider reload, #85).
+
+    Guard: snapshot the live threads before the test; after it, any NEW thread
+    still alive after a short grace is a leak. Threads whose name matches a
+    known worker prefix (they should be joined/stopped by their test) FAIL the
+    test; anything else is surfaced as a warning so genuinely long-lived helpers
+    don't turn into false reds. Give stragglers a brief join first — a thread
+    mid-shutdown at yield time is not a leak.
+    """
+    import threading
+    import warnings
+
+    # Worker-thread name prefixes that a well-behaved test must not leave running.
+    _LEAK_FAIL_PREFIXES = ("m3-embed-init",)
+
+    before = {t.ident for t in threading.enumerate()}
+    yield
+    current = threading.current_thread()
+
+    def _new_live():
+        return [
+            t for t in threading.enumerate()
+            if t.ident not in before and t is not current and t.is_alive()
+        ]
+
+    # A leaked thread may be a few ms from exiting; give it a short window.
+    for t in _new_live():
+        t.join(timeout=2.0)
+    leaked = _new_live()
+    if not leaked:
+        return
+    fail = [t for t in leaked if t.name.startswith(_LEAK_FAIL_PREFIXES)]
+    if fail:
+        names = ", ".join(sorted(t.name for t in fail))
+        raise AssertionError(
+            f"test leaked live worker thread(s): {names}. Join/stop them in "
+            "teardown (an unreleased native-init thread can crash a later "
+            "module reload — see #85)."
+        )
+    # Non-worker stragglers: surface but don't fail (may be a legit helper).
+    warnings.warn(
+        "test left non-main thread(s) alive: "
+        + ", ".join(sorted(t.name for t in leaked)),
+        stacklevel=2,
+    )
+
+
+@pytest.fixture(autouse=True)
 def _close_db_pools():
     """Close every cached M3Context SQLite pool after each test.
 

--- a/tests/test_embed_hang_proof.py
+++ b/tests/test_embed_hang_proof.py
@@ -110,10 +110,21 @@ def test_inproc_init_times_out_instead_of_hanging(monkeypatch):
                      M3_EMBED_GGUF="C:/fake/model.gguf",
                      M3_EMBED_INIT_TIMEOUT_S="1")
 
+    # The wedge must stay blocked while the caller's 1s deadline elapses (that's
+    # what proves the abandon path). But `embed.py` runs the init on a daemon
+    # thread it CANNOT force-kill, so a bare `Event().wait()` here leaks a live
+    # thread into the rest of the session — on Windows that later races with
+    # test_fips_integrity.py's crypto_provider reload and segfaults the run (#85).
+    # Make the wedge INTERRUPTIBLE: it waits on an event we set in teardown so the
+    # thread actually exits, with a finite backstop cap so it can never truly hang
+    # even if teardown is skipped. The cap (30s) is far beyond the <5s assertion
+    # window, so the wedge is still blocking when the caller times out.
+    _release = threading.Event()
+
     class _HangingEmbedder:
         def __init__(self, *_a):
-            # simulate a wedged CUDA load
-            threading.Event().wait()  # blocks forever
+            # simulate a wedged CUDA load — released only in teardown
+            _release.wait(timeout=30.0)
 
         def embedding_dim(self):  # pragma: no cover — never reached
             return 1024
@@ -128,11 +139,19 @@ def test_inproc_init_times_out_instead_of_hanging(monkeypatch):
     e._EMBED_GGUF_PATH = "C:/fake/model.gguf"
     e._EMBED_INIT_TIMEOUT_S = 1.0
 
-    t0 = _time.time()
-    result = e._get_embedded_embedder()
-    dt = _time.time() - t0
-    assert result is None, "hanging init must yield None (HTTP fallback)"
-    assert dt < 5.0, f"init should abandon within the deadline, took {dt:.1f}s"
+    try:
+        t0 = _time.time()
+        result = e._get_embedded_embedder()
+        dt = _time.time() - t0
+        assert result is None, "hanging init must yield None (HTTP fallback)"
+        assert dt < 5.0, f"init should abandon within the deadline, took {dt:.1f}s"
+    finally:
+        # Release the wedge and reap the abandoned m3-embed-init daemon thread so
+        # it does not survive into later tests (the #85 segfault trigger).
+        _release.set()
+        for _th in threading.enumerate():
+            if _th.name == "m3-embed-init" and _th is not threading.current_thread():
+                _th.join(timeout=5.0)
 
 
 def test_inproc_init_succeeds_fast_when_healthy(monkeypatch):


### PR DESCRIPTION
Two related test-isolation fixes. Together they remove a leaked worker thread and prevent the whole class from recurring.

## 1. Interruptible wedge (`test_embed_hang_proof.py`)

`test_inproc_init_times_out_instead_of_hanging` installed a `_HangingEmbedder` whose `__init__` called `threading.Event().wait()` — blocking forever. `embed.py` runs that init on a `daemon=True` thread it cannot force-kill, so the wedged thread **leaked into the rest of the pytest session** (the process doesn't exit between tests).

Fix: the wedge now waits on an `Event` set in teardown (with a finite 30s backstop cap, far beyond the <5s assertion window, so it still blocks while the caller's 1s deadline elapses). Teardown sets the event and joins any surviving `m3-embed-init` thread. Verified: the test still asserts the abandon path (`result is None`, `dt < 5s`) and **zero `m3-embed-init` threads survive**.

## 2. Thread-leak guard (`conftest.py`)

An autouse fixture that enforces what the wedge fix does by hand: snapshot live threads before each test; after a short join grace, **fail** the test if a new thread matching a known worker prefix (`m3-embed-init`) is still alive; surface other stragglers as a warning (so legitimate long-lived helpers aren't false reds).

Verified: catches a synthetic `m3-embed-init` leak, and runs the full suite (**1910 passed**) with **no false positives**.

## Why it matters

A lingering native-touching thread can race a later test that reloads a C-extension module and crash the whole run — the mechanism behind the FIPS-reload segfault (#85). This removes the thread-leak contributor and guards against its return. The remaining #85 segfault (native wolfSSL reload) is fixed in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)