### PR TITLE
fix(chatlog-status): stop false "capture may be down" alarm on session-start lull

### DIFF
--- a/bin/chatlog_status.py
+++ b/bin/chatlog_status.py
@@ -208,6 +208,33 @@ def _recent_write_count(config: chatlog_config.ChatlogConfig,
     return 0 if queried_ok else -1
 
 
+# A 0-in-15min window is only a genuine "capture down" signal if the LAST write
+# was also long ago. On a just-started session (or an ordinary between-turns
+# lull), the Stop/PreCompact hook has simply not fired yet, so the 15-min count
+# is legitimately 0 while the store is perfectly healthy — the last write is just
+# minutes-to-hours old. Screaming "capture may be down" in that case is a false
+# alarm that trips the CLAUDE.md session-start check every single fresh session
+# (observed 2026-07-12: alarm fired while this very session's turns were landing).
+# Grace: if the last write is within this many minutes, downgrade the scream to a
+# benign note. Beyond it (or last-write unknown), the real alarm still fires.
+_LULL_GRACE_MIN = 360  # 6h — comfortably longer than any between-turns gap
+
+
+def _minutes_since(iso_ts: str | None) -> float | None:
+    """Minutes between `iso_ts` (an ISO-8601 UTC stamp) and now, or None if the
+    stamp is missing/unparseable. Tolerant of a trailing 'Z' and of fractional
+    seconds, matching how last_write_at is stored."""
+    if not iso_ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - dt).total_seconds() / 60.0
+    except (ValueError, TypeError):
+        return None
+
+
 def _compute_warnings(
     state: dict[str, Any],
     config: chatlog_config.ChatlogConfig,
@@ -224,10 +251,22 @@ def _compute_warnings(
     # 0 recent writes and should not scream).
     total_rows = row_counts.get("main_chat_log_rows", 0) or row_counts.get("chatlog_rows", 0)
     if recent_writes == 0 and total_rows > 0:
-        warnings.append(
-            f"NO chatlog writes in last {recent_window_min}min "
-            "(capture may be down — verify before trusting memory)"
-        )
+        # Disambiguate session-start/between-turns lull from a real outage using
+        # the age of the LAST write (see _LULL_GRACE_MIN). A recent last-write
+        # means the hook just hasn't fired this window yet — benign; anything
+        # older (or unknown) keeps the real "capture may be down" alarm.
+        mins_since_last = _minutes_since(state.get("last_write_at"))
+        if mins_since_last is not None and mins_since_last <= _LULL_GRACE_MIN:
+            warnings.append(
+                f"no chatlog writes in last {recent_window_min}min "
+                f"(last write {int(mins_since_last)}min ago — "
+                "capture idle, not down)"
+            )
+        else:
+            warnings.append(
+                f"NO chatlog writes in last {recent_window_min}min "
+                "(capture may be down — verify before trusting memory)"
+            )
     elif recent_writes < 0:
         warnings.append("could not query recent chatlog writes (capture status unknown)")
 

--- a/tests/test_chatlog_status.py
+++ b/tests/test_chatlog_status.py
@@ -381,6 +381,98 @@ def test_recent_write_count_missing_dbs_returns_unknown(
     assert chatlog_status._recent_write_count(cfg) == -1
 
 
+def test_lull_does_not_trigger_capture_down_alarm(status_test_env):
+    """Session-start / between-turns regression: 0 rows in the 15-min window but
+    a RECENT last_write_at must NOT emit the 'capture may be down' scream — it is
+    an ordinary lull (the Stop hook just hasn't fired this window yet). This is
+    the false alarm that tripped the CLAUDE.md session-start check every fresh
+    session (observed 2026-07-12)."""
+    import chatlog_status
+
+    chatlog_db = status_test_env["db_path"]
+    main_db = status_test_env["main_db_path"]
+    _create_recent_schema(str(chatlog_db))
+    _create_recent_schema(str(main_db))
+
+    # An OLD row (outside the 15-min window) so total_rows > 0 and recent == 0...
+    conn = sqlite3.connect(str(chatlog_db))
+    conn.execute(
+        "INSERT INTO memory_items (id, type, created_at) "
+        "VALUES ('old', 'chat_log', '2020-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    conn.close()
+
+    # ...but the state file says the last write was 3 minutes ago (a lull).
+    from datetime import datetime, timedelta, timezone
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=3)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    with open(str(status_test_env["state_file"]), "w") as f:
+        json.dump({"last_write_at": recent}, f)
+
+    parsed = json.loads(chatlog_status.chatlog_status_impl())
+    assert not any("capture may be down" in w for w in parsed["warnings"]), (
+        f"lull wrongly raised capture-down alarm: {parsed['warnings']}"
+    )
+    # It should still note the idle window benignly, so the state is visible.
+    assert any("capture idle, not down" in w for w in parsed["warnings"])
+
+
+def test_stale_last_write_still_triggers_capture_down_alarm(status_test_env):
+    """Complement to the lull test: when the last write is OLDER than the grace
+    window, a 0-in-15min count is a genuine outage and the real 'capture may be
+    down' alarm MUST still fire. The lull grace must not mask a true failure."""
+    import chatlog_status
+
+    chatlog_db = status_test_env["db_path"]
+    main_db = status_test_env["main_db_path"]
+    _create_recent_schema(str(chatlog_db))
+    _create_recent_schema(str(main_db))
+
+    conn = sqlite3.connect(str(chatlog_db))
+    conn.execute(
+        "INSERT INTO memory_items (id, type, created_at) "
+        "VALUES ('old', 'chat_log', '2020-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    conn.close()
+
+    # last_write_at well beyond the 6h grace window.
+    with open(str(status_test_env["state_file"]), "w") as f:
+        json.dump({"last_write_at": "2020-01-01T00:00:00Z"}, f)
+
+    parsed = json.loads(chatlog_status.chatlog_status_impl())
+    assert any("capture may be down" in w for w in parsed["warnings"]), (
+        f"stale last-write failed to raise capture-down alarm: {parsed['warnings']}"
+    )
+
+
+def test_missing_last_write_triggers_capture_down_alarm(status_test_env):
+    """No last_write_at at all (unknown age) with 0 recent rows is treated as a
+    real outage, not a lull — the grace only applies to a KNOWN-recent write."""
+    import chatlog_status
+
+    chatlog_db = status_test_env["db_path"]
+    main_db = status_test_env["main_db_path"]
+    _create_recent_schema(str(chatlog_db))
+    _create_recent_schema(str(main_db))
+
+    conn = sqlite3.connect(str(chatlog_db))
+    conn.execute(
+        "INSERT INTO memory_items (id, type, created_at) "
+        "VALUES ('old', 'chat_log', '2020-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    conn.close()
+
+    # No state file written -> last_write_at is None -> unknown age.
+    parsed = json.loads(chatlog_status.chatlog_status_impl())
+    assert any("capture may be down" in w for w in parsed["warnings"]), (
+        f"unknown last-write failed to raise capture-down alarm: {parsed['warnings']}"
+    )
+
+
 def test_recent_write_probe_opens_read_only(status_test_env):
     """The probe must open DBs read-only (§6): it must never be able to mutate
     the store it is only counting."""


### PR DESCRIPTION
Fixes a false-positive in `chatlog_status` that fired the "capture may be down" alarm on **every fresh session**.

## Problem
`_compute_warnings` treated any 0-rows-in-15min as a capture-down signal. But a just-started session (before its first Stop/PreCompact hook fires) or an ordinary between-turns gap legitimately has 0 recent rows while the store is perfectly healthy. The scream tripped the `CLAUDE.md` session-start check into a false alarm — observed 2026-07-12 while the session's own turns were actively landing in the DB.

This is the latest in a lineage of "wiring flag ≠ capture signal" fixes (2026-06-13 / 06-27 / 07-04); the remaining gap was that a *real* 0 at session start was indistinguishable from a real outage.

## Fix
Disambiguate lull from outage by the **age of the last write**:
- Last write within a 6h grace window → benign note (`capture idle, not down`).
- Stale or unknown last-write → the real `capture may be down` alarm still fires.

`capture.healthy` / `recent_rows` are unchanged — this only affects warning text, not the health signal machine callers read.

## Tests
Adds 3 regressions: lull (no alarm), stale last-write (alarm), missing last-write (alarm). Full status suite green (29 passed).