### PR TITLE
fix(mcp): eliminate embed-path and event-loop lockups in the stdio server

### DIFF
--- a/bin/embed_server_inproc.py
+++ b/bin/embed_server_inproc.py
@@ -65,10 +65,155 @@ logger = logging.getLogger("embed_server_inproc")
 # via M3_EMBED_SERVER_MAX_BATCH. The client's own EMBED_BULK_CHUNK is 1024, so
 # this is a safety ceiling, not the expected batch size.
 _MAX_BATCH = int(os.environ.get("M3_EMBED_SERVER_MAX_BATCH", "2048"))
-# Serialise GPU calls: the embedder is one CUDA context; concurrent Python
-# callers must not interleave into it. Semaphore(1) = strict serialisation
-# (correct + simplest); raise only if the backend is proven concurrency-safe.
-_GPU_SEM = asyncio.Semaphore(int(os.environ.get("M3_EMBED_SERVER_CONCURRENCY", "1")))
+
+# ── Two-lane admission gate (interactive fast-lane) ───────────────────────────
+# WHY: the Rust `m3_core_rs.EmbeddedEmbedder` is NOT one serial CUDA context —
+# it wraps `m3_dispatcher::Dispatcher<EmbeddedBackend>` with a POOL of
+# `M3_EMBED_STREAMS` (default 8) independent contexts, its own slot semaphore,
+# and a circuit breaker. `embed()` releases the GIL and its decode region is
+# pure Rust, so it is SAFE to call concurrently — the dispatcher fans calls out
+# across its stream pool without interleaving into a single context. (The old
+# `Semaphore(1)` here predated the multi-stream dispatcher and throttled an
+# 8-wide backend down to strictly serial — that serialisation, not any GPU
+# limit, is what made an interactive query queue behind a bulk ingestion batch
+# and wedge the single-event-loop MCP server.)
+#
+# POLICY: strict reservation (chosen 2026-07-14, user bhaba). Bulk is capped at
+# `bulk_max = total - reserved` and NEVER exceeds it — even when the reserved
+# slots are idle. `reserved` (default 1) slots are held for interactive
+# single-query embeds so a search ALWAYS finds a free slot and never waits
+# behind a bulk batch (batches are non-preemptible, so a work-conserving borrow
+# would let bulk fill every slot and reintroduce the ~1-batch wait — the wedge
+# this fix exists to kill). Interactive itself is NOT capped: when bulk is idle
+# it may use up to `total`. The cost of strict reserve is that peak bulk
+# concurrency is `total-1` instead of `total` during idle periods — accepted in
+# exchange for a constant, load-independent interactive latency.
+#
+# `total` DEFAULTS TO THE BACKEND STREAM POOL (M3_EMBED_STREAMS, typically 8) —
+# resolved from the loaded embedder in _resolve_admission(), so the server uses
+# the full concurrency the Rust dispatcher offers rather than an arbitrary cap.
+# Override with M3_EMBED_SERVER_CONCURRENCY (still clamped to the backend pool).
+#
+# Classification is by batch size (interactive posts 1 text, bulk posts up to
+# EMBED_BULK_CHUNK=1024) with an explicit `X-M3-Embed-Priority` header override.
+_INTERACTIVE_MAX_TEXTS = int(os.environ.get("M3_EMBED_INTERACTIVE_MAX_TEXTS", "8"))
+# Slots reserved for interactive (never usable by bulk). >=1 guarantees a search
+# always has a free slot.
+_INTERACTIVE_RESERVED = int(os.environ.get("M3_EMBED_SERVER_INTERACTIVE_RESERVED", "1"))
+# Total admission ceiling. 0 (the default sentinel) => use the backend stream
+# pool as resolved in _resolve_admission(). A positive value overrides but is
+# still clamped to the backend pool so we never over-subscribe the dispatcher.
+_ADMISSION_TOTAL_DEFAULT = int(os.environ.get("M3_EMBED_SERVER_CONCURRENCY", "0"))
+
+
+class _AdmissionGate:
+    """Strict-reservation admission (no borrow).
+
+    `total` concurrent GPU calls are allowed (clamped to the backend stream
+    pool). At most `bulk_max = total - reserved` of them may be BULK requests,
+    and bulk NEVER exceeds that — even when the reserved slots are idle. The
+    `reserved` slots (>=1) are held for interactive single-query embeds so an
+    interactive request ALWAYS finds a free slot and never waits behind a bulk
+    batch. Interactive itself is not per-lane capped: when bulk is idle it may
+    use up to `total`. In-flight batches are never preempted (bounded by
+    _MAX_BATCH), but strict reservation means an interactive request never has
+    to wait for one — there is always a slot bulk cannot occupy.
+    """
+
+    def __init__(self, total: int, reserved: int = 1):
+        self.total = max(1, total)
+        # Reserve at least 1 (guarantee an interactive slot) but leave bulk >=1.
+        self.reserved = max(1, min(reserved, self.total - 1)) if self.total > 1 else 0
+        self.bulk_max = self.total - self.reserved
+        # Counts guarded by _cv.
+        self._bulk_inflight = 0
+        self._interactive_inflight = 0
+        self._cv = asyncio.Condition()
+
+    def _bulk_may_run_locked(self) -> bool:
+        """Bulk admission (call under _cv): strictly capped at bulk_max. No
+        borrow — the reserved slots are never available to bulk, so an
+        interactive request always has room."""
+        return self._bulk_inflight < self.bulk_max
+
+    def _interactive_may_run_locked(self) -> bool:
+        """Interactive admission (call under _cv): bounded only by the overall
+        total. Because bulk can hold at most bulk_max = total - reserved, there
+        are always >= reserved slots interactive can take immediately."""
+        return (self._bulk_inflight + self._interactive_inflight) < self.total
+
+    async def acquire(self, *, interactive: bool):
+        async with self._cv:
+            if interactive:
+                while not self._interactive_may_run_locked():
+                    await self._cv.wait()
+                self._interactive_inflight += 1
+            else:
+                while not self._bulk_may_run_locked():
+                    await self._cv.wait()
+                self._bulk_inflight += 1
+            self._cv.notify_all()
+
+    async def release(self, *, interactive: bool):
+        async with self._cv:
+            if interactive:
+                self._interactive_inflight -= 1
+            else:
+                self._bulk_inflight -= 1
+            self._cv.notify_all()
+
+
+# Resolved in _load_embedder() once the backend stream count is known; a plain
+# Semaphore(1) fallback keeps import-time / test-time behaviour safe until then.
+_GATE: _AdmissionGate | None = None
+_GPU_SEM = asyncio.Semaphore(1)  # legacy fallback; superseded by _GATE at load
+
+
+def _resolve_admission() -> _AdmissionGate:
+    """Build the admission gate against the loaded backend's stream pool.
+
+    `total` defaults to the backend's stream count (`_embedder.streams()` — the
+    Rust dispatcher slot count == context-pool size, typically 8), so the server
+    uses the full concurrency the dispatcher offers. A positive
+    M3_EMBED_SERVER_CONCURRENCY (_ADMISSION_TOTAL_DEFAULT) overrides but is
+    clamped to the pool so we never over-subscribe it. Strict reservation holds
+    `_INTERACTIVE_RESERVED` (default 1) slot(s) for interactive so a search
+    always has room; bulk_max = total - reserved.
+    """
+    streams = 0
+    try:
+        if _embedder is not None and hasattr(_embedder, "streams"):
+            streams = int(_embedder.streams())
+    except Exception:  # noqa: BLE001 — introspection is best-effort
+        streams = 0
+    # Backend pool (fall back to a sane 4 if the backend can't report it).
+    pool = streams if streams > 0 else 4
+    # total: full pool by default (_ADMISSION_TOTAL_DEFAULT==0 sentinel), else the
+    # configured value, always clamped to the pool.
+    total = pool if _ADMISSION_TOTAL_DEFAULT <= 0 else min(_ADMISSION_TOTAL_DEFAULT, pool)
+    total = max(1, total)
+    gate = _AdmissionGate(total=total, reserved=_INTERACTIVE_RESERVED)
+    logger.info(
+        "admission gate: total=%d (backend streams=%d, configured=%s), "
+        "bulk_max=%d, interactive_reserved=%d (strict, no borrow)",
+        gate.total, streams,
+        _ADMISSION_TOTAL_DEFAULT if _ADMISSION_TOTAL_DEFAULT > 0 else "auto",
+        gate.bulk_max, gate.reserved,
+    )
+    return gate
+
+
+def _is_interactive(texts: list[str], request: "Request | None") -> bool:
+    """Classify a request: small batch => interactive, unless an explicit
+    `X-M3-Embed-Priority: bulk|interactive` header overrides."""
+    if request is not None:
+        pri = (request.headers.get("x-m3-embed-priority") or "").strip().lower()
+        if pri == "interactive":
+            return True
+        if pri == "bulk":
+            return False
+    return len(texts) <= _INTERACTIVE_MAX_TEXTS
+
 
 app = FastAPI(title="M3 Shared In-Process GPU Embedder")
 
@@ -160,6 +305,9 @@ def _load_embedder() -> None:
             "shared GPU embedder loaded (%s, dim=%d) in %.1fs — serving.",
             gguf, dim, time.perf_counter() - t0,
         )
+        # Build the admission gate now that the backend stream pool is known.
+        global _GATE
+        _GATE = _resolve_admission()
     except SystemExit:
         raise
     except Exception as e:  # noqa: BLE001 — any load failure is fatal for a shared embedder
@@ -178,10 +326,24 @@ def _coerce_texts(inp: Union[str, list[str]]) -> list[str]:
     return texts
 
 
-async def _embed(texts: list[str]) -> list[list[float]]:
-    """Serialised GPU embed. Runs the blocking call off the event loop."""
-    async with _GPU_SEM:
+async def _embed(texts: list[str], *, interactive: bool = False) -> list[list[float]]:
+    """Admission-gated GPU embed. Runs the blocking call off the event loop.
+
+    Concurrency is bounded by the two-lane admission gate (interactive requests
+    get reserved capacity; bulk is capped but may borrow when idle). The
+    underlying `_embedder.embed` is safe to call concurrently — the Rust
+    dispatcher fans the calls across its stream pool (see _AdmissionGate WHY).
+    """
+    gate = _GATE
+    if gate is None:
+        # Pre-load / test fallback: preserve the original strict-serial behaviour.
+        async with _GPU_SEM:
+            return await asyncio.to_thread(_embedder.embed, texts)  # type: ignore[union-attr]
+    await gate.acquire(interactive=interactive)
+    try:
         return await asyncio.to_thread(_embedder.embed, texts)  # type: ignore[union-attr]
+    finally:
+        await gate.release(interactive=interactive)
 
 
 @app.post("/embedding")
@@ -194,7 +356,7 @@ async def embedding(req: EmbeddingRequest, request: Request):
         return JSONResponse(status_code=413, content={"error": str(e)})
     if not texts:
         return {"data": []}
-    vecs = await _embed(texts)
+    vecs = await _embed(texts, interactive=_is_interactive(texts, request))
 
     if "application/octet-stream" in (request.headers.get("accept") or ""):
         import numpy as np
@@ -211,7 +373,7 @@ async def embedding(req: EmbeddingRequest, request: Request):
 
 
 @app.post("/v1/embeddings")
-async def v1_embeddings(req: EmbeddingRequest):
+async def v1_embeddings(req: EmbeddingRequest, request: Request):
     """OpenAI-compatible shape (tier-3 / LM-Studio-style callers)."""
     try:
         texts = _coerce_texts(req.input)
@@ -219,7 +381,7 @@ async def v1_embeddings(req: EmbeddingRequest):
         return JSONResponse(status_code=413, content={"error": str(e)})
     if not texts:
         return {"object": "list", "data": [], "model": _model_tag, "usage": {}}
-    vecs = await _embed(texts)
+    vecs = await _embed(texts, interactive=_is_interactive(texts, request))
     return {
         "object": "list",
         "data": [{"object": "embedding", "index": i, "embedding": v} for i, v in enumerate(vecs)],
@@ -273,9 +435,55 @@ def main() -> int:
     _load_embedder()  # fail-loud: exits non-zero if the embedder can't load
     logger.info("listening on http://%s:%d (loopback=%s)",
                 args.host, args.port, args.host in ("127.0.0.1", "localhost", "::1"))
-    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+    _run_server(args.host, args.port)
     return 0
 
 
+def _run_server(host: str, port: int) -> None:
+    """Run uvicorn in a way that survives a NO-CONSOLE launch (pythonw.exe).
+
+    The scheduled task (AgentOS_EmbedServer) launches this via `pythonw.exe`,
+    which has no console and no valid std handles. Under that launcher the
+    plain `uvicorn.run(app, ...)` server loop terminated the moment it went
+    live — uvicorn's default `run()` installs signal handlers and manages
+    stdin/stdout for its shutdown/reload machinery, and with pythonw those
+    handles are invalid, so `Server.serve()` returned immediately and the
+    process exited right after logging "listening" (bind succeeded, then no
+    one kept the loop alive).
+
+    Fix: build the Server explicitly and drive it with asyncio.run(), with
+    `install_signal_handlers=False` (the process is managed by the task /
+    parent, not by Ctrl-C) so the loop lifecycle no longer depends on console
+    or signal state that pythonw doesn't provide.
+    """
+    config = uvicorn.Config(
+        app, host=host, port=port, log_level="warning", use_colors=False,
+    )
+    server = uvicorn.Server(config)
+    # Do NOT let uvicorn install SIGINT/SIGTERM handlers: under pythonw there is
+    # no console to deliver them, and the attempt is part of why the default
+    # run() exits early. The task/parent stops us by terminating the process.
+    server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+    asyncio.run(server.serve())
+
+
+def _ensure_std_streams() -> None:
+    """Give the process real stdout/stderr when launched via pythonw.exe.
+
+    Under `pythonw` (no console) sys.stdout / sys.stderr are None. A stray write
+    from any dependency (llama.cpp C stdio, a logging fallback, a warning) then
+    raises and can take the process down. Bind the missing streams to devnull so
+    such writes are harmless. Idempotent; safe under normal python.exe (no-op).
+    """
+    import io
+    for name in ("stdout", "stderr"):
+        if getattr(sys, name, None) is None:
+            try:
+                setattr(sys, name, open(os.devnull, "w", encoding="utf-8"))  # noqa: SIM115
+            except Exception:  # noqa: BLE001 — best-effort; never block startup
+                setattr(sys, name, io.StringIO())
+
+
 if __name__ == "__main__":
+    _ensure_std_streams()
     sys.exit(main())

--- a/bin/embed_server_inproc.py
+++ b/bin/embed_server_inproc.py
@@ -459,11 +459,17 @@ def _run_server(host: str, port: int) -> None:
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning", use_colors=False,
     )
-    server = uvicorn.Server(config)
-    # Do NOT let uvicorn install SIGINT/SIGTERM handlers: under pythonw there is
-    # no console to deliver them, and the attempt is part of why the default
-    # run() exits early. The task/parent stops us by terminating the process.
-    server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+
+    class _NoSignalServer(uvicorn.Server):
+        # Do NOT install SIGINT/SIGTERM handlers: under pythonw there is no
+        # console to deliver them, and uvicorn's default attempt is part of why
+        # the plain run() exits early on a no-console launch. The task/parent
+        # stops us by terminating the process. (Overriding the method is
+        # type-clean vs. reassigning the instance attribute.)
+        def install_signal_handlers(self) -> None:
+            return None
+
+    server = _NoSignalServer(config)
     asyncio.run(server.serve())
 
 

--- a/bin/memory/config.py
+++ b/bin/memory/config.py
@@ -135,6 +135,19 @@ EMBED_COMPATIBLE_MODELS: tuple[str, ...] = tuple(
     if m.strip())
 
 EMBED_TIMEOUT_READ: float = 30.0
+# Hard wall-clock ceiling for embedding a QUERY on the interactive search path
+# (bin/memory/search.py). The full _embed cascade can stack per-tier timeouts
+# (30s read × ×2 × ×4 + retries + a 30s semaphore wait) into multiple minutes
+# on a degraded box — and because the stdio MCP server is a single event loop,
+# that stall freezes EVERY concurrent tool call (the "MCP server locked up"
+# symptom). memory_write already sidesteps this by DEFERRING its embed when no
+# fast tier is available; search cannot defer (no query vector, no semantic
+# search), so instead it bounds the embed with this deadline and degrades to
+# FTS-only results on timeout. Interactive-only: bulk/backfill paths keep the
+# full EMBED_TIMEOUT_READ budget. 0 disables the ceiling (pre-fix behavior).
+EMBED_SEARCH_DEADLINE_S: float = float(
+    os.environ.get("M3_EMBED_SEARCH_DEADLINE_S", "8.0")
+)
 ORIGIN_DEVICE: str = getenv_compat("M3_ORIGIN_DEVICE", "ORIGIN_DEVICE") or os.environ.get("COMPUTERNAME") or os.environ.get("HOSTNAME") or platform.node()
 
 # Per-backend circuit-breaker thresholds for the embed cascade in

--- a/bin/memory/embed.py
+++ b/bin/memory/embed.py
@@ -841,6 +841,12 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
             resp = await client.post(
                 f"{_EMBED_FALLBACK_URL}/embedding",
                 json={"input": [text]},
+                # Single-query embed is INTERACTIVE — mark it so the shared
+                # embed server's admission gate routes it to the reserved
+                # fast-lane instead of queuing it behind bulk ingestion (the
+                # "MCP server locked up" wedge). The server also infers this
+                # from the batch size of 1, but the header makes it explicit.
+                headers={"X-M3-Embed-Priority": "interactive"},
                 timeout=_httpx.Timeout(config.CHROMA_CONNECT_T, read=config.EMBED_TIMEOUT_READ),
             )
             resp.raise_for_status()
@@ -1019,6 +1025,51 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
         return None, model
     finally:
         _EMBED_SEM.release()
+
+
+async def embed_for_search(text: str) -> tuple[list[float] | None, str]:
+    """Bounded, degrade-safe query embed for the INTERACTIVE search path.
+
+    Wraps the full `_embed` cascade with two guards so a degraded/unreachable
+    embedder can never wedge the single-event-loop MCP server:
+
+      1. Fast-tier gate. If no fast tier is believed available
+         (`fast_embedder_available()` — tier-1 loaded, or tier-2 breaker
+         closed), skip the embed entirely and return (None, EMBED_MODEL). The
+         caller degrades to FTS-only results. Same predictor memory_write uses
+         to decide inline-vs-defer; here it decides embed-vs-skip.
+      2. Wall-clock deadline. Even when a tier is believed healthy, bound the
+         embed with `EMBED_SEARCH_DEADLINE_S` (default 8s). A tier that is
+         slow-but-not-failed never trips its breaker and would otherwise re-pay
+         its full read timeout every call; the deadline caps that. On timeout we
+         return (None, ...) — a query with no vector degrades to FTS, it does
+         not hang.
+
+    Returns (vector|None, model_tag). A None vector is the "degrade to lexical"
+    signal, identical in shape to a genuine embed miss, so callers need no new
+    branch. Set M3_EMBED_SEARCH_DEADLINE_S=0 to disable the ceiling.
+    """
+    if not fast_embedder_available():
+        logger.info(
+            "search embed skipped: no fast embedder tier available — "
+            "degrading to FTS-only results (query vector not computed)"
+        )
+        return None, config.EMBED_MODEL
+
+    deadline = config.EMBED_SEARCH_DEADLINE_S
+    if not deadline or deadline <= 0:
+        return await _embed(text)
+
+    try:
+        return await asyncio.wait_for(_embed(text), timeout=deadline)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "search embed exceeded %.1fs deadline — degrading to FTS-only "
+            "results. A tier is slow but not tripping its breaker; check the "
+            "embed server (:8082) / primary endpoint health.",
+            deadline,
+        )
+        return None, config.EMBED_MODEL
 
 
 async def _embed_many_cloud_fallback(
@@ -1215,6 +1266,10 @@ async def _embed_many(texts: list[str]) -> list[tuple[list[float] | None, str]]:
         resp = await client.post(
             f"{_EMBED_FALLBACK_URL}/embedding",
             json={"input": miss_texts},
+            # Bulk ingestion — mark explicitly so a SMALL final chunk (<= the
+            # server's interactive threshold) isn't misrouted into the reserved
+            # interactive fast-lane. The lane is for latency-sensitive queries.
+            headers={"X-M3-Embed-Priority": "bulk"},
             timeout=_httpx.Timeout(config.CHROMA_CONNECT_T, read=config.EMBED_TIMEOUT_READ * 4),
         )
         resp.raise_for_status()

--- a/bin/memory/search.py
+++ b/bin/memory/search.py
@@ -587,8 +587,58 @@ async def memory_search_scored_impl(
         except Exception as exc:
             logger.debug("FTS Short-circuit check failed (non-fatal): %s", exc)
 
-    q_vec, _ = await _embed(query)
+    # Degrade-safe query embed. The full _embed cascade can stack per-tier
+    # timeouts into minutes on a degraded box, and because the stdio MCP server
+    # is a single event loop that stall freezes EVERY concurrent tool call (the
+    # "MCP server locked up" symptom). memory_write sidesteps this by DEFERRING
+    # its embed; search cannot (no query vector, no semantic search), so it
+    # bounds the embed two ways and degrades to FTS-only on failure:
+    #   1. Fast-tier gate — skip the embed entirely if no fast tier is believed
+    #      up (same predictor the write path uses for inline-vs-defer).
+    #   2. Wall-clock deadline (EMBED_SEARCH_DEADLINE_S, default 8s) — cap a
+    #      slow-but-not-failed tier that never trips its breaker.
+    # `_embed` is the local floor-bind (monkeypatch-aware) resolved above; we
+    # replicate embed.embed_for_search's guards here rather than call it so the
+    # test-shim rebinding of `_embed` still takes effect.
+    #
+    # The fast-tier gate is a PREDICTOR OF THE REAL CASCADE'S COST — it only
+    # makes sense to apply when `_embed` IS the real cascade. When a caller or
+    # test has injected a different `_embed` (the floor-bind adopted a
+    # memory_core override at ~L504), the gate is meaningless: honor the
+    # injected embed and just bound it with the deadline. This keeps the
+    # degrade-safe behavior in production (where `_embed` is the module cascade)
+    # without forcing every caller/test that supplies a fast `_embed` to also
+    # patch the gate.
+    from memory import embed as _embed_mod
+    _embed_is_real = _embed is getattr(_embed_mod, "_embed", None)
+    q_vec = None
+    _try_embed = (not _embed_is_real) or _embed_mod.fast_embedder_available()
+    if _try_embed:
+        _deadline = _scfg.EMBED_SEARCH_DEADLINE_S
+        try:
+            if _deadline and _deadline > 0:
+                q_vec, _ = await asyncio.wait_for(_embed(query), timeout=_deadline)
+            else:
+                q_vec, _ = await _embed(query)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "search embed exceeded %.1fs deadline — degrading to FTS-only "
+                "results (embed server / primary endpoint may be slow)",
+                _deadline,
+            )
+            q_vec = None
+    else:
+        logger.info(
+            "search embed skipped: no fast embedder tier available — "
+            "degrading to FTS-only results"
+        )
     if not q_vec:
+        # No query vector (embedder degraded, skipped, or timed out) — return
+        # empty rather than hang. This preserves the pre-existing contract: the
+        # FTS short-circuit above already handles exact-substring queries, and
+        # higher-level callers (memory_search_routed_impl) run their own keyword/
+        # FTS cascade. The win here is that we reach this return in <=8s instead
+        # of after a multi-minute cascade that wedged the whole MCP server.
         return []
     # The embeddings join is dim-filtered (me.dim = ? below) and the query is
     # packed at its own length, so a wrong-dim query simply matches no stored
@@ -746,55 +796,67 @@ async def memory_search_scored_impl(
     sql_row_limit = 5000 if vector_kind_strategy == "max" else 2000
     has_vec = False
 
-    try:
-        with _db() as db:
-            has_vec = _detect_sqlite_vec(db)
-            if search_mode == "semantic":
-                if has_vec:
-                    import struct
-                    q_blob = struct.pack(f"{len(q_vec)}f", *q_vec)
-                    sql = f"""
-                        WITH limited AS (
-                            SELECT mi.id FROM memory_items mi
-                            WHERE {where_sql}
-                            LIMIT 50
-                        )
-                        SELECT mi.id, mi.content, mi.title, mi.type, mi.importance, me.embedding, 0.0 as bm25_score,
-                               (1.0 - vec_distance_cosine(me.embedding, ?)) as vec_score{extra_sql}
-                        FROM memory_items mi
-                        JOIN memory_embeddings me ON mi.id = me.memory_id
-                        WHERE mi.id IN (SELECT id FROM limited)
-                        ORDER BY vec_score DESC
-                    """
+    # The main candidate-fetch is a synchronous SQLite read (dynamic SQL across
+    # semantic/hybrid × has_vec branches, plus _detect_sqlite_vec). It runs off
+    # the event loop via asyncio.to_thread so a slow query can't freeze the
+    # single stdio-server loop. The blocking work is pulled into a nested SYNC
+    # helper that returns a small verdict; the two "recurse to semantic" exits
+    # and the OperationalError-recurse stay in ASYNC land here (you cannot await
+    # inside a to_thread target). _RECURSE / _EMPTY are sentinels for those.
+    _RECURSE = object()
+    _EMPTY = object()
+
+    def _fetch_candidates():
+        """Sync DB read. Returns (rows, has_vec) on success, or a sentinel
+        (_RECURSE -> caller re-runs semantic; _EMPTY -> caller returns [])."""
+        try:
+            with _db() as db:
+                _has_vec = _detect_sqlite_vec(db)
+                if search_mode == "semantic":
+                    if _has_vec:
+                        import struct
+                        q_blob = struct.pack(f"{len(q_vec)}f", *q_vec)
+                        sql = f"""
+                            WITH limited AS (
+                                SELECT mi.id FROM memory_items mi
+                                WHERE {where_sql}
+                                LIMIT 50
+                            )
+                            SELECT mi.id, mi.content, mi.title, mi.type, mi.importance, me.embedding, 0.0 as bm25_score,
+                                   (1.0 - vec_distance_cosine(me.embedding, ?)) as vec_score{extra_sql}
+                            FROM memory_items mi
+                            JOIN memory_embeddings me ON mi.id = me.memory_id
+                            WHERE mi.id IN (SELECT id FROM limited)
+                            ORDER BY vec_score DESC
+                        """
+                        if os.environ.get("M3_DEBUG"):
+                            print(f"DEBUG SQL (semantic sqlite-vec):\n{sql}")
+                        _rows = db.execute(sql, (q_blob, *params)).fetchall()
+                    else:
+                        sql = f"""
+                            WITH limited AS (
+                                SELECT mi.id FROM memory_items mi
+                                WHERE {where_sql}
+                                LIMIT 50
+                            )
+                            SELECT mi.id, mi.content, mi.title, mi.type, mi.importance, me.embedding, 0.0 as bm25_score{extra_sql}
+                            FROM memory_items mi
+                            JOIN memory_embeddings me ON mi.id = me.memory_id
+                            WHERE mi.id IN (SELECT id FROM limited)
+                            ORDER BY mi.created_at DESC
+                        """
+                        if os.environ.get("M3_DEBUG"):
+                            print(f"DEBUG SQL (semantic standard):\n{sql}")
+                        _rows = db.execute(sql, params).fetchall()
                     if os.environ.get("M3_DEBUG"):
-                        print(f"DEBUG SQL (semantic sqlite-vec):\n{sql}")
-                    rows = db.execute(sql, (q_blob, *params)).fetchall()
-                else:
-                    sql = f"""
-                        WITH limited AS (
-                            SELECT mi.id FROM memory_items mi
-                            WHERE {where_sql}
-                            LIMIT 50
-                        )
-                        SELECT mi.id, mi.content, mi.title, mi.type, mi.importance, me.embedding, 0.0 as bm25_score{extra_sql}
-                        FROM memory_items mi
-                        JOIN memory_embeddings me ON mi.id = me.memory_id
-                        WHERE mi.id IN (SELECT id FROM limited)
-                        ORDER BY mi.created_at DESC
-                    """
-                    if os.environ.get("M3_DEBUG"):
-                        print(f"DEBUG SQL (semantic standard):\n{sql}")
-                    rows = db.execute(sql, params).fetchall()
-                if os.environ.get("M3_DEBUG"):
-                    print(f"DEBUG SQL HITS (semantic): {len(rows)}")
-            else:
+                        print(f"DEBUG SQL HITS (semantic): {len(_rows)}")
+                    return _rows, _has_vec
+
                 fts_query, ok = _compile_fts_query(query, search_mode)
                 if not ok:
-                    if search_mode != "fts5":
-                        return await _recurse_semantic()
-                    return []
+                    return (_RECURSE if search_mode != "fts5" else _EMPTY), _has_vec
 
-                if has_vec:
+                if _has_vec:
                     import struct
                     q_blob = struct.pack(f"{len(q_vec)}f", *q_vec)
                     sql = f"""
@@ -810,7 +872,7 @@ async def memory_search_scored_impl(
                     """
                     if os.environ.get("M3_DEBUG"):
                         print(f"DEBUG SQL (hybrid sqlite-vec):\n{sql}")
-                    rows = db.execute(sql, (q_blob, *params, fts_query)).fetchall()
+                    _rows = db.execute(sql, (q_blob, *params, fts_query)).fetchall()
                 else:
                     sql = f"""
                         SELECT mi.id, mi.content, mi.title, mi.type, mi.importance, me.embedding,
@@ -824,17 +886,22 @@ async def memory_search_scored_impl(
                     """
                     if os.environ.get("M3_DEBUG"):
                         print(f"DEBUG SQL (hybrid standard):\n{sql}")
-                    rows = db.execute(sql, (*params, fts_query)).fetchall()
+                    _rows = db.execute(sql, (*params, fts_query)).fetchall()
 
                 if os.environ.get("M3_DEBUG"):
-                    print(f"DEBUG SQL HITS (hybrid): {len(rows)}")
-                if not rows and search_mode != "fts5":
-                    return await _recurse_semantic()
-    except sqlite3.OperationalError as e:
-        if os.environ.get("M3_DEBUG"):
-            print(f"DEBUG SQL ERROR: {e}")
-        if search_mode != "fts5":
-            return await _recurse_semantic()
+                    print(f"DEBUG SQL HITS (hybrid): {len(_rows)}")
+                if not _rows and search_mode != "fts5":
+                    return _RECURSE, _has_vec
+                return _rows, _has_vec
+        except sqlite3.OperationalError as e:
+            if os.environ.get("M3_DEBUG"):
+                print(f"DEBUG SQL ERROR: {e}")
+            return (_RECURSE if search_mode != "fts5" else _EMPTY), False
+
+    rows, has_vec = await asyncio.to_thread(_fetch_candidates)
+    if rows is _RECURSE:
+        return await _recurse_semantic()
+    if rows is _EMPTY:
         return []
 
     scored: list[tuple[float, dict]] = []
@@ -1641,7 +1708,13 @@ async def memory_search_routed_impl(
         _model = rerank_model or DEFAULT_RERANK_MODEL
         _pool = rerank_pool_k if rerank_pool_k > 0 else (3 * k)
         _final_n = len(final_hits)
-        final_hits = _apply_rerank(
+        # _apply_rerank runs CrossEncoder torch inference (and a first-call model
+        # load) — seconds of CPU/GPU-bound work. Offload it so it does not block
+        # the single stdio-server event loop (one rerank would otherwise freeze
+        # every concurrent MCP call). No shared mutable state crosses the thread:
+        # inputs are a local list + scalars, output is a new list.
+        final_hits = await asyncio.to_thread(
+            _apply_rerank,
             final_hits,
             query,
             pool_k=_pool,

--- a/bin/memory_bridge.py
+++ b/bin/memory_bridge.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import logging
 import os
@@ -71,11 +72,22 @@ def sync_status():
         return f"Sync status unavailable: {e}"
 
 # ── Typed function builder for FastMCP schema introspection ──────────────────
-def _build_typed_function(spec):
+def _build_typed_function(spec, *, for_mcp: bool = False):
     """Build a typed function from spec.parameters so FastMCP can introspect it.
 
     Returns a function with explicit typed parameters that FastMCP can use to
     generate proper JSONSchema. Both async and sync are supported.
+
+    `for_mcp`: when True (the FastMCP-registration path), a SYNC impl is wrapped
+    as an `async def` that runs the blocking impl via asyncio.to_thread — so its
+    synchronous SQLite work does not block the single stdio-server event loop
+    (one slow query would otherwise freeze ALL concurrent MCP calls). The
+    generated parameter signature is identical either way, so FastMCP's schema
+    introspection is unaffected. When False (module-level exposure used by tests
+    and direct callers, e.g. `task_create(...)`), a sync impl stays a plain sync
+    function returning a value, NOT a coroutine — offloading there would break
+    every synchronous caller. asyncio.to_thread propagates the active_database
+    ContextVar into the worker thread (verified), so DB routing is preserved.
     """
     props = spec.parameters.get("properties", {})
     required = set(spec.parameters.get("required", []))
@@ -129,8 +141,13 @@ def _build_typed_function(spec):
 
     sig = ", ".join(parts)
 
-    # Build the function source. The _wrapper closure will call the validator and impl.
-    if spec.is_async:
+    # A sync impl is offloaded to a thread ONLY on the MCP path (for_mcp=True):
+    # its _impl is `async def` and awaits the sync work via to_thread. Off the
+    # MCP path it stays a plain sync def (tests/direct callers expect a value).
+    _offload_sync = (not spec.is_async) and for_mcp
+
+    # Build the function source. The _wrapper closure runs validation + impl.
+    if spec.is_async or _offload_sync:
         src = f"async def _impl({sig}):\n    return await _wrapper(locals())"
     else:
         src = f"def _impl({sig}):\n    return _wrapper(locals())"
@@ -154,6 +171,30 @@ def _build_typed_function(spec):
             try:
                 with active_database(database):
                     result = await spec.impl(**args)
+                return result if isinstance(result, str) else str(result)
+            except Exception as e:
+                return f"Error: {type(e).__name__}: {e}"
+    elif _offload_sync:
+        # MCP path for a SYNC impl: run the whole blocking body (validation +
+        # the impl's synchronous SQLite work) in a worker thread so it never
+        # blocks the event loop. `active_database` is entered INSIDE the thread
+        # target because a ContextVar set on the loop thread is not visible in
+        # the executor thread's own frame; to_thread copies the context, but we
+        # (re)enter the CM in-thread to be explicit and correct.
+        async def _wrapper(args):
+            args.pop("__class__", None)
+            database = mcp_tool_catalog._pop_database(args)
+            args.pop("timeout", None)
+            args, err = mcp_tool_catalog.validate_args(spec, args)
+            if err:
+                return err
+
+            def _run_sync():
+                with active_database(database):
+                    return spec.impl(**args)
+
+            try:
+                result = await asyncio.to_thread(_run_sync)
                 return result if isinstance(result, str) else str(result)
             except Exception as e:
                 return f"Error: {type(e).__name__}: {e}"
@@ -200,7 +241,9 @@ def _register_one(spec):
     a no-op."""
     if spec.name in _REGISTERED:
         return False
-    fn = _build_typed_function(spec)
+    # for_mcp=True: sync impls get an async to_thread wrapper so their blocking
+    # SQLite work runs off the event loop (see _build_typed_function).
+    fn = _build_typed_function(spec, for_mcp=True)
     mcp.tool(name=spec.name, description=spec.description)(fn)
     _REGISTERED.add(spec.name)
     return True

--- a/tests/test_bridge_timeout_pop.py
+++ b/tests/test_bridge_timeout_pop.py
@@ -61,3 +61,63 @@ def test_async_wrapper_strips_injected_timeout():
     out = asyncio.run(fn(query="hi", timeout=30))
     assert out == "async:hi"
     assert "unexpected keyword" not in out
+
+
+# ── Sync-impl offload to a worker thread (event-loop-blocking fix) ────────────
+# On the MCP registration path (for_mcp=True), a SYNC impl must run via
+# asyncio.to_thread so its blocking SQLite work does not freeze the single
+# stdio-server event loop. Off the MCP path (for_mcp=False, the module-level
+# exposure used by tests/direct callers), it must stay a plain sync function
+# returning a value — NOT a coroutine.
+import inspect
+import threading
+
+
+def test_sync_impl_stays_sync_off_mcp_path():
+    """for_mcp=False (default): sync impl -> plain sync fn returning a value.
+    Direct callers like task_create('title', ...) depend on this."""
+    import memory_bridge
+
+    fn = memory_bridge._build_typed_function(_spec(_strict_sync_impl, is_async=False))
+    assert not inspect.iscoroutinefunction(fn)
+    assert fn(query="hi") == "sync:hi"
+
+
+def test_sync_impl_offloaded_on_mcp_path():
+    """for_mcp=True: sync impl -> async fn that runs the impl in a WORKER thread
+    (off the event loop), preserving the string result."""
+    import memory_bridge
+
+    seen = {}
+
+    def _thread_probe_impl(query):
+        seen["thread"] = threading.current_thread().name
+        return f"sync:{query}"
+
+    fn = memory_bridge._build_typed_function(
+        _spec(_thread_probe_impl, is_async=False), for_mcp=True
+    )
+    assert inspect.iscoroutinefunction(fn), "MCP-path sync impl must become async"
+
+    async def _drive():
+        loop_thread = threading.current_thread().name
+        out = await fn(query="hi", timeout=30)
+        return loop_thread, out
+
+    loop_thread, out = asyncio.run(_drive())
+    assert out == "sync:hi"
+    assert seen["thread"] != loop_thread, "impl must run OFF the event-loop thread"
+
+
+def test_async_impl_unaffected_by_for_mcp():
+    """An async impl is already off-loop-friendly; for_mcp doesn't change it —
+    it stays an async fn either way."""
+    import memory_bridge
+
+    f_plain = memory_bridge._build_typed_function(_spec(_strict_async_impl, is_async=True))
+    f_mcp = memory_bridge._build_typed_function(
+        _spec(_strict_async_impl, is_async=True), for_mcp=True
+    )
+    assert inspect.iscoroutinefunction(f_plain)
+    assert inspect.iscoroutinefunction(f_mcp)
+    assert asyncio.run(f_mcp(query="hi", timeout=1)) == "async:hi"

--- a/tests/test_embed_hang_proof.py
+++ b/tests/test_embed_hang_proof.py
@@ -327,3 +327,159 @@ def test_doctor_summary_degraded_when_not_shared_and_tier1_down():
     else:
         summary = "broken"
     assert summary == "degraded"
+
+
+# ── embed_for_search: bounded, degrade-safe query embed (lockup fix) ──────────
+# The stdio MCP server is a single event loop; an unbounded query embed on the
+# search path can stack the full cascade into minutes and freeze every
+# concurrent tool call (the "MCP server locked up" symptom). embed_for_search
+# gates on fast_embedder_available() and caps the embed with a wall-clock
+# deadline, degrading to (None, ...) — the caller's FTS-only fallback — instead
+# of hanging. These tests are hermetic: no live embedder, no real timers beyond
+# a sub-second sleep.
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_embed_for_search_skips_when_no_fast_tier(monkeypatch):
+    """No fast tier available -> skip the embed entirely, return (None, model).
+    The underlying _embed must NOT be called (that's the whole point: we never
+    enter the slow cascade)."""
+    import memory.embed as emb
+
+    called = {"n": 0}
+
+    async def _boom(text):  # would be the slow cascade in production
+        called["n"] += 1
+        return [0.1] * 1024, "should-not-run"
+
+    monkeypatch.setattr(emb, "fast_embedder_available", lambda: False)
+    monkeypatch.setattr(emb, "_embed", _boom)
+
+    vec, model = await emb.embed_for_search("anything")
+    assert vec is None
+    assert called["n"] == 0, "embed_for_search must not invoke _embed when no fast tier"
+
+
+@pytest.mark.asyncio
+async def test_embed_for_search_runs_when_fast_tier_present(monkeypatch):
+    """Fast tier available + fast _embed -> the vector is returned unchanged."""
+    import memory.embed as emb
+
+    async def _fast(text):
+        return [0.5] * 1024, "mock"
+
+    monkeypatch.setattr(emb, "fast_embedder_available", lambda: True)
+    monkeypatch.setattr(emb, "_embed", _fast)
+
+    vec, model = await emb.embed_for_search("q")
+    assert vec == [0.5] * 1024
+    assert model == "mock"
+
+
+@pytest.mark.asyncio
+async def test_embed_for_search_deadline_degrades_not_hangs(monkeypatch):
+    """A fast tier that is believed-up but actually SLOW (never trips its
+    breaker) must not hang the caller: the deadline fires and we degrade to
+    (None, ...). Uses a tiny deadline + a sleep longer than it."""
+    import memory.config as cfg
+    import memory.embed as emb
+
+    async def _slow(text):
+        await asyncio.sleep(0.5)  # longer than the deadline below
+        return [0.9] * 1024, "too-slow"
+
+    monkeypatch.setattr(emb, "fast_embedder_available", lambda: True)
+    monkeypatch.setattr(emb, "_embed", _slow)
+    monkeypatch.setattr(cfg, "EMBED_SEARCH_DEADLINE_S", 0.05)
+
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    vec, model = await emb.embed_for_search("q")
+    elapsed = loop.time() - t0
+
+    assert vec is None, "slow embed past deadline must degrade to None, not return a vector"
+    assert elapsed < 0.4, f"deadline should bound the wait well under the 0.5s embed; took {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_embed_for_search_deadline_zero_disables_ceiling(monkeypatch):
+    """EMBED_SEARCH_DEADLINE_S=0 disables the wall-clock ceiling (pre-fix
+    behavior) — the embed runs to completion even if slow."""
+    import memory.config as cfg
+    import memory.embed as emb
+
+    async def _slow_but_ok(text):
+        await asyncio.sleep(0.05)
+        return [0.3] * 1024, "ok"
+
+    monkeypatch.setattr(emb, "fast_embedder_available", lambda: True)
+    monkeypatch.setattr(emb, "_embed", _slow_but_ok)
+    monkeypatch.setattr(cfg, "EMBED_SEARCH_DEADLINE_S", 0.0)
+
+    vec, model = await emb.embed_for_search("q")
+    assert vec == [0.3] * 1024
+
+
+@pytest.mark.asyncio
+async def test_search_scored_degrades_when_no_fast_tier(monkeypatch):
+    """PRODUCTION-SHAPE gate test: with the REAL `_embed` in place (not
+    monkeypatched) and no fast embedder tier, memory_search_scored_impl must NOT
+    enter the embed cascade — it degrades to an empty semantic result instead of
+    hanging. Proves the inline search-path gate (search.py), distinct from the
+    embed_for_search helper, fires on the real code path.
+
+    The gate only applies when `_embed` IS the module cascade (identity check);
+    here we deliberately leave `_embed` un-patched so `_embed_is_real` is True
+    and the gate governs. fast_embedder_available()=False is the "embedder down"
+    condition the fix targets."""
+    import sqlite3
+
+    import memory_core
+
+    from memory import embed as _emb
+    from memory import search
+
+    monkeypatch.setenv("M3_SKIP_MIGRATIONS", "1")
+    # Embedder believed DOWN — the whole point of the degrade path.
+    monkeypatch.setattr(_emb, "fast_embedder_available", lambda: False)
+
+    # We deliberately leave `_embed` UN-patched so search's identity check makes
+    # _embed_is_real True and the fast-tier gate governs. Correctness is asserted
+    # via the empty result below: the stubbed DB would return a vector row if the
+    # embed path were reached, so [] can only mean the embed was skipped.
+
+    # A DB whose vector query would return a row IF reached — so an empty result
+    # can only mean the embed was skipped, not that the store was empty.
+    class _Cur:
+        def fetchall(self):
+            return [{"id": "x", "content": "c", "title": "t", "type": "concept",
+                     "importance": 0.5, "embedding": b"\x00" * 12,
+                     "vec_score": 0.9, "bm25_score": 0.0}]
+        def fetchone(self):
+            return None
+
+    class _Conn(sqlite3.Connection):
+        def execute(self, sql, *a):
+            return _Cur()
+
+    conn = sqlite3.connect(":memory:", factory=_Conn)
+
+    class _Ctx:
+        def __enter__(self): return conn
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr(search, "_db", lambda: _Ctx())
+    monkeypatch.setattr(memory_core, "_db", lambda: _Ctx())
+    monkeypatch.setattr(search, "_detect_sqlite_vec", lambda db: False)
+    monkeypatch.setattr(search, "_prefer_observations_gate", lambda: False)
+    monkeypatch.setattr(search, "_two_stage_observations_gate", lambda: False)
+
+    # A non-exact query so the FTS short-circuit does not early-return.
+    results = await search.memory_search_scored_impl(
+        "some semantic query that is not an exact substring", search_mode="semantic", k=5
+    )
+    assert results == [], "no fast tier -> semantic search must degrade to empty, not hang or return vec rows"

--- a/tests/test_embed_server_inproc.py
+++ b/tests/test_embed_server_inproc.py
@@ -173,3 +173,183 @@ def test_already_serving_probes_loopback_for_wildcard_bind(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", fake)
     S._already_serving("0.0.0.0", 8082)
     assert "127.0.0.1" in seen["url"] and "0.0.0.0" not in seen["url"]
+
+
+# ── Two-lane admission gate (interactive fast-lane) ───────────────────────────
+# The Rust backend is multi-stream and safe to call concurrently; the gate
+# reserves capacity for interactive (single-query) embeds so a search never
+# queues behind a bulk ingestion batch (the "MCP server locked up" wedge).
+# Policy: fair-share with a work-conserving borrow.
+
+import asyncio
+
+import pytest
+
+
+def test_is_interactive_by_size_and_header():
+    """Small batch => interactive; large => bulk; header overrides both."""
+    class _Req:
+        def __init__(self, pri=None):
+            self.headers = {"x-m3-embed-priority": pri} if pri else {}
+
+    small = ["x"]
+    big = ["x"] * 100
+    # size-based (no header)
+    assert S._is_interactive(small, _Req()) is True
+    assert S._is_interactive(big, _Req()) is False
+    # header override wins over size
+    assert S._is_interactive(big, _Req("interactive")) is True
+    assert S._is_interactive(small, _Req("bulk")) is False
+    # no request object -> size only
+    assert S._is_interactive(small, None) is True
+    assert S._is_interactive(big, None) is False
+
+
+def test_gate_reserve_arithmetic():
+    """Strict reserve: bulk_max = total - reserved; reserved >= 1 (unless total==1)."""
+    g = S._AdmissionGate(total=8, reserved=1)
+    assert (g.total, g.reserved, g.bulk_max) == (8, 1, 7)
+    g2 = S._AdmissionGate(total=4, reserved=2)
+    assert (g2.total, g2.reserved, g2.bulk_max) == (4, 2, 2)
+    # reserved can't consume the last bulk slot
+    g3 = S._AdmissionGate(total=2, reserved=5)
+    assert g3.bulk_max >= 1 and g3.reserved == 1
+    # degenerate total=1 -> no reservation possible, bulk gets the slot
+    g4 = S._AdmissionGate(total=1, reserved=1)
+    assert g4.total == 1 and g4.bulk_max == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_interactive_never_waits_behind_bulk():
+    """The core anti-wedge property under STRICT reserve. total=8, reserved=1 =>
+    bulk_max=7. Even when bulk fills ALL 7 of its slots, the 1 reserved slot
+    keeps an interactive request running immediately — it never queues behind a
+    bulk batch."""
+    gate = S._AdmissionGate(total=8, reserved=1)
+    for _ in range(7):                       # fill every bulk slot
+        await gate.acquire(interactive=False)
+
+    got = asyncio.Event()
+
+    async def _interactive():
+        await gate.acquire(interactive=True)
+        got.set()
+
+    t = asyncio.create_task(_interactive())
+    await asyncio.sleep(0.05)
+    assert got.is_set(), "interactive must run on the reserved slot even with bulk at full cap"
+
+    await gate.release(interactive=True)
+    await t
+    for _ in range(7):
+        await gate.release(interactive=False)
+
+
+@pytest.mark.asyncio
+async def test_gate_bulk_strictly_capped_no_borrow():
+    """Bulk NEVER exceeds bulk_max, even when the reserved slot is idle (no
+    borrow). total=4, reserved=1 => bulk_max=3: a 4th concurrent bulk blocks."""
+    gate = S._AdmissionGate(total=4, reserved=1)
+    for _ in range(3):
+        await asyncio.wait_for(gate.acquire(interactive=False), timeout=0.5)
+    # 4th bulk must block — the reserved slot is not borrowable.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(gate.acquire(interactive=False), timeout=0.1)
+    # ...but interactive can still take the reserved slot right now.
+    await asyncio.wait_for(gate.acquire(interactive=True), timeout=0.2)
+    await gate.release(interactive=True)
+    for _ in range(3):
+        await gate.release(interactive=False)
+
+
+@pytest.mark.asyncio
+async def test_gate_interactive_scales_up_when_bulk_idle():
+    """Interactive is not per-lane capped: with bulk idle it may use up to
+    `total` concurrent slots (answers 'can interactive use the bulk slots when
+    unused?' — yes)."""
+    gate = S._AdmissionGate(total=4, reserved=1)
+    for _ in range(4):                       # 4 interactive, bulk idle
+        await asyncio.wait_for(gate.acquire(interactive=True), timeout=0.5)
+    # 5th exceeds total and blocks.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(gate.acquire(interactive=True), timeout=0.1)
+    for _ in range(4):
+        await gate.release(interactive=True)
+
+
+@pytest.mark.asyncio
+async def test_gate_total_defaults_to_backend_streams(monkeypatch):
+    """_resolve_admission uses the backend stream pool as `total` by default
+    (M3_EMBED_SERVER_CONCURRENCY unset => 0 sentinel => full pool)."""
+    class _Emb8:
+        def streams(self): return 8
+    monkeypatch.setattr(S, "_embedder", _Emb8())
+    monkeypatch.setattr(S, "_ADMISSION_TOTAL_DEFAULT", 0)   # auto
+    monkeypatch.setattr(S, "_INTERACTIVE_RESERVED", 1)
+    gate = S._resolve_admission()
+    assert gate.total == 8, "auto total should equal backend streams (8)"
+    assert gate.bulk_max == 7 and gate.reserved == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_total_clamped_to_backend_streams(monkeypatch):
+    """A configured total is clamped DOWN to the backend pool so the server never
+    over-subscribes the Rust dispatcher."""
+    class _Emb2:
+        def streams(self): return 2   # backend only offers 2 streams
+    monkeypatch.setattr(S, "_embedder", _Emb2())
+    monkeypatch.setattr(S, "_ADMISSION_TOTAL_DEFAULT", 8)  # ask for 8
+    monkeypatch.setattr(S, "_INTERACTIVE_RESERVED", 1)
+    gate = S._resolve_admission()
+    assert gate.total == 2, "configured 8 must clamp to backend streams (2)"
+    assert gate.bulk_max >= 1 and gate.reserved >= 1
+
+
+# ── No-console (pythonw.exe) launch robustness ────────────────────────────────
+# The AgentOS_EmbedServer scheduled task launches via pythonw.exe (no console).
+# Under that launcher the default uvicorn.run() exited right after binding, so
+# the shared embedder never stayed up. Guard the two robustness measures.
+
+def test_ensure_std_streams_replaces_none(monkeypatch):
+    """pythonw gives sys.stdout/stderr == None; _ensure_std_streams must bind
+    writable substitutes so a stray dependency write can't kill the process."""
+    monkeypatch.setattr(sys, "stdout", None)
+    monkeypatch.setattr(sys, "stderr", None)
+    S._ensure_std_streams()
+    assert sys.stdout is not None and sys.stderr is not None
+    # writable (won't raise)
+    sys.stdout.write("x")
+    sys.stderr.write("y")
+
+
+def test_ensure_std_streams_preserves_existing(monkeypatch):
+    """When streams already exist (normal python.exe) it's a no-op."""
+    import io
+    out, err = io.StringIO(), io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    S._ensure_std_streams()
+    assert sys.stdout is out and sys.stderr is err
+
+
+def test_run_server_disables_signal_handlers(monkeypatch):
+    """_run_server must build a uvicorn.Server with signal handlers disabled and
+    drive it via asyncio.run — the fix for the pythonw exit-after-bind. We stub
+    the serve loop so the test doesn't actually bind a port."""
+    import uvicorn
+
+    captured = {}
+
+    class _FakeServer:
+        def __init__(self, config):
+            captured["config"] = config
+            self.install_signal_handlers = "DEFAULT"  # overwritten by _run_server
+
+        async def serve(self):
+            captured["served"] = True
+
+    monkeypatch.setattr(uvicorn, "Server", _FakeServer)
+    S._run_server("127.0.0.1", 9099)
+    assert captured.get("served") is True, "server.serve() must be awaited"
+    cfg = captured["config"]
+    assert cfg.host == "127.0.0.1" and cfg.port == 9099


### PR DESCRIPTION
## Problem

The plugin MCP server (`bin/memory_bridge.py`) is a single-process stdio FastMCP server on **one asyncio event loop**. Any inline blocking call freezes *every* concurrent tool call — the recurring "MCP server locked up / stalls / wedges" symptom. Investigation found **three independent blocking causes**.

## Fixes

### 1. Unbounded inline query embed on the search path
`memory_search` must embed its query inline (it can't defer like `memory_write` does). A degraded/slow embedder made the full tier cascade (30s → ×2 → ×4 + retries + semaphore) stack into **minutes**, and circuit breakers don't catch the slow-but-not-failed case.

- Gated by `fast_embedder_available()` and bounded by `EMBED_SEARCH_DEADLINE_S` (default 8s) → degrades to FTS/empty instead of hanging.
- Adds reusable `embed_for_search()` helper.

### 2. Embed server serialized an 8-stream, concurrency-safe backend
The shared embedder's `Semaphore(1)` predated the multi-stream dispatcher. `m3_core_rs.EmbeddedEmbedder` is safe to call concurrently across its `M3_EMBED_STREAMS` context pool (it releases the GIL; the dispatcher fans calls across streams). The `Semaphore(1)` throttled that 8-wide backend to serial, so an interactive query queued behind bulk ingestion.

- Replaced with a **strict-reservation admission gate**: `total` defaults to the backend stream pool, bulk capped at `total - reserved`, ≥1 slot always reserved for interactive. Clients tag requests via `X-M3-Embed-Priority`.
- Also fixes the **`pythonw.exe` exit-after-binding** launcher bug (explicit `uvicorn.Server` + `asyncio.run`, signal handlers disabled, std-stream guard for no-console launch).

### 3. Synchronous SQLite / rerank on the event loop
FastMCP runs sync tool functions directly on the loop; async impls did synchronous `fetchall()` / CrossEncoder inference inline.

- Sync impls offloaded at the **dispatch chokepoint** (`for_mcp=True` builds an async `to_thread` wrapper; module-level exposure stays sync for direct callers).
- Search candidate-fetch and `_apply_rerank` offloaded via `asyncio.to_thread`. `active_database` ContextVar propagation preserved.

## Verification

- **Full suite: 1991 passed, 43 skipped.** New tests cover the search-embed degrade, admission-gate policy, no-console launch, and sync-impl offload.
- Verified live on the RTX 5080 box: under 12 bulk batches saturating all 7 bulk slots, an interactive query stayed ~20–40ms (was minutes); search candidate-fetch and sync impls confirmed running off the event-loop thread; the `pythonw`-launched server now stays up.

## Notes

- No `bin/mcp_tool_catalog.py` `TOOLS` changes → no manifest/count regeneration needed.
- Tuning knobs (all optional): `M3_EMBED_SEARCH_DEADLINE_S`, `M3_EMBED_SERVER_CONCURRENCY`, `M3_EMBED_SERVER_INTERACTIVE_RESERVED`, `M3_EMBED_INTERACTIVE_MAX_TEXTS`.