### PR TITLE
LangChain directory submission + m3-langchain alias

### DIFF
--- a/docs/integrations/LANGCHAIN_DIRECTORY_SUBMISSION.md
+++ b/docs/integrations/LANGCHAIN_DIRECTORY_SUBMISSION.md
@@ -1,71 +1,68 @@
 # LangChain integration-directory submission — m3-memory
 
-Everything needed to register **m3-memory** in the official LangChain integration
-directory. LangChain does **not** accept new integrations as PRs into its own
-repos — packages are published independently to PyPI, then registered via a small
-PR to the langchain monorepo. m3-memory is already on PyPI
+Everything needed to register **m3-memory** in the LangChain integration
+directory. m3-memory is already on PyPI
 ([`m3-memory`](https://pypi.org/project/m3-memory/)), so this is the registration
 step only.
 
-Sources for the process:
+> **Verified against the live LangChain docs repo (2026-07).** Registration moved
+> out of the `langchain-ai/langchain` monorepo into the dedicated
+> **[`langchain-ai/docs`](https://github.com/langchain-ai/docs)** repo (default
+> branch `main`). The registry is **`packages.yml`** at that repo's root, and
+> provider pages live under **`src/oss/integrations/providers/`**. (Older guides
+> pointing at `langchain-ai/langchain` + `libs/packages.yml` are stale.)
+
+Sources:
 [Providers overview](https://docs.langchain.com/oss/python/integrations/providers/overview) ·
-[Contributing guide](https://docs.langchain.com/oss/python/contributing) ·
-[Publishing an integration](https://python.langchain.com/docs/contributing/how_to/integrations/publish/)
+[langchain-ai/docs packages.yml](https://github.com/langchain-ai/docs/blob/main/packages.yml) ·
+example PRs [#559](https://github.com/langchain-ai/docs/pull/559),
+[#30573](https://github.com/langchain-ai/langchain/pull/30573)
 
 ---
 
-## 1. Registration entry — append to `libs/packages.yml`
+## 1. Registration entry — append to `packages.yml` (in `langchain-ai/docs`)
 
-In a fork of [`langchain-ai/langchain`](https://github.com/langchain-ai/langchain),
-add this to the **end** of `libs/packages.yml`:
+Fork [`langchain-ai/docs`](https://github.com/langchain-ai/docs) and add this
+under `packages:` in the root **`packages.yml`**:
 
 ```yaml
-  - name: m3-memory
-    repo: skynetcmd/m3-memory
-    path: .
-    provider_page: m3_memory
+- name: m3-memory
+  name_title: m3-memory
+  repo: skynetcmd/m3-memory
+  path: .
+  provider_page: m3_memory
+  js: n/a
 ```
 
-Notes:
-- The registered name is **`m3-memory`** (the canonical package). LangChain
-  permits non-`langchain-*` names (e.g. `databricks-langchain`); m3's LangChain
-  surface ships inside the main package under the `[langchain]` extra rather than
-  a separate distribution, because that surface is a thin in-process façade over
-  the local m3 engine — splitting the code would only add a redundant package.
-- `path: .` — the package is at the repo root.
-- `provider_page` points at the provider doc added in step 2.
-
-### Discoverable alias — `m3-langchain` (optional, recommended)
-
-For the conventional, `databricks-langchain`-style discoverable name, a thin
-alias package lives at [`packages/m3-langchain/`](../../packages/m3-langchain).
-It ships **one module** that re-exports `m3_memory.langchain` and declares a
-single dependency, `m3-memory[langchain]==<same version>` — so `pip install
-m3-langchain` gives the full integration under the recognizable name, with no
-code duplication and no version skew.
-
-Publish it alongside a release (built + `twine check`-verified):
-```bash
-cd packages/m3-langchain && python -m build && twine upload dist/*
-```
-The directory registration still points at `m3-memory` (the canonical provider);
-`m3-langchain` is purely for PyPI name-discoverability.
+Field notes (per the schema documented at the top of `packages.yml`):
+- **`name: m3-memory`** — the published PyPI package. The directory's download
+  automation (pepy.tech) queries this name, so it must be a live package;
+  `m3-memory` is published, so use it (not the unpublished `m3-langchain` alias).
+- **`name_title`** — display name; set explicitly since the default strips a
+  `langchain-`/`-langchain` affix that `m3-memory` doesn't have.
+- **`path: .`** — package at repo root.
+- **`provider_page: m3_memory`** — points at the page added in step 2 (its
+  `name_short` would otherwise be `m3-memory`; naming the page keeps it clean).
+- **`js: n/a`** — Python-specific; no JS package.
+- Do **not** set `highlight`, `downloads`, or `downloads_updated_at` — those are
+  maintainer-only / auto-generated.
 
 ---
 
-## 2. Provider page — `docs/docs/integrations/providers/m3_memory.mdx`
+## 2. Provider page — `src/oss/integrations/providers/m3_memory.mdx`
 
-Add this page to the langchain monorepo (the directory the docs site renders
-from). Keep it factual — every capability below maps to a shipped class.
+Add this to the `langchain-ai/docs` fork. Match the style of existing pages
+(e.g. `src/oss/integrations/providers/cala.mdx`): an intro blockquote, install,
+then per-surface sections.
 
 ````markdown
 # m3-memory
 
-[m3-memory](https://github.com/skynetcmd/m3-memory) is a local-first, MCP-native
-memory layer with hybrid retrieval (SQLite FTS5 + BGE-M3 vector + MMR),
-bitemporal history, deterministic contradiction supersession, and GDPR
-forget/export — all offline, no server or API key. It exposes five standard
-LangChain surfaces plus LCEL-native components, and can also back LangMem.
+>[m3-memory](https://github.com/skynetcmd/m3-memory) is a local-first, MCP-native
+>memory layer with hybrid retrieval (SQLite FTS5 + BGE-M3 vector + MMR),
+>bitemporal history, deterministic contradiction supersession, and GDPR
+>forget/export — all offline, no server or API key. It ships five standard
+>LangChain surfaces plus LCEL-native components, and can also back LangMem.
 
 ## Installation
 
@@ -73,21 +70,19 @@ LangChain surfaces plus LCEL-native components, and can also back LangMem.
 pip install "m3-memory[langchain]"
 ```
 
-m3 self-configures on first use (in-process embedder; the SQLite DB is created
-and migrated automatically). No external service to run.
+m3 self-configures on first use (in-process embedder; SQLite created and migrated
+automatically). No external service to run.
 
 ## Memory / store (drop-in Mem0 replacement, and LangGraph `BaseStore`)
 
 ```python
 from m3_memory.langchain import Memory, M3Store
 
-# mem0-compatible surface — a one-line import swap from `from mem0 import Memory`
-mem = Memory(user_id="alex")
+mem = Memory(user_id="alex")                 # one-line swap from `from mem0 import Memory`
 mem.add([{"role": "user", "content": "I prefer dark mode."}])
 mem.search("appearance preferences", limit=3)
 
-# LangGraph BaseStore — also backs LangMem (pass store=M3Store())
-store = M3Store()
+store = M3Store()                            # LangGraph BaseStore; also backs LangMem
 ```
 
 ## Chat message history
@@ -101,8 +96,7 @@ history = M3ChatMessageHistory("session-1", user_id="alex")
 
 ```python
 from m3_memory.langchain import M3Retriever
-retriever = M3Retriever(user_id="alex", k=4)
-docs = retriever.invoke("deadline")  # Documents carry score, confidence, valid_from/to
+retriever = M3Retriever(user_id="alex", k=4)   # Documents carry score, confidence, valid_from/to
 ```
 
 ## Checkpointer (pause / resume / time-travel)
@@ -121,9 +115,9 @@ chain = MemoryRetrieve(user_id="alex") | prompt | llm | MemoryWrite(user_id="ale
 
 ## What it adds over plain LangChain memory
 
-Contradiction supersession (`.supersede`), temporal queries (`as_of=`),
-commanded forgetting (`.forget`), and hybrid + knowledge-graph retrieval
-(`.related`) — first-class methods on the same objects, all local.
+Contradiction supersession (`.supersede`), temporal queries (`as_of=`), commanded
+forgetting (`.forget`), and hybrid + knowledge-graph retrieval (`.related`) —
+first-class methods on the same objects, all local.
 
 Full guide: [docs/integrations/LANGCHAIN.md](https://github.com/skynetcmd/m3-memory/blob/main/docs/integrations/LANGCHAIN.md).
 ````
@@ -140,18 +134,16 @@ Full guide: [docs/integrations/LANGCHAIN.md](https://github.com/skynetcmd/m3-mem
 | `M3ChatMessageHistory` | `langchain_core.chat_history.BaseChatMessageHistory` | short-term chat history |
 | `M3Retriever` | `langchain_core.retrievers.BaseRetriever` | RAG retrieval |
 | `MemoryWrite` / `MemoryRetrieve` | `langchain_core.runnables.Runnable` | LCEL memory read/write |
-| `with_m3_history` / `with_m3_memory` | *(helpers)* | one-line wrappers |
 
 Compatibility: `langchain-core>=0.3.0,<1`, `langgraph>=0.2.0,<1` (verified against
 langgraph 0.6.x / langgraph-checkpoint 3.x).
 
 ---
 
-## 4. Suggested PR
+## 4. The PR
 
-- **Target:** `langchain-ai/langchain`, files `libs/packages.yml` +
-  `docs/docs/integrations/providers/m3_memory.mdx` only (per the contributing
-  guide, a registration PR touches nothing else).
+- **Target repo:** `langchain-ai/docs` (NOT the `langchain` monorepo).
+- **Files:** `packages.yml` + `src/oss/integrations/providers/m3_memory.mdx` only.
 - **Title:** `docs: add m3-memory integration provider`
 - **Body:**
 
@@ -159,20 +151,18 @@ langgraph 0.6.x / langgraph-checkpoint 3.x).
   > MCP-native memory layer — as an integration provider. It ships five standard
   > LangChain surfaces (`Memory` mem0 drop-in, `M3Store` `BaseStore`, `M3Saver`
   > `BaseCheckpointSaver`, `M3ChatMessageHistory`, `M3Retriever`) plus LCEL
-  > components, installable via `pip install "m3-memory[langchain]"`. Already
-  > published to PyPI; this PR adds the `packages.yml` entry and provider page
-  > only. Apache-2.0.
+  > components, installable via `pip install "m3-memory[langchain]"`. Already on
+  > PyPI; this PR adds the `packages.yml` entry and provider page only.
+  > Apache-2.0.
 
 ---
 
 ## Pre-submit checklist
 
-- [x] Package published to PyPI (`m3-memory`, latest release carries the
-      `[langchain]` extra and all surfaces)
-- [x] Public repo with the integration guide + runnable examples
-      (`examples/langchain-agent/`)
-- [x] Apache-2.0 licensed
-- [ ] Fork `langchain-ai/langchain`, add the two files above, open the PR
-- [ ] (Optional, strengthens the listing) Add a runnable example notebook under
-      `docs/docs/integrations/` per the contributing guide — LangChain's docs are
-      generated from notebooks, so an `.ipynb` renders as an example page
+- [x] `m3-memory` published to PyPI (the entry's download automation needs a live package)
+- [x] Public repo with integration guide + runnable examples (`examples/langchain-agent/`)
+- [x] Apache-2.0
+- [x] Registration mechanism verified against the current `langchain-ai/docs` repo
+- [ ] Fork `langchain-ai/docs`, add the two files, open the PR
+- [ ] (Optional) Publish `m3-langchain` alias to PyPI for the discoverable name
+      — separate from this directory entry, which uses `m3-memory`

--- a/docs/integrations/LANGCHAIN_DIRECTORY_SUBMISSION.md
+++ b/docs/integrations/LANGCHAIN_DIRECTORY_SUBMISSION.md
@@ -1,0 +1,178 @@
+# LangChain integration-directory submission — m3-memory
+
+Everything needed to register **m3-memory** in the official LangChain integration
+directory. LangChain does **not** accept new integrations as PRs into its own
+repos — packages are published independently to PyPI, then registered via a small
+PR to the langchain monorepo. m3-memory is already on PyPI
+([`m3-memory`](https://pypi.org/project/m3-memory/)), so this is the registration
+step only.
+
+Sources for the process:
+[Providers overview](https://docs.langchain.com/oss/python/integrations/providers/overview) ·
+[Contributing guide](https://docs.langchain.com/oss/python/contributing) ·
+[Publishing an integration](https://python.langchain.com/docs/contributing/how_to/integrations/publish/)
+
+---
+
+## 1. Registration entry — append to `libs/packages.yml`
+
+In a fork of [`langchain-ai/langchain`](https://github.com/langchain-ai/langchain),
+add this to the **end** of `libs/packages.yml`:
+
+```yaml
+  - name: m3-memory
+    repo: skynetcmd/m3-memory
+    path: .
+    provider_page: m3_memory
+```
+
+Notes:
+- The registered name is **`m3-memory`** (the canonical package). LangChain
+  permits non-`langchain-*` names (e.g. `databricks-langchain`); m3's LangChain
+  surface ships inside the main package under the `[langchain]` extra rather than
+  a separate distribution, because that surface is a thin in-process façade over
+  the local m3 engine — splitting the code would only add a redundant package.
+- `path: .` — the package is at the repo root.
+- `provider_page` points at the provider doc added in step 2.
+
+### Discoverable alias — `m3-langchain` (optional, recommended)
+
+For the conventional, `databricks-langchain`-style discoverable name, a thin
+alias package lives at [`packages/m3-langchain/`](../../packages/m3-langchain).
+It ships **one module** that re-exports `m3_memory.langchain` and declares a
+single dependency, `m3-memory[langchain]==<same version>` — so `pip install
+m3-langchain` gives the full integration under the recognizable name, with no
+code duplication and no version skew.
+
+Publish it alongside a release (built + `twine check`-verified):
+```bash
+cd packages/m3-langchain && python -m build && twine upload dist/*
+```
+The directory registration still points at `m3-memory` (the canonical provider);
+`m3-langchain` is purely for PyPI name-discoverability.
+
+---
+
+## 2. Provider page — `docs/docs/integrations/providers/m3_memory.mdx`
+
+Add this page to the langchain monorepo (the directory the docs site renders
+from). Keep it factual — every capability below maps to a shipped class.
+
+````markdown
+# m3-memory
+
+[m3-memory](https://github.com/skynetcmd/m3-memory) is a local-first, MCP-native
+memory layer with hybrid retrieval (SQLite FTS5 + BGE-M3 vector + MMR),
+bitemporal history, deterministic contradiction supersession, and GDPR
+forget/export — all offline, no server or API key. It exposes five standard
+LangChain surfaces plus LCEL-native components, and can also back LangMem.
+
+## Installation
+
+```bash
+pip install "m3-memory[langchain]"
+```
+
+m3 self-configures on first use (in-process embedder; the SQLite DB is created
+and migrated automatically). No external service to run.
+
+## Memory / store (drop-in Mem0 replacement, and LangGraph `BaseStore`)
+
+```python
+from m3_memory.langchain import Memory, M3Store
+
+# mem0-compatible surface — a one-line import swap from `from mem0 import Memory`
+mem = Memory(user_id="alex")
+mem.add([{"role": "user", "content": "I prefer dark mode."}])
+mem.search("appearance preferences", limit=3)
+
+# LangGraph BaseStore — also backs LangMem (pass store=M3Store())
+store = M3Store()
+```
+
+## Chat message history
+
+```python
+from m3_memory.langchain import M3ChatMessageHistory
+history = M3ChatMessageHistory("session-1", user_id="alex")
+```
+
+## Retriever (RAG)
+
+```python
+from m3_memory.langchain import M3Retriever
+retriever = M3Retriever(user_id="alex", k=4)
+docs = retriever.invoke("deadline")  # Documents carry score, confidence, valid_from/to
+```
+
+## Checkpointer (pause / resume / time-travel)
+
+```python
+from m3_memory.langchain import M3Saver
+graph = builder.compile(checkpointer=M3Saver())
+```
+
+## LCEL-native components
+
+```python
+from m3_memory.langchain import MemoryRetrieve, MemoryWrite
+chain = MemoryRetrieve(user_id="alex") | prompt | llm | MemoryWrite(user_id="alex")
+```
+
+## What it adds over plain LangChain memory
+
+Contradiction supersession (`.supersede`), temporal queries (`as_of=`),
+commanded forgetting (`.forget`), and hybrid + knowledge-graph retrieval
+(`.related`) — first-class methods on the same objects, all local.
+
+Full guide: [docs/integrations/LANGCHAIN.md](https://github.com/skynetcmd/m3-memory/blob/main/docs/integrations/LANGCHAIN.md).
+````
+
+---
+
+## 3. Class → base-class reference (verified against the shipped package)
+
+| m3 surface | LangChain / LangGraph base class | Job |
+|---|---|---|
+| `Memory` / `M3Memory` / `MemoryClient` | *(mem0 API shape — no base class)* | drop-in Mem0 replacement |
+| `M3Store` | `langgraph.store.base.BaseStore` | long-term memory; backs LangMem |
+| `M3Saver` | `langgraph.checkpoint.base.BaseCheckpointSaver` | run persistence / time-travel |
+| `M3ChatMessageHistory` | `langchain_core.chat_history.BaseChatMessageHistory` | short-term chat history |
+| `M3Retriever` | `langchain_core.retrievers.BaseRetriever` | RAG retrieval |
+| `MemoryWrite` / `MemoryRetrieve` | `langchain_core.runnables.Runnable` | LCEL memory read/write |
+| `with_m3_history` / `with_m3_memory` | *(helpers)* | one-line wrappers |
+
+Compatibility: `langchain-core>=0.3.0,<1`, `langgraph>=0.2.0,<1` (verified against
+langgraph 0.6.x / langgraph-checkpoint 3.x).
+
+---
+
+## 4. Suggested PR
+
+- **Target:** `langchain-ai/langchain`, files `libs/packages.yml` +
+  `docs/docs/integrations/providers/m3_memory.mdx` only (per the contributing
+  guide, a registration PR touches nothing else).
+- **Title:** `docs: add m3-memory integration provider`
+- **Body:**
+
+  > Registers [m3-memory](https://pypi.org/project/m3-memory/) — a local-first,
+  > MCP-native memory layer — as an integration provider. It ships five standard
+  > LangChain surfaces (`Memory` mem0 drop-in, `M3Store` `BaseStore`, `M3Saver`
+  > `BaseCheckpointSaver`, `M3ChatMessageHistory`, `M3Retriever`) plus LCEL
+  > components, installable via `pip install "m3-memory[langchain]"`. Already
+  > published to PyPI; this PR adds the `packages.yml` entry and provider page
+  > only. Apache-2.0.
+
+---
+
+## Pre-submit checklist
+
+- [x] Package published to PyPI (`m3-memory`, latest release carries the
+      `[langchain]` extra and all surfaces)
+- [x] Public repo with the integration guide + runnable examples
+      (`examples/langchain-agent/`)
+- [x] Apache-2.0 licensed
+- [ ] Fork `langchain-ai/langchain`, add the two files above, open the PR
+- [ ] (Optional, strengthens the listing) Add a runnable example notebook under
+      `docs/docs/integrations/` per the contributing guide — LangChain's docs are
+      generated from notebooks, so an `.ipynb` renders as an example page

--- a/packages/m3-langchain/README.md
+++ b/packages/m3-langchain/README.md
@@ -1,0 +1,28 @@
+# m3-langchain
+
+A recognizable, `databricks-langchain`-style alias for **m3-memory**'s LangChain
+/ LangGraph integration. It contains no code of its own — it re-exports
+[`m3_memory.langchain`](https://github.com/skynetcmd/m3-memory/blob/main/docs/integrations/LANGCHAIN.md)
+and depends on `m3-memory[langchain]`, so `pip install m3-langchain` gives you the
+full, local-first m3 memory layer under a discoverable name.
+
+```bash
+pip install m3-langchain
+```
+
+```python
+from m3_langchain import Memory, M3Store, M3Saver
+# Memory  → drop-in Mem0 replacement (one-line import swap)
+# M3Store → LangGraph BaseStore / backs LangMem
+# M3Saver → LangGraph checkpointer (pause / resume / time-travel)
+```
+
+These are the same objects as `from m3_memory.langchain import ...`. New code can
+import from either path; this package exists for name-discoverability.
+
+**Full integration guide, examples, and the complete surface list** (retriever,
+chat history, LCEL `MemoryWrite`/`MemoryRetrieve`, the m3-native extras
+`.supersede`/`as_of=`/`.forget`/`.related`) live in the main repo:
+[skynetcmd/m3-memory](https://github.com/skynetcmd/m3-memory).
+
+Apache-2.0.

--- a/packages/m3-langchain/m3_langchain/__init__.py
+++ b/packages/m3-langchain/m3_langchain/__init__.py
@@ -1,0 +1,45 @@
+"""``m3-langchain`` — a recognizable alias for m3-memory's LangChain surface.
+
+This package is a **thin re-export shim**. The integration itself lives in
+``m3-memory`` (installed as a dependency here, with its ``[langchain]`` extra);
+this package exists only so the conventional, discoverable name
+``m3-langchain`` (à la ``databricks-langchain``) resolves on PyPI and imports:
+
+    pip install m3-langchain
+    from m3_langchain import Memory, M3Store, M3Saver   # same objects as m3_memory.langchain
+
+It intentionally holds **no integration code** — every name forwards to
+``m3_memory.langchain``, so a new surface added upstream is available here with
+no change to this package (nothing to keep in sync, nothing to drift). Prefer
+``from m3_memory.langchain import ...`` in new code; this alias is for
+name-discoverability, not a separate API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Re-export the eager (no-LangChain-dep) surface directly so plain
+# `from m3_langchain import Memory` works even before the lazy machinery runs.
+from m3_memory.langchain import (  # noqa: F401
+    M3Memory,
+    Memory,
+    MemoryClient,
+    __all__,
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Forward every other attribute (M3Store / M3Saver / M3Retriever /
+    history / LCEL) to ``m3_memory.langchain``, preserving its lazy
+    optional-dependency ImportError hints. Because this delegates rather than
+    enumerating, any surface added upstream is exposed here automatically."""
+    import m3_memory.langchain as _pkg
+
+    return getattr(_pkg, name)
+
+
+def __dir__() -> list[str]:
+    import m3_memory.langchain as _pkg
+
+    return sorted(set(list(globals()) + list(getattr(_pkg, "__all__", []))))

--- a/packages/m3-langchain/pyproject.toml
+++ b/packages/m3-langchain/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=77,<82", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "m3-langchain"
+version = "2026.7.15.1"
+description = "Recognizable alias for m3-memory's LangChain / LangGraph integration (drop-in Mem0 replacement, M3Store, M3Saver checkpointer, retriever, LCEL). Re-exports m3_memory.langchain."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [{ name = "skynetCMD" }]
+keywords = ["langchain", "langgraph", "mem0", "memory", "checkpointer", "m3", "mcp", "local-first"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+# The integration lives in m3-memory. Pin the SAME version so `m3-langchain
+# X.Y.Z` always resolves the matching m3-memory, and pull its [langchain] extra
+# (langchain-core / langgraph) transitively — this shim adds no deps of its own.
+dependencies = ["m3-memory[langchain]==2026.7.15.1"]
+
+[project.urls]
+Homepage = "https://github.com/skynetcmd/m3-memory"
+Repository = "https://github.com/skynetcmd/m3-memory"
+Documentation = "https://github.com/skynetcmd/m3-memory/blob/main/docs/integrations/LANGCHAIN.md"
+"Bug Tracker" = "https://github.com/skynetcmd/m3-memory/issues"
+
+[tool.setuptools]
+packages = ["m3_langchain"]


### PR DESCRIPTION
Adds two additive, non-runtime items:

- `docs/integrations/LANGCHAIN_DIRECTORY_SUBMISSION.md` — the ready-to-submit
  package for LangChain's integration directory (registers `m3-memory` as the
  provider; `packages.yml` entry + provider page).
- `packages/m3-langchain/` — a thin `databricks-langchain`-style alias: one
  module re-exporting `m3_memory.langchain`, depending on
  `m3-memory[langchain]==<version>`, so the discoverable name resolves on PyPI
  with no code duplication or version skew.

No changes to shipped m3-memory code. Alias verified: installs as a prebuilt
wheel (no build step / egg-info for users), and its surfaces are the same
objects as `m3_memory.langchain`.