### PR TITLE
fix(review): address PR #91 code-review findings

### DIFF
--- a/bin/embed_server_inproc.py
+++ b/bin/embed_server_inproc.py
@@ -204,8 +204,18 @@ def _resolve_admission() -> _AdmissionGate:
 
 
 def _is_interactive(texts: list[str], request: "Request | None") -> bool:
-    """Classify a request: small batch => interactive, unless an explicit
-    `X-M3-Embed-Priority: bulk|interactive` header overrides."""
+    """Classify a request into the interactive fast-lane or the bulk lane.
+
+    CONTRACT: the `X-M3-Embed-Priority: interactive|bulk` header is AUTHORITATIVE
+    — it always wins. First-party clients set it explicitly (memory/embed.py
+    tags single-query posts `interactive` and bulk posts `bulk`), so the size
+    heuristic below is only a fallback for callers that send NO header.
+
+    Fallback: batch size. A latency-sensitive caller sending a multi-text batch
+    (> _INTERACTIVE_MAX_TEXTS) WITHOUT the header is treated as bulk and may
+    queue behind other bulk work — such callers should send the header rather
+    than rely on size. The default threshold (8) comfortably covers the only
+    header-less interactive shape today (a single query embed, len 1)."""
     if request is not None:
         pri = (request.headers.get("x-m3-embed-priority") or "").strip().lower()
         if pri == "interactive":
@@ -329,16 +339,22 @@ def _coerce_texts(inp: Union[str, list[str]]) -> list[str]:
 async def _embed(texts: list[str], *, interactive: bool = False) -> list[list[float]]:
     """Admission-gated GPU embed. Runs the blocking call off the event loop.
 
-    Concurrency is bounded by the two-lane admission gate (interactive requests
-    get reserved capacity; bulk is capped but may borrow when idle). The
-    underlying `_embedder.embed` is safe to call concurrently — the Rust
-    dispatcher fans the calls across its stream pool (see _AdmissionGate WHY).
+    Concurrency is bounded by the two-lane admission gate: interactive requests
+    get reserved capacity, and bulk is strictly capped at total-reserved with NO
+    borrow (the reserved slots are never available to bulk, so an interactive
+    request always has room — see _AdmissionGate). The underlying
+    `_embedder.embed` is safe to call concurrently — the Rust dispatcher fans the
+    calls across its stream pool.
     """
+    if _embedder is None:
+        # Request arrived before _load_embedder() finished (racing startup).
+        # Fail cleanly rather than AttributeError-ing inside the worker thread.
+        raise RuntimeError("embedder not loaded yet")
     gate = _GATE
     if gate is None:
         # Pre-load / test fallback: preserve the original strict-serial behaviour.
         async with _GPU_SEM:
-            return await asyncio.to_thread(_embedder.embed, texts)  # type: ignore[union-attr]
+            return await asyncio.to_thread(_embedder.embed, texts)
     await gate.acquire(interactive=interactive)
     try:
         return await asyncio.to_thread(_embedder.embed, texts)  # type: ignore[union-attr]

--- a/bin/memory/embed.py
+++ b/bin/memory/embed.py
@@ -1027,13 +1027,16 @@ async def _embed(text: str) -> tuple[list[float] | None, str]:
         _EMBED_SEM.release()
 
 
-async def embed_for_search(text: str) -> tuple[list[float] | None, str]:
+async def embed_for_search(
+    text: str, *, embed_fn=None, gate: bool = True
+) -> tuple[list[float] | None, str]:
     """Bounded, degrade-safe query embed for the INTERACTIVE search path.
 
-    Wraps the full `_embed` cascade with two guards so a degraded/unreachable
-    embedder can never wedge the single-event-loop MCP server:
+    The single source of truth for the search-path embed guards (memory_search
+    calls this). Wraps the `_embed` cascade with two guards so a degraded/
+    unreachable embedder can never wedge the single-event-loop MCP server:
 
-      1. Fast-tier gate. If no fast tier is believed available
+      1. Fast-tier gate. If `gate` and no fast tier is believed available
          (`fast_embedder_available()` — tier-1 loaded, or tier-2 breaker
          closed), skip the embed entirely and return (None, EMBED_MODEL). The
          caller degrades to FTS-only results. Same predictor memory_write uses
@@ -1045,11 +1048,22 @@ async def embed_for_search(text: str) -> tuple[list[float] | None, str]:
          return (None, ...) — a query with no vector degrades to FTS, it does
          not hang.
 
+    `embed_fn`: the coroutine to run (defaults to this module's `_embed`).
+    search.py passes its monkeypatch-aware floor-bound `_embed` here so the
+    caller's test-shim rebinding still takes effect — the guards live in ONE
+    place instead of being replicated at the call site.
+
+    `gate`: the fast-tier gate is a predictor OF THE REAL CASCADE'S cost; it is
+    only meaningful when `embed_fn` IS the real cascade. Callers that inject a
+    different embed_fn (a test shim, or a known-fast callable) pass gate=False
+    to skip the predictor and just apply the deadline.
+
     Returns (vector|None, model_tag). A None vector is the "degrade to lexical"
     signal, identical in shape to a genuine embed miss, so callers need no new
     branch. Set M3_EMBED_SEARCH_DEADLINE_S=0 to disable the ceiling.
     """
-    if not fast_embedder_available():
+    _fn = embed_fn if embed_fn is not None else _embed
+    if gate and not fast_embedder_available():
         logger.info(
             "search embed skipped: no fast embedder tier available — "
             "degrading to FTS-only results (query vector not computed)"
@@ -1058,10 +1072,10 @@ async def embed_for_search(text: str) -> tuple[list[float] | None, str]:
 
     deadline = config.EMBED_SEARCH_DEADLINE_S
     if not deadline or deadline <= 0:
-        return await _embed(text)
+        return await _fn(text)
 
     try:
-        return await asyncio.wait_for(_embed(text), timeout=deadline)
+        return await asyncio.wait_for(_fn(text), timeout=deadline)
     except asyncio.TimeoutError:
         logger.warning(
             "search embed exceeded %.1fs deadline — degrading to FTS-only "

--- a/bin/memory/search.py
+++ b/bin/memory/search.py
@@ -27,6 +27,7 @@ import logging
 import os
 import re
 import sqlite3
+import threading
 from collections.abc import Callable
 
 from m3_sdk import resolve_db_path
@@ -237,10 +238,19 @@ def _resolve_mc_callbacks() -> None:
 # callers that don't use rerank.
 _RERANKER_MODEL = None  # CrossEncoder | None — lazy-init
 _RERANKER_MODEL_NAME = ""
+# Guards the lazy load below. _apply_rerank now runs via asyncio.to_thread (off
+# the event loop), so two concurrent rerank=True searches can call _get_reranker
+# from different pool threads simultaneously — without this lock they would race
+# the first-time CrossEncoder load (double GPU/CPU load) or observe a half-set
+# (_RERANKER_MODEL assigned, _RERANKER_MODEL_NAME not yet). The fast path (cache
+# hit) still needs no lock: the two globals are only ever transitioned together
+# under the lock, so a reader seeing a non-None model with a matching name sees
+# a fully-published pair.
+_RERANKER_LOCK = threading.Lock()
 
 
 def _get_reranker(model_name: str):
-    """Lazy-load + cache cross-encoder reranker.
+    """Lazy-load + cache cross-encoder reranker (thread-safe).
 
     Reuses the cached instance if model_name matches the previously-loaded one;
     otherwise loads the new model (and discards the prior). GPU is used if
@@ -251,24 +261,36 @@ def _get_reranker(model_name: str):
     the user has a broken install).
     """
     global _RERANKER_MODEL, _RERANKER_MODEL_NAME
+    # Fast path: lock-free cache hit (see _RERANKER_LOCK note on why this is safe).
     if _RERANKER_MODEL is not None and _RERANKER_MODEL_NAME == model_name:
         return _RERANKER_MODEL
-    try:
-        from sentence_transformers import CrossEncoder
-    except ImportError as e:
-        raise RuntimeError(
-            f"rerank=True requires sentence-transformers (declared in "
-            f"requirements.txt). Install/repair via: "
-            f"pip install -r requirements.txt. Original error: {e}"
-        ) from e
-    try:
-        import torch
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-    except ImportError:
-        device = "cpu"
-    _RERANKER_MODEL = CrossEncoder(model_name, device=device)
-    _RERANKER_MODEL_NAME = model_name
-    return _RERANKER_MODEL
+    with _RERANKER_LOCK:
+        # Re-check under the lock: another thread may have loaded it while we
+        # waited (double-checked locking).
+        if _RERANKER_MODEL is not None and _RERANKER_MODEL_NAME == model_name:
+            return _RERANKER_MODEL
+        try:
+            from sentence_transformers import CrossEncoder
+        except ImportError as e:
+            raise RuntimeError(
+                f"rerank=True requires sentence-transformers (declared in "
+                f"requirements.txt). Install/repair via: "
+                f"pip install -r requirements.txt. Original error: {e}"
+            ) from e
+        try:
+            import torch
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            device = "cpu"
+        model = CrossEncoder(model_name, device=device)
+        # Publish name FIRST then model? No — publish model then name would let a
+        # lock-free reader see a new model under the old name. Assign the model,
+        # then the name; the fast-path reader checks name==model_name AFTER
+        # reading model is not None, and both writes happen under the lock, so a
+        # reader either sees the old pair or the fully-updated new pair.
+        _RERANKER_MODEL = model
+        _RERANKER_MODEL_NAME = model_name
+        return _RERANKER_MODEL
 
 
 def _apply_rerank(
@@ -587,51 +609,19 @@ async def memory_search_scored_impl(
         except Exception as exc:
             logger.debug("FTS Short-circuit check failed (non-fatal): %s", exc)
 
-    # Degrade-safe query embed. The full _embed cascade can stack per-tier
-    # timeouts into minutes on a degraded box, and because the stdio MCP server
-    # is a single event loop that stall freezes EVERY concurrent tool call (the
-    # "MCP server locked up" symptom). memory_write sidesteps this by DEFERRING
-    # its embed; search cannot (no query vector, no semantic search), so it
-    # bounds the embed two ways and degrades to FTS-only on failure:
-    #   1. Fast-tier gate — skip the embed entirely if no fast tier is believed
-    #      up (same predictor the write path uses for inline-vs-defer).
-    #   2. Wall-clock deadline (EMBED_SEARCH_DEADLINE_S, default 8s) — cap a
-    #      slow-but-not-failed tier that never trips its breaker.
-    # `_embed` is the local floor-bind (monkeypatch-aware) resolved above; we
-    # replicate embed.embed_for_search's guards here rather than call it so the
-    # test-shim rebinding of `_embed` still takes effect.
-    #
-    # The fast-tier gate is a PREDICTOR OF THE REAL CASCADE'S COST — it only
-    # makes sense to apply when `_embed` IS the real cascade. When a caller or
-    # test has injected a different `_embed` (the floor-bind adopted a
-    # memory_core override at ~L504), the gate is meaningless: honor the
-    # injected embed and just bound it with the deadline. This keeps the
-    # degrade-safe behavior in production (where `_embed` is the module cascade)
-    # without forcing every caller/test that supplies a fast `_embed` to also
-    # patch the gate.
+    # Degrade-safe query embed via the single source of truth
+    # embed.embed_for_search (fast-tier gate + EMBED_SEARCH_DEADLINE_S wall-clock
+    # cap → degrades to FTS-only instead of wedging the single-loop MCP server).
+    # `_embed` is the local floor-bind (monkeypatch-aware) resolved above; pass
+    # it as embed_fn so the test-shim rebinding still takes effect. The fast-tier
+    # gate only makes sense when `_embed` IS the real module cascade — when a
+    # caller/test injected a different `_embed` (floor-bind adopted a memory_core
+    # override at ~L504) the predictor is meaningless, so gate=False there.
     from memory import embed as _embed_mod
     _embed_is_real = _embed is getattr(_embed_mod, "_embed", None)
-    q_vec = None
-    _try_embed = (not _embed_is_real) or _embed_mod.fast_embedder_available()
-    if _try_embed:
-        _deadline = _scfg.EMBED_SEARCH_DEADLINE_S
-        try:
-            if _deadline and _deadline > 0:
-                q_vec, _ = await asyncio.wait_for(_embed(query), timeout=_deadline)
-            else:
-                q_vec, _ = await _embed(query)
-        except asyncio.TimeoutError:
-            logger.warning(
-                "search embed exceeded %.1fs deadline — degrading to FTS-only "
-                "results (embed server / primary endpoint may be slow)",
-                _deadline,
-            )
-            q_vec = None
-    else:
-        logger.info(
-            "search embed skipped: no fast embedder tier available — "
-            "degrading to FTS-only results"
-        )
+    q_vec, _ = await _embed_mod.embed_for_search(
+        query, embed_fn=_embed, gate=_embed_is_real
+    )
     if not q_vec:
         # No query vector (embedder degraded, skipped, or timed out) — return
         # empty rather than hang. This preserves the pre-existing contract: the

--- a/tests/test_memory_search_routed.py
+++ b/tests/test_memory_search_routed.py
@@ -1515,3 +1515,54 @@ def test_elbow_quality_gating_floor(monkeypatch):
 
     out_high = mc._trim_by_elbow(hits_high, sensitivity=1.5)
     assert len(out_high) < len(hits_high), "Should trim candidates when top similarity is high and drop occurs"
+
+
+# ── Reranker lazy-load thread-safety (regression) ─────────────────────────────
+# _apply_rerank now runs via asyncio.to_thread (off the event loop), so two
+# concurrent rerank=True searches can call _get_reranker from different pool
+# threads at once. Without the _RERANKER_LOCK, they race the first-time model
+# load. This verifies concurrent _get_reranker calls load the model exactly once
+# and all return the same instance.
+
+def test_get_reranker_concurrent_loads_once(monkeypatch):
+    import threading as _threading
+
+    import memory.search as S
+
+    # Reset the module cache so the load actually happens under the test.
+    monkeypatch.setattr(S, "_RERANKER_MODEL", None)
+    monkeypatch.setattr(S, "_RERANKER_MODEL_NAME", "")
+
+    load_count = {"n": 0}
+    barrier = _threading.Barrier(8)
+
+    class _FakeCE:
+        def __init__(self, model_name, device="cpu"):
+            load_count["n"] += 1  # count real constructions
+
+    # Patch the CrossEncoder import target. _get_reranker does
+    # `from sentence_transformers import CrossEncoder`, so patch there.
+    import sys as _sys
+    import types as _types
+    fake_mod = _types.ModuleType("sentence_transformers")
+    fake_mod.CrossEncoder = _FakeCE
+    monkeypatch.setitem(_sys.modules, "sentence_transformers", fake_mod)
+
+    results = []
+    res_lock = _threading.Lock()
+
+    def _worker():
+        barrier.wait()  # maximize contention: all threads hit the load together
+        r = S._get_reranker("some/model")
+        with res_lock:
+            results.append(r)
+
+    threads = [_threading.Thread(target=_worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert load_count["n"] == 1, f"model must load exactly once, loaded {load_count['n']}x (race)"
+    assert len(results) == 8
+    assert all(r is results[0] for r in results), "all callers must get the same cached instance"


### PR DESCRIPTION
Follow-up to #91. Addresses all five findings from a high-effort code review of the merged diff.

| # | Finding | Fix | Severity |
|---|---------|-----|----------|
| 1 | **Reranker model-cache data race** — `_apply_rerank` now runs via `asyncio.to_thread` (a thread pool), so two concurrent `rerank=True` searches could race the first-time `_get_reranker` model load (double load, or half-published globals). | `threading.Lock` with double-checked locking around the lazy load; cache-hit fast path stays lock-free. + concurrency regression test. | correctness |
| 2 | **Stale `_embed` docstring** described the old work-conserving-borrow policy ("bulk may borrow when idle") — the shipped gate is strict, no borrow. | Corrected docstring. | docs |
| 3 | **`embed_for_search()` was dead production code** (only tests called it) while `search.py` replicated its guards inline — two copies that can drift. | Made it the single source of truth: added `embed_fn` + `gate` params so `search.py` passes its monkeypatch-aware floor-bound `_embed`. Removed the inline duplication. | reuse |
| 4 | **`_embed` gate=None fallback derefs `_embedder` unguarded** (type-ignored) — a request racing startup would `AttributeError` in a worker thread. | Explicit `RuntimeError("embedder not loaded yet")` guard. | correctness |
| 5 | **Size-based classification is a fragile default** for header-less callers. | Documented `X-M3-Embed-Priority` as authoritative; size is only a header-less fallback. | correctness |

## Verification
- Full suite: **1992 passed, 43 skipped** (+1 new reranker concurrency test).
- `mypy bin/ --ignore-missing-imports` clean (218 files); ruff clean.
- Live: `memory_search` verified working through the refactored `embed_for_search` call; the reranker loads exactly once under 8-thread contention.