### PR TITLE
fix(test): subprocess-isolate native-wolfSSL FIPS tests to stop the full-suite segfault (#85)

### DIFF
--- a/tests/test_fips_integrity.py
+++ b/tests/test_fips_integrity.py
@@ -51,17 +51,32 @@ def _run_fips_subprocess(body: str, env: dict) -> dict:
 
         def _bin_mock():
             # Load MockLibWolf from bin/test_fips_integrity.py by path (the tests/
-            # file of the same name shadows it on sys.path).
+            # file of the same name shadows it on sys.path). That bin module
+            # transitively imports auth_utils -> crypto_provider at module scope;
+            # under M3_FIPS_MODE=1 with no wolfSSL that import fails closed BEFORE
+            # we can install the mock. So load it with FIPS mode temporarily off
+            # (we only need the MockLibWolf class), then restore the env.
             import importlib.util as _ilu
-            p = os.path.join({_BIN!r}, "test_fips_integrity.py")
-            spec = _ilu.spec_from_file_location("_bin_fips_mock", p)
-            m = _ilu.module_from_spec(spec); spec.loader.exec_module(m)
-            return m.MockLibWolf
+            saved = {{k: os.environ.pop(k, None)
+                      for k in ("M3_FIPS_MODE", "M3_FIPS_STRICT", "M3_CRYPTO_BACKEND")}}
+            try:
+                p = os.path.join({_BIN!r}, "test_fips_integrity.py")
+                spec = _ilu.spec_from_file_location("_bin_fips_mock", p)
+                m = _ilu.module_from_spec(spec); spec.loader.exec_module(m)
+                return m.MockLibWolf
+            finally:
+                for k, v in saved.items():
+                    if v is not None:
+                        os.environ[k] = v
+                # crypto_provider was imported (DEFAULT backend) while FIPS was
+                # off; drop it so _install_mock re-imports it fresh under FIPS +
+                # the mock CDLL.
+                sys.modules.pop("crypto_provider", None)
 
         def _install_mock(*, break_sha=False, non_fips=False):
-            # Patch ctypes.CDLL to return a MockLibWolf for wolfssl, pin a real
-            # placeholder file so the secure loader resolves it, then return the
-            # freshly-imported crypto_provider. Mirrors the in-process helper.
+            # Order matters: build the mock + pin the fake lib + patch ctypes.CDLL
+            # BEFORE importing crypto_provider, so its module-level FIPS init sees
+            # the mock. Returns the freshly-imported crypto_provider module.
             MockLibWolf = _bin_mock()
             mock = MockLibWolf()
             if break_sha:
@@ -82,6 +97,7 @@ def _run_fips_subprocess(body: str, env: dict) -> dict:
                 f.write(b"mock-wolfssl-placeholder")
             os.environ["M3_WOLFSSL_LIB"] = fake
             ctypes.CDLL = _mock_cdll
+            sys.modules.pop("crypto_provider", None)  # ensure a fresh FIPS init
             import crypto_provider
             return crypto_provider
     """)

--- a/tests/test_fips_integrity.py
+++ b/tests/test_fips_integrity.py
@@ -12,18 +12,100 @@ Exit criteria (Milestone 2):
 """
 import hashlib
 import importlib
+import json
 import os
+import subprocess
 import sys
+import textwrap
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
+_BIN = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "bin"))
+sys.path.insert(0, _BIN)
+
+
+# ── Subprocess isolation for native-wolfSSL tests (#85) ─────────────────────────
+#
+# Loading crypto_provider under a wolfSSL backend initializes the native wolfSSL
+# library via ctypes at import time (`provider = CryptoProvider(BACKEND)`). Once
+# that DLL is loaded, any later importlib.reload() of crypto_provider re-inits it
+# in the same process and, on Windows, segfaults the ENTIRE pytest run (Windows
+# fatal exception: access violation, #85). A fresh interpreter loads it exactly
+# once and exits cleanly, so every test that must load wolfSSL (real or the
+# ctypes-mocked build) runs its assertions in a subprocess and we inspect the
+# JSON verdict here. DEFAULT-backend tests don't touch native code and stay
+# in-process. This mirrors conftest's native-embedder-disabled discipline.
+
+def _run_fips_subprocess(body: str, env: dict) -> dict:
+    """Execute `body` in a fresh interpreter with `env` overlaid; return the dict
+    it prints via `_emit(**kv)`. `_install_mock(...)` and `_bin_mock()` are
+    available to the snippet for the ctypes-mocked wolfSSL build. A crash or a
+    missing verdict surfaces as a readable test failure — never a crash of the
+    shared test run (that's the whole point)."""
+    prelude = textwrap.dedent(f"""
+        import ctypes, hashlib, importlib, json, os, sys, tempfile
+        sys.path.insert(0, {_BIN!r})
+
+        def _emit(**kv):
+            print("__FIPS__" + json.dumps(kv))
+
+        def _bin_mock():
+            # Load MockLibWolf from bin/test_fips_integrity.py by path (the tests/
+            # file of the same name shadows it on sys.path).
+            import importlib.util as _ilu
+            p = os.path.join({_BIN!r}, "test_fips_integrity.py")
+            spec = _ilu.spec_from_file_location("_bin_fips_mock", p)
+            m = _ilu.module_from_spec(spec); spec.loader.exec_module(m)
+            return m.MockLibWolf
+
+        def _install_mock(*, break_sha=False, non_fips=False):
+            # Patch ctypes.CDLL to return a MockLibWolf for wolfssl, pin a real
+            # placeholder file so the secure loader resolves it, then return the
+            # freshly-imported crypto_provider. Mirrors the in-process helper.
+            MockLibWolf = _bin_mock()
+            mock = MockLibWolf()
+            if break_sha:
+                def _bad_sha(in_buf, sz, out_buf):
+                    ctypes.memmove(out_buf, b"\\x00" * 32, 32); return 0
+                mock.wc_Sha256Hash.func = _bad_sha
+            if non_fips:
+                for sym in ("wolfCrypt_GetStatus_fips", "wc_SetSeed_Cb", "wolfCrypt_SetCb_fips"):
+                    if hasattr(mock, sym):
+                        delattr(mock, sym)
+            real_cdll = ctypes.CDLL
+            def _mock_cdll(name, *a, **k):
+                if "wolfssl" in str(name).lower():
+                    return mock
+                return real_cdll(name, *a, **k)
+            fake = os.path.join(tempfile.mkdtemp(prefix="m3wolf-"), "wolfssl.dll")
+            with open(fake, "wb") as f:
+                f.write(b"mock-wolfssl-placeholder")
+            os.environ["M3_WOLFSSL_LIB"] = fake
+            ctypes.CDLL = _mock_cdll
+            import crypto_provider
+            return crypto_provider
+    """)
+    proc = subprocess.run(
+        [sys.executable, "-c", prelude + textwrap.dedent(body)],
+        capture_output=True, text=True,
+        env={**os.environ, **{k: str(v) for k, v in env.items()}},
+        timeout=120,
+    )
+    marker = "__FIPS__"
+    line = next((ln for ln in proc.stdout.splitlines() if ln.startswith(marker)), None)
+    assert line is not None, (
+        f"FIPS subprocess produced no verdict (rc={proc.returncode}).\n"
+        f"stdout:\n{proc.stdout[-3000:]}\nstderr:\n{proc.stderr[-2000:]}"
+    )
+    return json.loads(line[len(marker):])
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
 def _reload_provider(monkeypatch, backend=None, fips_mode=None, strict=None):
-    """Reload crypto_provider with specific env knobs."""
+    """Reload crypto_provider with specific env knobs (DEFAULT backend only — the
+    native-wolfSSL path is exercised via _run_fips_subprocess to avoid the #85
+    in-process reload segfault)."""
     if backend is not None:
         monkeypatch.setenv("M3_CRYPTO_BACKEND", backend)
     else:
@@ -98,84 +180,71 @@ class TestDefaultBackend:
 class TestFIPSEnforcement:
     """Validate that M3_FIPS_MODE=1 enforces fail-closed policy."""
 
-    def test_fips_mode_sets_backend_to_wolfssl(self, monkeypatch):
-        """The module must select WOLFSSL when M3_FIPS_MODE=1."""
-        # If wolfSSL is missing, the constructor raises — we catch that.
-        try:
-            cp = _reload_provider(monkeypatch, fips_mode="1")
-            # If no exception: wolfSSL loaded successfully
-            assert cp.BACKEND == "WOLFSSL"
-        except RuntimeError as exc:
-            # Fail-closed path: must mention FIPS in the message
-            assert "FIPS" in str(exc) or "FATAL" in str(exc)
+    def test_fips_mode_sets_backend_to_wolfssl(self):
+        """The module must select WOLFSSL when M3_FIPS_MODE=1. Isolated (#85):
+        either wolfSSL loads (BACKEND==WOLFSSL) or it is absent and the module
+        fails closed with a RuntimeError mentioning FIPS — both accepted."""
+        v = _run_fips_subprocess(
+            """
+            try:
+                import crypto_provider
+                _emit(outcome="loaded", backend=crypto_provider.BACKEND)
+            except RuntimeError as exc:
+                _emit(outcome="raised", msg=str(exc))
+            """,
+            env={"M3_FIPS_MODE": "1"},
+        )
+        if v["outcome"] == "loaded":
+            assert v["backend"] == "WOLFSSL"
+        else:
+            assert "FIPS" in v["msg"] or "FATAL" in v["msg"]
 
-    def test_fips_mode_without_wolfssl_raises_on_sha256(self, monkeypatch):
-        """Under M3_FIPS_MODE=1, sha256() must NOT silently use hashlib.
+    def _assert_fips_boundary(self, primitive: str):
+        """Under M3_FIPS_MODE=1 a primitive must NOT silently use stdlib: either
+        the module fails closed at import (wolfSSL absent), or wolfSSL loads and a
+        stub DEFAULT-backend provider raises 'FIPS boundary violation'. Isolated
+        in a subprocess (#85)."""
+        v = _run_fips_subprocess(
+            f"""
+            try:
+                import crypto_provider
+            except RuntimeError as exc:
+                _emit(outcome="raised", msg=str(exc)); sys.exit(0)
+            prov = crypto_provider.CryptoProvider.__new__(crypto_provider.CryptoProvider)
+            prov.backend = "DEFAULT"; prov._initialized = False
+            prov._libwolf = None; prov._fips_cb_ref = None
+            try:
+                if {primitive!r} == "sha256":
+                    prov.sha256(b"test")
+                elif {primitive!r} == "encrypt":
+                    prov.encrypt(b"data", os.urandom(32))
+                else:
+                    prov.decrypt(b"\\x00" * 29, os.urandom(32))
+                _emit(outcome="no_raise")
+            except RuntimeError as exc:
+                _emit(outcome="boundary", msg=str(exc))
+            """,
+            env={"M3_FIPS_MODE": "1"},
+        )
+        if v["outcome"] == "raised":
+            assert "FIPS" in v["msg"] or "FATAL" in v["msg"]
+        else:
+            assert v["outcome"] == "boundary", (
+                f"{primitive} must not silently use stdlib under FIPS mode"
+            )
+            assert "FIPS boundary violation" in v["msg"]
 
-        Two valid outcomes depending on whether wolfssl.dll is installed:
-          a) wolfSSL present: provider loads; we test boundary enforcement directly.
-          b) wolfSSL absent: importlib.reload raises RuntimeError at module level
-             (fail-closed enforcement — this IS the correct behavior).
-        """
-        monkeypatch.setenv("M3_FIPS_MODE", "1")
-        import crypto_provider
-        try:
-            importlib.reload(crypto_provider)
-        except RuntimeError as exc:
-            # wolfSSL not installed — fail-closed raised during module init. Correct.
-            assert "FIPS" in str(exc) or "FATAL" in str(exc)
-            return
+    def test_fips_mode_without_wolfssl_raises_on_sha256(self):
+        """Under M3_FIPS_MODE=1, sha256() must NOT silently use hashlib."""
+        self._assert_fips_boundary("sha256")
 
-        # wolfSSL loaded — now test that boundary is enforced on a stub provider
-        prov = crypto_provider.CryptoProvider.__new__(crypto_provider.CryptoProvider)
-        prov.backend = "DEFAULT"
-        prov._initialized = False
-        prov._libwolf = None
-        prov._fips_cb_ref = None
-
-        with pytest.raises(RuntimeError, match="FIPS boundary violation"):
-            prov.sha256(b"test")
-
-    def test_fips_mode_without_wolfssl_raises_on_encrypt(self, monkeypatch):
+    def test_fips_mode_without_wolfssl_raises_on_encrypt(self):
         """Under M3_FIPS_MODE=1, encrypt() must NOT silently use stdlib."""
-        monkeypatch.setenv("M3_FIPS_MODE", "1")
-        import crypto_provider
-        try:
-            importlib.reload(crypto_provider)
-        except RuntimeError as exc:
-            assert "FIPS" in str(exc) or "FATAL" in str(exc)
-            return
+        self._assert_fips_boundary("encrypt")
 
-        prov = crypto_provider.CryptoProvider.__new__(crypto_provider.CryptoProvider)
-        prov.backend = "DEFAULT"
-        prov._initialized = False
-        prov._libwolf = None
-        prov._fips_cb_ref = None
-
-        key = os.urandom(32)
-        with pytest.raises(RuntimeError, match="FIPS boundary violation"):
-            prov.encrypt(b"data", key)
-
-    def test_fips_mode_without_wolfssl_raises_on_decrypt(self, monkeypatch):
+    def test_fips_mode_without_wolfssl_raises_on_decrypt(self):
         """Under M3_FIPS_MODE=1, decrypt() must NOT silently use stdlib."""
-        monkeypatch.setenv("M3_FIPS_MODE", "1")
-        import crypto_provider
-        try:
-            importlib.reload(crypto_provider)
-        except RuntimeError as exc:
-            assert "FIPS" in str(exc) or "FATAL" in str(exc)
-            return
-
-        prov = crypto_provider.CryptoProvider.__new__(crypto_provider.CryptoProvider)
-        prov.backend = "DEFAULT"
-        prov._initialized = False
-        prov._libwolf = None
-        prov._fips_cb_ref = None
-
-        token = b"\x00" * 29
-        key = os.urandom(32)
-        with pytest.raises(RuntimeError, match="FIPS boundary violation"):
-            prov.decrypt(token, key)
+        self._assert_fips_boundary("decrypt")
 
     def test_non_fips_mode_allows_stdlib(self, monkeypatch):
         """Without M3_FIPS_MODE, sha256 must succeed using stdlib fallback."""
@@ -209,83 +278,25 @@ class TestErrorCodeTable:
 
 
 # ── Power-up Known-Answer-Tests (Phase 2) ──────────────────────────────────────
-
-def _load_mock_lib_wolf():
-    """Load MockLibWolf from bin/test_fips_integrity.py by PATH.
-
-    `from test_fips_integrity import MockLibWolf` is ambiguous — this tests/ file
-    has the same module name and shadows the bin/ one on sys.path. Load the bin/
-    module explicitly under a distinct name to avoid the collision.
-    """
-    import importlib.util as _ilu
-    bin_path = os.path.join(os.path.dirname(__file__), "..", "bin", "test_fips_integrity.py")
-    spec = _ilu.spec_from_file_location("_bin_fips_mock", os.path.abspath(bin_path))
-    mod = _ilu.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.MockLibWolf
-
-
-def _wolf_provider_with_mock(monkeypatch, *, fips_mode="1", strict=None,
-                             break_sha=False, non_fips=False):
-    """Build a WOLFSSL-backed CryptoProvider with the MockLibWolf installed,
-    so the power-up KATs run against a (correct or deliberately broken) backend
-    without a real wolfSSL library. ``non_fips=True`` strips the CMVP FIPS
-    service symbols to simulate the open-source wolfSSL build.
-
-    Order matters: ctypes.CDLL must be patched BEFORE crypto_provider reloads,
-    because the module instantiates `provider = CryptoProvider(BACKEND)` at
-    import time — that init would otherwise try (and fail) to load the real
-    wolfssl.dll before any per-test patch lands.
-    """
-    import ctypes as _ct
-
-    MockLibWolf = _load_mock_lib_wolf()  # the bin/ mock (real-crypto-backed)
-
-    mock = MockLibWolf()
-    if break_sha:
-        def _bad_sha(in_buf, sz, out_buf):
-            _ct.memmove(out_buf, b"\x00" * 32, 32)  # wrong digest
-            return 0
-        mock.wc_Sha256Hash.func = _bad_sha
-    if non_fips:
-        # Simulate the OPEN-SOURCE wolfSSL build: it has the core crypto symbols
-        # but NOT the CMVP FIPS service symbols (POST/entropy callbacks).
-        for sym in ("wolfCrypt_GetStatus_fips", "wc_SetSeed_Cb", "wolfCrypt_SetCb_fips"):
-            if hasattr(mock, sym):
-                delattr(mock, sym)
-
-    real_cdll = _ct.CDLL
-
-    def _mock_cdll(name, *a, **k):
-        if "wolfssl" in str(name).lower():
-            return mock
-        return real_cdll(name, *a, **k)
-
-    # The secure loader resolves a TRUSTED ABSOLUTE path and only loads if the
-    # file exists (it never loads a bare name). Create a real placeholder file
-    # and pin it via M3_WOLFSSL_LIB so _resolve_wolfssl_path() returns it; the
-    # CDLL monkeypatch then returns the mock instead of loading the placeholder.
-    import tempfile
-    fake = os.path.join(tempfile.mkdtemp(prefix="m3wolf-"), "wolfssl.dll")
-    with open(fake, "wb") as f:
-        f.write(b"mock-wolfssl-placeholder")
-    monkeypatch.setenv("M3_WOLFSSL_LIB", fake)
-
-    # Patch the shared ctypes module FIRST, then reload the provider so its
-    # module-level `provider = CryptoProvider(BACKEND)` sees the mock.
-    monkeypatch.setattr(_ct, "CDLL", _mock_cdll)
-    cp = _reload_provider(monkeypatch, backend="WOLFSSL", fips_mode=fips_mode, strict=strict)
-    return cp
+# The MockLibWolf install + reload that these used in-process now lives in the
+# subprocess prelude's `_install_mock()` (see _run_fips_subprocess) — the ctypes
+# CDLL patch + native provider init runs in a fresh process, so it can never
+# corrupt the shared test run (#85).
 
 
 class TestPowerUpKATs:
-    def test_kats_pass_against_correct_backend(self, monkeypatch):
-        cp = _wolf_provider_with_mock(monkeypatch, fips_mode="1")
-        p = cp.CryptoProvider("WOLFSSL")
-        assert p._initialized is True
-        assert p.backend == "WOLFSSL"
-        # Explicit re-run is idempotent and must not raise.
-        p._run_self_tests()
+    def test_kats_pass_against_correct_backend(self):
+        v = _run_fips_subprocess(
+            """
+            cp = _install_mock()
+            p = cp.CryptoProvider("WOLFSSL")
+            p._run_self_tests()  # idempotent re-run must not raise
+            _emit(initialized=p._initialized, backend=p.backend)
+            """,
+            env={"M3_FIPS_MODE": "1"},
+        )
+        assert v["initialized"] is True
+        assert v["backend"] == "WOLFSSL"
 
     def test_kat_vectors_are_canonical(self, monkeypatch):
         """Lock the published KAT constants so a future edit can't silently
@@ -299,15 +310,25 @@ class TestPowerUpKATs:
         assert len(cp._KAT_AESGCM_KEY) == 32
         assert len(cp._KAT_AESGCM_NONCE) == 12
 
-    def test_broken_backend_fatally_aborts_under_fips(self, monkeypatch):
+    def test_broken_backend_fatally_aborts_under_fips(self):
         """A primitive that computes the WRONG answer must abort init under
         M3_FIPS_MODE=1 — the FIPS power-up-self-test failure contract. With the
-        broken mock installed before reload, the module-level
-        `provider = CryptoProvider(BACKEND)` raises during reload itself; a
-        direct construction raises identically. Assert either path raises."""
-        with pytest.raises(RuntimeError):
-            cp = _wolf_provider_with_mock(monkeypatch, fips_mode="1", break_sha=True)
-            cp.CryptoProvider("WOLFSSL")
+        broken mock installed before import, the module-level
+        `provider = CryptoProvider(BACKEND)` raises during import itself; a direct
+        construction raises identically. Assert either path raises."""
+        v = _run_fips_subprocess(
+            """
+            raised = False
+            try:
+                cp = _install_mock(break_sha=True)
+                cp.CryptoProvider("WOLFSSL")
+            except RuntimeError:
+                raised = True
+            _emit(raised=raised)
+            """,
+            env={"M3_FIPS_MODE": "1"},
+        )
+        assert v["raised"] is True
 
     def test_self_tests_method_exists(self, monkeypatch):
         cp = _reload_provider(monkeypatch, backend="DEFAULT")
@@ -321,35 +342,55 @@ class TestTieredFipsMode:
     homelab/dev use; M3_FIPS_STRICT additionally requires the CMVP-validated
     FIPS module and refuses a non-FIPS lib with a clear message."""
 
-    def test_fips_mode_accepts_non_fips_wolfssl(self, monkeypatch):
+    def test_fips_mode_accepts_non_fips_wolfssl(self):
         """Homelab tier: M3_FIPS_MODE=1 + open-source wolfSSL (no FIPS symbols)
         -> initializes, runs real wolfCrypt, but flags itself non-validated."""
-        cp = _wolf_provider_with_mock(monkeypatch, fips_mode="1", non_fips=True)
-        p = cp.CryptoProvider("WOLFSSL")
-        assert p._initialized is True
-        assert p.backend == "WOLFSSL"
-        assert p._fips_validated is False  # open-source build is NOT validated
-        # Real wolfCrypt crypto still works.
-        import hashlib
-        assert p.sha256(b"abc") == hashlib.sha256(b"abc").hexdigest()
+        v = _run_fips_subprocess(
+            """
+            cp = _install_mock(non_fips=True)
+            p = cp.CryptoProvider("WOLFSSL")
+            _emit(initialized=p._initialized, backend=p.backend,
+                  validated=p._fips_validated,
+                  sha_ok=(p.sha256(b"abc") == hashlib.sha256(b"abc").hexdigest()))
+            """,
+            env={"M3_FIPS_MODE": "1"},
+        )
+        assert v["initialized"] is True
+        assert v["backend"] == "WOLFSSL"
+        assert v["validated"] is False  # open-source build is NOT validated
+        assert v["sha_ok"] is True      # real wolfCrypt crypto still works
 
-    def test_fips_strict_refuses_non_fips_wolfssl(self, monkeypatch):
+    def test_fips_strict_refuses_non_fips_wolfssl(self):
         """Strict tier: M3_FIPS_STRICT=1 + open-source wolfSSL -> FATAL, with a
         message naming the open-source-vs-validated distinction."""
-        with pytest.raises(RuntimeError) as exc:
-            cp = _wolf_provider_with_mock(
-                monkeypatch, fips_mode="1", strict="1", non_fips=True
-            )
-            cp.CryptoProvider("WOLFSSL")
-        assert "OPEN-SOURCE" in str(exc.value) or "validated" in str(exc.value).lower()
+        v = _run_fips_subprocess(
+            """
+            msg = None
+            try:
+                cp = _install_mock(non_fips=True)
+                cp.CryptoProvider("WOLFSSL")
+            except RuntimeError as exc:
+                msg = str(exc)
+            _emit(msg=msg)
+            """,
+            env={"M3_FIPS_MODE": "1", "M3_FIPS_STRICT": "1"},
+        )
+        assert v["msg"] is not None, "strict mode must refuse a non-FIPS build"
+        assert "OPEN-SOURCE" in v["msg"] or "validated" in v["msg"].lower()
 
-    def test_fips_strict_accepts_validated_wolfssl(self, monkeypatch):
+    def test_fips_strict_accepts_validated_wolfssl(self):
         """Strict tier with the FIPS symbols present (mock simulates validated)
         -> initializes and reports validated."""
-        cp = _wolf_provider_with_mock(monkeypatch, fips_mode="1", strict="1", non_fips=False)
-        p = cp.CryptoProvider("WOLFSSL")
-        assert p._initialized is True
-        assert p._fips_validated is True
+        v = _run_fips_subprocess(
+            """
+            cp = _install_mock(non_fips=False)
+            p = cp.CryptoProvider("WOLFSSL")
+            _emit(initialized=p._initialized, validated=p._fips_validated)
+            """,
+            env={"M3_FIPS_MODE": "1", "M3_FIPS_STRICT": "1"},
+        )
+        assert v["initialized"] is True
+        assert v["validated"] is True
 
     def test_fips_validated_flag_exists(self, monkeypatch):
         cp = _reload_provider(monkeypatch, backend="DEFAULT")
@@ -420,8 +461,13 @@ class TestSecureWolfsslDiscovery:
         cp = _reload_provider(monkeypatch, backend="DEFAULT")
         monkeypatch.delenv("M3_WOLFSSL_LIB", raising=False)
         # Point M3 roots at an empty temp area so ~/.m3/lib resolves nowhere real.
+        # BOTH roots must move: _m3_lib_dir() prefers M3_CONFIG_ROOT's parent over
+        # M3_MEMORY_ROOT, so on a dev box that has a real ~/.m3/lib/wolfssl.dll,
+        # redirecting only M3_MEMORY_ROOT leaves the real lib discoverable.
         import tempfile
-        monkeypatch.setenv("M3_MEMORY_ROOT", tempfile.mkdtemp(prefix="m3empty-"))
+        empty = tempfile.mkdtemp(prefix="m3empty-")
+        monkeypatch.setenv("M3_MEMORY_ROOT", empty)
+        monkeypatch.setenv("M3_CONFIG_ROOT", os.path.join(empty, "config"))
         # System dirs won't have wolfssl on a test box; expect None.
         assert cp._resolve_wolfssl_path() is None
 
@@ -444,13 +490,30 @@ class TestSecureWolfsslDiscovery:
         monkeypatch.setenv("M3_WOLFSSL_SHA256", hashlib.sha256(data).hexdigest())
         assert cp._resolve_wolfssl_path() == str(lib)
 
-    def test_fips_mode_fatal_when_no_trusted_lib(self, monkeypatch):
+    def test_fips_mode_fatal_when_no_trusted_lib(self):
         """FIPS mode + no wolfSSL in any trusted path -> FATAL (never silently
-        falls back, never searches CWD/PATH)."""
-        import tempfile
-        cp = _reload_provider(monkeypatch, backend="DEFAULT")
-        monkeypatch.delenv("M3_WOLFSSL_LIB", raising=False)
-        monkeypatch.setenv("M3_MEMORY_ROOT", tempfile.mkdtemp(prefix="m3empty-"))
-        monkeypatch.setenv("M3_FIPS_MODE", "1")
-        with pytest.raises(RuntimeError, match="TRUSTED|trusted"):
-            cp.CryptoProvider("WOLFSSL")
+        falls back, never searches CWD/PATH). Isolated (#85): constructing the
+        WOLFSSL provider touches the native loader."""
+        v = _run_fips_subprocess(
+            """
+            os.environ.pop("M3_WOLFSSL_LIB", None)
+            # Move BOTH roots so a real ~/.m3/lib/wolfssl.dll on a dev box can't be
+            # discovered (M3_CONFIG_ROOT's parent wins over M3_MEMORY_ROOT).
+            empty = tempfile.mkdtemp(prefix="m3empty-")
+            os.environ["M3_MEMORY_ROOT"] = empty
+            os.environ["M3_CONFIG_ROOT"] = os.path.join(empty, "config")
+            # Under FIPS mode with no trusted lib, fail-closed can fire either at
+            # module import (the module-level provider init) OR at explicit
+            # construction — accept a RuntimeError from either point.
+            msg = None
+            try:
+                import crypto_provider as cp
+                cp.CryptoProvider("WOLFSSL")
+            except RuntimeError as exc:
+                msg = str(exc)
+            _emit(msg=msg)
+            """,
+            env={"M3_FIPS_MODE": "1"},
+        )
+        assert v["msg"] is not None, "FIPS mode with no trusted lib must be FATAL"
+        assert "TRUSTED" in v["msg"] or "trusted" in v["msg"]


### PR DESCRIPTION
Fixes #85.

## Problem

`test_fips_integrity.py` reloaded `crypto_provider` in ~13 tests to exercise wolfSSL backend selection. Once one test loaded the native wolfSSL DLL, a later `importlib.reload()` re-initialized it in the same process and, on **Windows**, segfaulted the **entire** pytest run (`Windows fatal exception: access violation`, exit 139) — so `pytest tests/` could not be run as a single command.

Root cause (proven): a plain `import crypto_provider` in a fresh interpreter is fine; adding `importlib.reload()` right after crashes even in a fresh interpreter. Reloading a ctypes-loaded native library in an already-initialized process is the hazard.

## Fix

Every test that loads wolfSSL — real, or the ctypes-mocked build — now runs its assertions in a **subprocess** via `_run_fips_subprocess()` and returns a JSON verdict. A fresh interpreter loads the native lib exactly once and exits cleanly, so it can never corrupt the shared run. DEFAULT-backend tests don't touch native code and stay in-process. The in-process `MockLibWolf` install+reload helper is replaced by the subprocess prelude's `_install_mock()`. Mirrors conftest's native-embedder-disabled discipline.

Also fixed two **latent, pre-existing** env-assumption bugs surfaced once the crash was gone: `test_resolve_returns_none_when_no_trusted_lib` and `test_fips_mode_fatal_when_no_trusted_lib` assumed no wolfSSL is installed, but a dev box with a real `~/.m3/lib/wolfssl.dll` made `_m3_lib_dir()` (which prefers `M3_CONFIG_ROOT`'s parent) still discover it. Both now redirect **both** roots to an empty temp dir. (These two failed on `main` too on a wolfSSL-equipped box — verified.)

## Verification

- `test_fips_integrity.py`: **32/32 pass**, stable across repeated runs (was: segfault).
- Full local suite: **1942 passed, exit 0** (was: exit 139 mid-run).
- ruff + mypy (py3.11) clean.

## Note on merge order

Best merged **after** #86 (thread-leak guard + wedge fix). This PR doesn't touch threads, so it passes the guard; landing #86 first means `main` is fully green on the whole `pytest tests/` on Windows once both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)