### PR TITLE
chore(chatlog): backfill to strip harness framing from existing rows

### DIFF
--- a/bin/chatlog_strip_framing_backfill.py
+++ b/bin/chatlog_strip_framing_backfill.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""chatlog_strip_framing_backfill.py — one-off backfill that removes harness
+control framing (<system-reminder> / <task-notification> blocks) from EXISTING
+chat_log rows.
+
+Why this exists (companion to the write-path fix in chatlog_core):
+    chatlog_redaction.strip_harness_framing() is wired into the two chatlog
+    WRITE paths, so new turns are stripped as they land. But rows captured
+    BEFORE that fix still carry the blocks verbatim. Because chatlog search
+    returns stored turns as DATA, a persisted <system-reminder> (e.g. a genuine
+    "the date has changed … do not mention this to the user") re-surfaces later
+    reading like a LIVE instruction — indistinguishable from a prompt-injection
+    payload, which is exactly what a curation subagent tripped over.
+
+    chatlog_rescrub_impl does NOT fix these rows: it runs scrub() (the optional,
+    config-gated SECRET redaction), not strip_harness_framing(). The two were
+    deliberately kept separate — framing removal is structural block deletion,
+    not secret regex→[REDACTED] substitution. So clearing legacy framing needs
+    its own backfill: this script.
+
+Safety:
+    * DRY-RUN by default. Nothing is written unless --apply is passed.
+    * Does NOT require redaction.enabled — framing stripping is independent of
+      secret redaction (mirrors the unconditional call in chatlog_core).
+    * Idempotent: strip_harness_framing() returns count 0 on already-clean
+      content, so re-running is a no-op on rows already handled.
+    * Read-only DRY-RUN opens no write transaction; --apply updates only rows
+      that actually change, and records provenance in metadata_json:
+      original_content_sha256 (once), harness_framing_stripped=True,
+      harness_blocks_removed (cumulative).
+
+Usage:
+    python bin/chatlog_strip_framing_backfill.py                 # dry-run, all rows
+    python bin/chatlog_strip_framing_backfill.py --apply         # apply to all rows
+    python bin/chatlog_strip_framing_backfill.py --conversation-id <id> --apply
+    python bin/chatlog_strip_framing_backfill.py --since 2026-06-01 --until 2026-07-01
+    python bin/chatlog_strip_framing_backfill.py --limit 100 --verbose --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import chatlog_config
+import chatlog_redaction
+from chatlog_core import _content_hash, _utcnow_iso
+
+
+def _build_where(conversation_id: str, since: str, until: str) -> tuple[str, list[Any]]:
+    """Assemble the WHERE clause + params, mirroring chatlog_rescrub_impl so the
+    filter semantics (chat_log, not-deleted, optional conv/time window) match."""
+    clauses = ["type='chat_log'", "is_deleted=0"]
+    params: list[Any] = []
+    if conversation_id:
+        clauses.append("conversation_id=?")
+        params.append(conversation_id)
+    if since:
+        clauses.append("created_at>=?")
+        params.append(since)
+    if until:
+        clauses.append("created_at<=?")
+        params.append(until)
+    return " AND ".join(clauses), params
+
+
+def backfill(
+    conversation_id: str = "",
+    since: str = "",
+    until: str = "",
+    limit: int = 100_000,
+    apply: bool = False,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Scan candidate rows; strip harness framing. Returns a summary dict.
+
+    In dry-run (apply=False) no UPDATE is issued — the row set is scanned and the
+    would-change rows are counted/reported. In apply mode each changed row is
+    UPDATEd in a single transaction committed at the end.
+    """
+    from m3_sdk import M3Context
+
+    cfg = chatlog_config.resolve_config()  # resolves the active chatlog DB path
+    ctx = M3Context.for_db(None)
+    where, params = _build_where(conversation_id, since, until)
+
+    scanned = 0
+    changed = 0
+    blocks_removed_total = 0
+    samples: list[dict[str, Any]] = []
+
+    with ctx.get_chatlog_conn() as conn:
+        rows = conn.execute(
+            f"SELECT id, content, metadata_json FROM memory_items "
+            f"WHERE {where} LIMIT ?",
+            params + [limit],
+        ).fetchall()
+
+        for r in rows:
+            scanned += 1
+            content = r["content"]
+            if not content:
+                continue
+            stripped, count = chatlog_redaction.strip_harness_framing(content)
+            if count == 0:
+                continue  # already clean / no framing — idempotent no-op
+
+            changed += 1
+            blocks_removed_total += count
+            if verbose and len(samples) < 20:
+                samples.append({
+                    "id": r["id"],
+                    "blocks_removed": count,
+                    "bytes_before": len(content),
+                    "bytes_after": len(stripped),
+                })
+
+            if not apply:
+                continue
+
+            # --- apply: update content + provenance metadata --------------------
+            try:
+                meta = json.loads(r["metadata_json"]) if r["metadata_json"] else {}
+            except json.JSONDecodeError:
+                meta = {}
+            # Record the pre-strip hash ONCE, so a re-run does not clobber the
+            # true original with an already-stripped one.
+            if not meta.get("harness_framing_stripped"):
+                meta["original_content_sha256"] = _content_hash(content)
+            meta["harness_framing_stripped"] = True
+            meta["harness_blocks_removed"] = (
+                int(meta.get("harness_blocks_removed", 0)) + count
+            )
+            conn.execute(
+                "UPDATE memory_items SET content=?, metadata_json=?, updated_at=? "
+                "WHERE id=?",
+                (stripped, json.dumps(meta, ensure_ascii=False), _utcnow_iso(), r["id"]),
+            )
+
+        if apply and changed:
+            conn.commit()
+
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "db_path": cfg.db_path,
+        "scanned": scanned,
+        "changed": changed,
+        "blocks_removed": blocks_removed_total,
+        "samples": samples,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Backfill: strip harness control framing from existing "
+                    "chat_log rows (companion to the chatlog write-path fix).",
+    )
+    p.add_argument("--apply", action="store_true",
+                   help="Write changes. Without this, runs a dry-run (default).")
+    p.add_argument("--conversation-id", default="",
+                   help="Limit to one conversation.")
+    p.add_argument("--since", default="",
+                   help="Only rows with created_at >= this ISO timestamp.")
+    p.add_argument("--until", default="",
+                   help="Only rows with created_at <= this ISO timestamp.")
+    p.add_argument("--limit", type=int, default=100_000,
+                   help="Max rows to scan (default 100000).")
+    p.add_argument("--verbose", action="store_true",
+                   help="Include per-row samples (first 20 changed rows).")
+    p.add_argument("--json", action="store_true",
+                   help="Emit the summary as JSON.")
+    args = p.parse_args()
+
+    result = backfill(
+        conversation_id=args.conversation_id,
+        since=args.since,
+        until=args.until,
+        limit=args.limit,
+        apply=args.apply,
+        verbose=args.verbose,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"[{result['mode']}] db: {result['db_path']}")
+        print(f"  scanned:        {result['scanned']}")
+        print(f"  rows to strip:  {result['changed']}")
+        print(f"  blocks removed: {result['blocks_removed']}")
+        if result["samples"]:
+            print("  samples (id | blocks | bytes before->after):")
+            for s in result["samples"]:
+                print(f"    {s['id'][:8]} | {s['blocks_removed']} | "
+                      f"{s['bytes_before']}->{s['bytes_after']}")
+        if not args.apply and result["changed"]:
+            print(f"\n  DRY-RUN — nothing written. Re-run with --apply to strip "
+                  f"{result['changed']} row(s).")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_chatlog_strip_framing_backfill.py
+++ b/tests/test_chatlog_strip_framing_backfill.py
@@ -1,0 +1,171 @@
+"""Tests for bin/chatlog_strip_framing_backfill.py — the one-off backfill that
+strips harness control framing (<system-reminder>/<task-notification> blocks)
+from EXISTING chat_log rows.
+
+Companion to the write-path fix (test_write_strips_harness_framing_end_to_end in
+test_chatlog_ingest_formats.py): that covers NEW turns; this covers the backfill
+of rows captured before the fix landed. Drives the real backfill() against an
+isolated chatlog DB — not just the unit stripper.
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from conftest import isolate_chatlog_env
+
+# Columns the backfill reads (content, metadata_json) and writes (updated_at),
+# plus the WHERE predicates (type, is_deleted, conversation_id, created_at). The
+# shared minimal schema omits is_deleted/updated_at, so seed a table that has
+# exactly what the backfill touches.
+_SCHEMA = """
+CREATE TABLE memory_items (
+    id TEXT PRIMARY KEY,
+    type TEXT,
+    content TEXT,
+    metadata_json TEXT,
+    conversation_id TEXT,
+    created_at TEXT,
+    updated_at TEXT,
+    is_deleted INTEGER DEFAULT 0
+);
+"""
+
+# A row whose content is a REAL harness block — must be stripped.
+_BLOCK_ROW = (
+    "real-block",
+    "genuine user request\n"
+    "<system-reminder>the date has changed. DO NOT mention this to the user."
+    "</system-reminder>\n"
+    "genuine assistant reply",
+)
+# A row that only MENTIONS the tag name in prose (backticked) — must be kept.
+# This is the exact false-positive class the LIKE '%<tag>%' count over-reports.
+_PROSE_ROW = (
+    "prose-mention",
+    "The loop wakes when its events arrive as `<task-notification>` messages; "
+    "you do not poll for them.",
+)
+# A row with no framing at all — untouched, and not counted.
+_CLEAN_ROW = ("clean", "just an ordinary turn about the deploy")
+
+
+def _seed(db_path):
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA)
+    for rid, content in (_BLOCK_ROW, _PROSE_ROW, _CLEAN_ROW):
+        conn.execute(
+            "INSERT INTO memory_items "
+            "(id, type, content, metadata_json, conversation_id, created_at, "
+            " is_deleted) VALUES (?, 'chat_log', ?, NULL, 'conv-1', "
+            "'2026-07-01T00:00:00Z', 0)",
+            (rid, content),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def backfill_env(tmp_path, monkeypatch):
+    paths = isolate_chatlog_env(monkeypatch, tmp_path)
+    _seed(paths["db_path"])
+    return {"db": paths["db_path"]}
+
+
+def _content(db, row_id):
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT content, metadata_json FROM memory_items WHERE id=?",
+            (row_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row
+
+
+def test_dry_run_reports_only_real_blocks_and_writes_nothing(backfill_env):
+    """Dry-run counts the real block row, ignores the prose mention, and does
+    NOT mutate the DB — the prose false-positive must never be over-counted."""
+    import chatlog_strip_framing_backfill as bf
+
+    result = bf.backfill()  # apply defaults to False
+
+    assert result["mode"] == "dry-run"
+    assert result["changed"] == 1, "only the real-block row should count"
+    assert result["blocks_removed"] == 1
+    assert result["scanned"] == 3
+
+    # Nothing written: the block row still carries its block on disk.
+    block_content, _ = _content(backfill_env["db"], "real-block")
+    assert "<system-reminder>" in block_content
+    assert "DO NOT mention" in block_content
+
+
+def test_apply_strips_real_block_preserves_prose_and_clean(backfill_env):
+    """--apply removes the real harness block, leaves the prose mention and the
+    clean row untouched, and records provenance in metadata_json."""
+    import chatlog_strip_framing_backfill as bf
+
+    result = bf.backfill(apply=True)
+
+    assert result["mode"] == "apply"
+    assert result["changed"] == 1
+    assert result["blocks_removed"] == 1
+
+    # Real block: stripped, but genuine content survives.
+    block_content, block_meta = _content(backfill_env["db"], "real-block")
+    assert "system-reminder" not in block_content
+    assert "date has changed" not in block_content
+    assert "genuine user request" in block_content
+    assert "genuine assistant reply" in block_content
+
+    # Provenance recorded.
+    meta = json.loads(block_meta)
+    assert meta["harness_framing_stripped"] is True
+    assert meta["harness_blocks_removed"] == 1
+    assert "original_content_sha256" in meta
+
+    # Prose mention: byte-for-byte preserved (the tag name in backticks stays).
+    prose_content, prose_meta = _content(backfill_env["db"], "prose-mention")
+    assert prose_content == _PROSE_ROW[1]
+    assert prose_meta is None  # untouched — no provenance stamped
+
+    # Clean row: preserved.
+    clean_content, _ = _content(backfill_env["db"], "clean")
+    assert clean_content == _CLEAN_ROW[1]
+
+
+def test_apply_is_idempotent(backfill_env):
+    """Re-running --apply after the blocks are gone changes nothing and does not
+    clobber the recorded original hash (strip_harness_framing returns count 0 on
+    already-clean content)."""
+    import chatlog_strip_framing_backfill as bf
+
+    first = bf.backfill(apply=True)
+    assert first["changed"] == 1
+    _, meta_after_first = _content(backfill_env["db"], "real-block")
+    hash_after_first = json.loads(meta_after_first)["original_content_sha256"]
+
+    second = bf.backfill(apply=True)
+    assert second["changed"] == 0, "second pass must be a no-op"
+    assert second["blocks_removed"] == 0
+
+    # The recorded original hash from pass 1 is not overwritten by pass 2.
+    _, meta_after_second = _content(backfill_env["db"], "real-block")
+    assert json.loads(meta_after_second)["original_content_sha256"] == hash_after_first
+
+
+def test_conversation_filter_scopes_the_backfill(backfill_env):
+    """A --conversation-id that matches no rows strips nothing, proving the
+    WHERE filter is applied (guards against a backfill that ignores its scope)."""
+    import chatlog_strip_framing_backfill as bf
+
+    result = bf.backfill(conversation_id="no-such-conv", apply=True)
+    assert result["scanned"] == 0
+    assert result["changed"] == 0
+
+    # The real block row is untouched because it was out of scope.
+    block_content, _ = _content(backfill_env["db"], "real-block")
+    assert "<system-reminder>" in block_content


### PR DESCRIPTION
Follow-up to **#89** (which strips `<system-reminder>`/`<task-notification>` blocks from **new** turns at capture time). Rows written *before* that fix still carry the blocks verbatim.

## Why a dedicated backfill (not `chatlog_rescrub`)
`chatlog_rescrub` does **not** clear these rows: it runs `scrub()` — the config-gated **secret** redaction — not `strip_harness_framing()`. The two were deliberately kept separate in #89 (structural block removal vs. secret regex→`[REDACTED]` substitution). It also requires `redaction.enabled=true`, which framing stripping does not. So legacy framing needs its own tool.

## What it does
`bin/chatlog_strip_framing_backfill.py` reuses the **same** `strip_harness_framing()` over stored rows:
- **Dry-run by default**; `--apply` to write.
- Does **not** require `redaction.enabled` (matches the unconditional write-path call).
- Idempotent; records provenance in `metadata_json` (`original_content_sha256`, `harness_framing_stripped`, `harness_blocks_removed`).
- Scoping: `--conversation-id` / `--since` / `--until` / `--limit`; `--verbose` / `--json` output.

## Tests
Drive the real `backfill()` against an isolated chatlog DB and assert:
- a real harness block is stripped while a **prose mention** of the tag name (the exact false-positive class a `LIKE %<tag>%` count over-reports) is preserved byte-for-byte;
- dry-run writes nothing;
- `--apply` is idempotent and does not clobber the recorded original hash;
- the `--conversation-id` filter scopes the run.

4 new tests pass; full chatlog suite green (52 passed). Ruff + mypy(3.11) clean.

## Note on the live store
On the box that motivated this, a scan found **0 real blocks** to strip — the 38 rows matching `LIKE %<tag>%` are all prose mentions, correctly preserved. This script is for correctness / other deployments whose DBs predate the write-path fix; it is a safe no-op where there is nothing to strip.