### PR TITLE
fix(loop): converge chatlog-prune + cap entity-extraction retries

### DIFF
--- a/bin/chatlog_prune.py
+++ b/bin/chatlog_prune.py
@@ -189,6 +189,7 @@ def run(db_path: str, args) -> dict:
     S: dict[str, Any] = {
         "db": db_path, "apply": args.apply, "scanned": 0,
         "fresh_kept": 0, "decay": {}, "prune": {}, "kept_noise_recent": 0,
+        "kept_already_decayed": 0,
         "writes_decay": 0, "writes_prune": 0,
         "prune_rows": 0, "prune_content_mb": 0.0, "errors": [],
         "params": {"fresh_days": args.fresh_days, "prune_days": args.prune_days,
@@ -251,7 +252,14 @@ def _run_sweep(conn, db_path, args, now_ts, S, _d, _p, _tbl, _is_sqlite) -> dict
         fresh_cutoff = datetime.fromtimestamp(
             now_ts - args.fresh_days * 86400.0, timezone.utc
         ).isoformat()
-        rows = conn.execute(f"""SELECT id, {role_sql} AS role, content, importance, created_at
+        # Select aged candidates. We DO still pull already-decayed rows (valid_to
+        # set) here, because a row decayed while it was in the DECAY tier must
+        # still be re-examined once it ages past prune_days so it can be
+        # soft-deleted (the PRUNE tier). The convergence guard that stops the
+        # infinite re-decay loop is applied per-row in PASS 2 (see `already_decayed`
+        # below), NOT by excluding decayed rows from the scan — excluding them
+        # here would strand them from ever being pruned.
+        rows = conn.execute(f"""SELECT id, {role_sql} AS role, content, importance, created_at{', valid_to' if has_valid_to else ''}
                                 FROM {_tbl}
                                 WHERE type='chat_log' AND is_deleted=0
                                   AND created_at < {_p}
@@ -297,7 +305,30 @@ def _run_sweep(conn, db_path, args, now_ts, S, _d, _p, _tbl, _is_sqlite) -> dict
                 _is_protected(content, args.generic_protect_len)
                 or (cat == "generic_low" and len(content) >= args.generic_delete_maxlen))
             if age < args.prune_days or protected:
-                # DECAY/SUPPRESS tier
+                # DECAY/SUPPRESS tier.
+                # CONVERGENCE GUARD: if this row was already decayed on a prior
+                # run (valid_to set), do NOT decay it again. Without this the same
+                # aged-but-not-yet-prunable rows are re-decayed every run
+                # (0.06 -> 0.012 -> ...), the pass reports an identical
+                # `suppress=N capped=True` forever, and — because decayed rows
+                # keep importance<=0.3 — has_chatlog_prune_work stays True so the
+                # loop re-fires every cycle. This was the ~11s "same 5000 rows
+                # over and over" loop. A decayed row still reaches the PRUNE tier
+                # once it ages past prune_days (the branch below), so suppression
+                # remains a way-station to deletion, not a dead end.
+                # Cross-backend "decayed" test: valid_to is set to a real
+                # timestamp. SQLite TEXT columns represent "open"/unset as EITHER
+                # NULL OR the empty string '' (loose typing; see dialect
+                # coalesce_open_timestamp / valid_from filter notes), while
+                # Postgres/MariaDB use NULL only. Treat BOTH None and '' (after
+                # strip) as not-yet-decayed so a never-touched row is not wrongly
+                # skipped on SQLite, and a genuinely decayed row is skipped on all
+                # backends.
+                _vt = r["valid_to"] if has_valid_to else None
+                already_decayed = bool(_vt is not None and str(_vt).strip() != "")
+                if already_decayed:
+                    S["kept_already_decayed"] += 1
+                    continue
                 tag = cat if age < args.prune_days else f"{cat}!protected"
                 S["decay"][tag] = S["decay"].get(tag, 0) + 1
                 new_imp = round(min(imp, 0.3) * 0.2, 4)

--- a/bin/dashboard_server.py
+++ b/bin/dashboard_server.py
@@ -2216,7 +2216,9 @@ def _port_already_serving(host: str, port: int, timeout: float = 1.0) -> bool:
     probed via loopback (you connect TO a concrete address, not the wildcard).
     """
     import socket
-    probe = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host
+    # B104 false positive: "0.0.0.0" here is a string comparison that remaps the
+    # wildcard to loopback for an outbound connect probe; this is not a bind-to-all.
+    probe = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host  # nosec B104
     try:
         with socket.create_connection((probe, port), timeout=timeout):
             return True

--- a/bin/doctor/dashboard_probe.py
+++ b/bin/doctor/dashboard_probe.py
@@ -65,7 +65,9 @@ def _port_serving(host: str, port: int, timeout: float = 2.0) -> bool:
     route staying stable. 0.0.0.0 is probed via loopback (you can't connect TO
     the wildcard address).
     """
-    probe_host = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host
+    # B104 false positive: "0.0.0.0" here is a string comparison that remaps the
+    # wildcard to loopback for an outbound connect probe; this is not a bind-to-all.
+    probe_host = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host  # nosec B104
     try:
         with socket.create_connection((probe_host, port), timeout=timeout):
             return True

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -103,8 +103,20 @@ def daemonize_windows(args):
             stdout=child_out,
             stderr=subprocess.STDOUT,
         )
-    print("Cognitive Loop started in background (Windows pythonw).")
-    sys.stdout.flush()
+    # CRITICAL: the parent MUST hard-exit now, or we get TWO live loops (the
+    # detached child worker + this parent). The status print() is best-effort and
+    # MUST NOT be able to prevent the exit: under pythonw.exe there is NO console,
+    # so sys.stdout is None / a dead handle and BOTH print() and flush() raise
+    # (AttributeError/OSError/ValueError). If that exception propagates before
+    # os._exit(0), the parent survives, falls through to acquire_lock()+main_loop,
+    # and double-dispatches to the local LLM — the observed "parent+child both
+    # looping" bug that survived the scheduled-task single-instance fix. Wrap the
+    # I/O so nothing stands between the Popen and the exit.
+    try:
+        print("Cognitive Loop started in background (Windows pythonw).")
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001 — no console under pythonw; never block the exit
+        pass
     os._exit(0)
 
 def daemonize_unix():
@@ -869,20 +881,49 @@ def has_chatlog_prune_work(chatlog_db: Optional[str], prune_days: float,
     Event-driven gate (mirrors has_consolidate_work) so the loop only does a
     sweep when a real backlog of prune-eligible noise has accumulated."""
     try:
-        from memory.backends import chatlog_table, dialect
+        from memory.backends import active_backend, chatlog_table, dialect
         _d = dialect()
         _p = _d.param()
+        _is_sqlite = active_backend().name == "sqlite"
         _T = chatlog_table("items")  # memory_items (sqlite) | chat_log_items (pg)
-        sql = (
-            f"SELECT 1 FROM {_T} "
-            f"WHERE type='chat_log' AND is_deleted=0 AND importance <= 0.3 "
-            f"AND created_at < {_d.now_minus_days(_p)} "
-            f"GROUP BY type HAVING COUNT(*) > {_p} LIMIT 1"
-        )
-        # Route through the chatlog connection (PG: core pool + chat_log_* tables;
-        # SQLite: the chatlog file). now_minus_days binds an INT (portable).
+        # CONVERGENCE: the sweep decays a noise row ONCE (lowers importance to
+        # ~0.06, sets valid_to). A decayed row keeps importance<=0.3, so a gate
+        # keyed only on that stays True forever after the backlog drains —
+        # re-firing the pass every cycle to do nothing (part of the "same rows
+        # over and over" loop). Count only rows the sweep can still ACT on:
+        # not-yet-decayed (valid_to open). Cross-backend "open" test — SQLite
+        # stores an unset bound as NULL OR '' (loose TEXT typing); Postgres/
+        # MariaDB use NULL only — so a bare `valid_to IS NULL` would miss SQLite's
+        # '' and undercount. Guard on the column existing (older schema/backend
+        # without valid_to falls back to the importance-only gate, matching that
+        # schema's sweep behaviour).
         ctx = M3Context.for_db(None)
         with ctx.get_chatlog_conn() as conn:
+            _has_valid_to = False
+            try:
+                _cs, _cp = _d.columns_of(_T)
+                _has_valid_to = any(r[0] == "valid_to" for r in conn.execute(_cs, _cp).fetchall())
+            except Exception:  # noqa: BLE001 — introspection failure degrades to importance-only
+                _has_valid_to = False
+            # "not-yet-decayed" = valid_to is open. No extra bind params: the
+            # clause is a literal comparison the backend evaluates directly.
+            #   SQLite : valid_to open == NULL OR '' (loose TEXT typing)
+            #   PG/MDB : valid_to open == NULL only (TIMESTAMPTZ; '' is illegal,
+            #            so referencing = '' there would error — hence the branch)
+            _open_clause = ""
+            if _has_valid_to:
+                if _is_sqlite:
+                    _open_clause = " AND (valid_to IS NULL OR valid_to = '')"
+                else:
+                    _open_clause = " AND valid_to IS NULL"
+            sql = (
+                f"SELECT 1 FROM {_T} "
+                f"WHERE type='chat_log' AND is_deleted=0 AND importance <= 0.3 "
+                f"AND created_at < {_d.now_minus_days(_p)} "
+                f"{_open_clause} "
+                f"GROUP BY type HAVING COUNT(*) > {_p} LIMIT 1"
+            )
+            # now_minus_days binds an INT; only prune_days + min_rows are params.
             return len(conn.execute(sql, (int(prune_days), min_rows)).fetchall()) > 0
     except Exception as e:
         logger.debug(f"Chatlog-prune work check failed (non-fatal): {e}")

--- a/bin/m3_entities.py
+++ b/bin/m3_entities.py
@@ -85,6 +85,30 @@ ALWAYS_SKIP_TYPES = ("auto", "scratchpad", "summary")  # summary excluded; delet
 
 JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
 
+# Max times a row may fail HTTP/write before it stops being re-selected. A
+# deterministically-failing row (e.g. content that always overflows the loaded
+# model's context) would otherwise sit at the top of the worst-first ORDER BY
+# and be re-sent to the LLM every pass forever. Mirrors
+# enrichment_state.DEFAULT_MAX_ATTEMPTS. Transient failures (LM Studio
+# OOM-reload 500s) still get retried up to this bound.
+MAX_ENTITY_ATTEMPTS = 3
+
+
+class ContextOverflowError(RuntimeError):
+    """The server rejected the request with 'Context size has been exceeded'.
+
+    NOTE ON CAUSE: this is NOT necessarily oversized content. Observed on rows
+    as small as ~124 input tokens with a 16384 nominal CTX — far under the
+    window. The real cause is server-side: when LM Studio is loaded with N
+    parallel sequences the KV cache is split into N slots of ~n_ctx/N tokens
+    each, so a request can overflow its *slot* (e.g. 2048) while the nominal
+    context (16384) is untouched. Retrying with the same or halved input cannot
+    succeed while the model is loaded that way, so the caller marks the row
+    terminally 'ctx_error' (a cause-neutral status — the content is usually
+    fine; re-enable these rows once the server's per-slot context is fixed)
+    instead of burning the retry budget. Detected via the 500 body containing
+    'Context size has been exceeded' from LM Studio's /v1/messages."""
+
 # Names the model habitually emits with a misclassified type. Filtered
 # regardless of etype; one entry is the spec, expand only on recurrence.
 ANTI_EXTRACTION_NAMES: frozenset[str] = frozenset({
@@ -218,6 +242,14 @@ def _build_extractor(
         except (httpx.HTTPError, TimeoutError) as e:
             raise RuntimeError(f"http error: {type(e).__name__}: {e}")
         if r.status_code != 200:
+            # A context-overflow 500 is terminal for this row, not transient:
+            # the prompt+max_tokens exceed the loaded model's n_ctx, and halving
+            # the input on retry doesn't help when the prompt is already small
+            # (the overflow is prompt+generation vs a small loaded window).
+            # Surface it as a distinct type so gated() can skip the retry and
+            # mark the row 'ctx_error' instead of looping.
+            if "context size has been exceeded" in r.text.lower():
+                raise ContextOverflowError(f"http {r.status_code}: {r.text[:300]}")
             raise RuntimeError(f"http {r.status_code}: {r.text[:300]}")
 
         data = r.json()
@@ -437,15 +469,31 @@ def _query_eligible_rows(
             # every run (worst-first under ORDER BY LENGTH DESC), re-sending it to
             # the LLM forever. The `status='done'` marker (written by
             # _mark_extracted on empty OR success) is what makes an empty
-            # extraction terminal. Failed rows (status='failed' or NULL) stay
-            # eligible for retry. Tolerant of a DB lacking the status column.
+            # extraction terminal.
+            #
+            # Terminal statuses excluded from re-selection:
+            #   - 'done'      : processed (empty OR success).
+            #   - 'ctx_error' : a 'Context size has been exceeded' 500 (usually a
+            #                   too-small per-sequence KV slot, NOT oversized
+            #                   content); retrying can't succeed while the model
+            #                   is loaded that way. Re-enable in bulk once the
+            #                   server's per-slot context is fixed.
+            #   - 'failed' with attempts >= MAX_ENTITY_ATTEMPTS : exhausted the
+            #                   retry budget. WITHOUT this cap a deterministically
+            #                   failing row sits atop the worst-first ORDER BY and
+            #                   is re-sent to the LLM every pass forever — the
+            #                   "same item over and over" loop.
+            # Failed rows still under the cap (attempts < N) stay eligible so
+            # genuinely transient failures (LM Studio OOM-reload 500s) retry.
+            # Tolerant of a DB lacking the status column.
             extracted_clause = (
                 " AND id NOT IN (SELECT DISTINCT memory_id FROM memory_item_entities)"
             )
             if _has_status:
                 extracted_clause += (
                     " AND id NOT IN (SELECT memory_id FROM entity_extraction_queue"
-                    "                WHERE status = 'done')"
+                    "                WHERE status IN ('done', 'ctx_error')"
+                    f"                   OR (status = 'failed' AND attempts >= {int(MAX_ENTITY_ATTEMPTS)}))"
                 )
 
         sql = f"""
@@ -546,6 +594,38 @@ async def _run_db(
         except Exception:
             pass  # never let queue bookkeeping break the run
 
+    def _enqueue_ctx_error(memory_id: str, err: Exception) -> None:
+        """Mark a row terminally 'ctx_error': the server returned 'Context size
+        has been exceeded'. Usually a too-small per-sequence KV slot rather than
+        oversized content (seen on ~124-token rows under a 16384 CTX), so no
+        retry can succeed while the model is loaded that way. Excluded from
+        re-selection immediately (see _query_eligible_rows), so — unlike
+        'failed' — it does not consume the MAX_ENTITY_ATTEMPTS retry budget
+        before it stops looping. Once the server's per-slot context is fixed,
+        clear these rows' status (UPDATE ... SET status=NULL WHERE
+        status='ctx_error') to make them eligible again. Best-effort, same UPSERT
+        shape as _enqueue_failure."""
+        try:
+            from memory.backends import dialect
+            _d = dialect()
+            _p = _d.param()
+            with mc._db() as qc:
+                _ensure_extraction_status_column(qc)
+                qc.execute(
+                    f"""INSERT INTO entity_extraction_queue
+                           (memory_id, attempts, last_error, last_attempt_at, status)
+                       VALUES ({_p}, 1, {_p}, {_d.now()}, 'ctx_error')
+                       ON CONFLICT(memory_id) DO UPDATE SET
+                           attempts        = entity_extraction_queue.attempts + 1,
+                           last_error      = excluded.last_error,
+                           last_attempt_at = excluded.last_attempt_at,
+                           status          = 'ctx_error'""",
+                    (memory_id, f"{type(err).__name__}: {err}"[:500]),
+                )
+                qc.commit()
+        except Exception:
+            pass  # never let queue bookkeeping break the run
+
     # Batched 'done' bookkeeping. Previously _mark_extracted opened its OWN
     # mc._db() write transaction PER ROW, back-to-back with the entity write —
     # two separate write-lock acquisitions per row. Under concurrency, with a
@@ -639,6 +719,18 @@ async def _run_db(
                         body = text[: int(profile.input_max_chars * slice_ratio)] if profile.input_max_chars else text
                         out = await extractor(body)
                         break
+                    except ContextOverflowError as e:
+                        # Terminal, not transient: a 'Context size has been
+                        # exceeded' 500 — usually a too-small per-sequence KV
+                        # slot, not oversized content (seen on tiny rows under a
+                        # 16384 CTX). Halving the input can't help; mark
+                        # 'ctx_error' and stop — do NOT loop. Fix is server-side
+                        # (per-slot context), after which these rows can be
+                        # re-enabled in bulk.
+                        counters["ctx_error"] += 1
+                        _enqueue_ctx_error(memory_id, e)
+                        print(f"[m3-entities] CTX-ERROR {memory_id[:8]}: context exceeded (marked, no retry)", flush=True)
+                        return
                     except Exception as e:
                         last_err = e
                         if attempt == 1:
@@ -696,6 +788,7 @@ async def _run_db(
         f"{counters['entities_emitted']} entities, "
         f"{counters['relationships_emitted']} relationships, "
         f"{counters['empty']} empty, "
+        f"{counters['ctx_error']} ctx-error, "
         f"{counters['failed']} HTTP-fail, "
         f"{counters['write_failed']} write-fail",
         flush=True,
@@ -865,6 +958,7 @@ async def _main_async(args: argparse.Namespace) -> int:
     print(f"  entities emitted:      {counters_total.get('entities_emitted', 0)}")
     print(f"  relationships emitted: {counters_total.get('relationships_emitted', 0)}")
     print(f"  empty (no entities):   {counters_total.get('empty', 0)}")
+    print(f"  ctx-error (ctx exceed):{counters_total.get('ctx_error', 0)}")
     print(f"  HTTP failures:         {counters_total.get('failed', 0)}")
     print(f"  write failures:        {counters_total.get('write_failed', 0)}")
     print()

--- a/tests/test_chatlog_prune_cap.py
+++ b/tests/test_chatlog_prune_cap.py
@@ -86,3 +86,78 @@ def test_scan_scoped_to_aged_window_skips_fresh(tmp_path):
     # Only the 5 aged rows are pulled into Python, not the 100 fresh ones.
     assert summary["scanned"] == 5
     assert summary["writes_prune"] + summary["writes_decay"] == 5
+
+
+def _seed_decay_tier(db_path, *, n: int):
+    """Seed n noise turns in the DECAY tier (14 <= age < prune_days=45) so they
+    are suppressed (importance lowered + valid_to set), NOT soft-deleted."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE memory_items(id TEXT PRIMARY KEY, type TEXT, title TEXT, "
+        "content TEXT, importance REAL, created_at TEXT, is_deleted INT DEFAULT 0, "
+        "updated_at TEXT, valid_to TEXT)"
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    rows = []
+    for i in range(n):  # 20 days old => decay tier (>=fresh_days, <prune_days)
+        ts = (now - datetime.timedelta(days=20)).isoformat()
+        rows.append((f"decay{i}", "chat_log", "user@x", "status", 0.1, ts))
+    conn.executemany(
+        "INSERT INTO memory_items(id,type,title,content,importance,created_at) "
+        "VALUES(?,?,?,?,?,?)", rows)
+    conn.commit()
+    conn.close()
+
+
+def test_decay_converges_second_run_is_noop(tmp_path):
+    # THE LOOP BUG: decay lowers importance to ~0.06 and sets valid_to, but a
+    # decayed row still has importance<=generic_imp_max, so without a convergence
+    # guard it is re-decayed every run forever (the ~11s "same 5000 rows over and
+    # over" loop). Assert: run 1 decays all rows; run 2 finds nothing to do.
+    db = str(tmp_path / "converge.db")
+    _seed_decay_tier(db, n=8)
+
+    first = cp.run(db, _opts(max_actions=0))
+    assert first["writes_decay"] == 8, "run 1 should decay all 8 decay-tier rows"
+    assert first["writes_prune"] == 0, "decay-tier rows must not be soft-deleted"
+
+    # Confirm they were actually suppressed (valid_to set, importance lowered).
+    conn = sqlite3.connect(db)
+    decayed = conn.execute(
+        "SELECT COUNT(*) FROM memory_items WHERE type='chat_log' "
+        "AND valid_to IS NOT NULL AND valid_to <> '' AND importance <= 0.3"
+    ).fetchone()[0]
+    conn.close()
+    assert decayed == 8
+
+    second = cp.run(db, _opts(max_actions=0))
+    assert second["writes_decay"] == 0, "run 2 re-decayed already-suppressed rows (loop bug)"
+    assert second["writes_prune"] == 0
+    assert second["kept_already_decayed"] == 8, "already-decayed rows should be counted + skipped"
+
+
+def test_decayed_row_still_prunes_when_aged(tmp_path):
+    # A row decayed in the DECAY tier must STILL be soft-deleted once it ages past
+    # prune_days — the convergence guard skips only re-DECAY, never the eventual
+    # prune. Simulate: a row already has valid_to set (decayed earlier) but is now
+    # 90 days old (past prune_days) and unprotected.
+    db = str(tmp_path / "agedprune.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE memory_items(id TEXT PRIMARY KEY, type TEXT, title TEXT, "
+        "content TEXT, importance REAL, created_at TEXT, is_deleted INT DEFAULT 0, "
+        "updated_at TEXT, valid_to TEXT)"
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    old_ts = (now - datetime.timedelta(days=90)).isoformat()
+    decayed_ts = (now - datetime.timedelta(days=30)).isoformat()
+    conn.execute(
+        "INSERT INTO memory_items(id,type,title,content,importance,created_at,valid_to) "
+        "VALUES(?,?,?,?,?,?,?)",
+        ("aged", "chat_log", "user@x", "status", 0.06, old_ts, decayed_ts))
+    conn.commit()
+    conn.close()
+
+    summary = cp.run(db, _opts(max_actions=0))
+    assert summary["writes_prune"] == 1, "an aged, already-decayed, unprotected row must still prune"
+    assert summary["writes_decay"] == 0

--- a/tests/test_entity_selection_empty.py
+++ b/tests/test_entity_selection_empty.py
@@ -65,12 +65,13 @@ def test_processed_empty_turn_not_reselected(tmp_path):
     assert after == set(), "nothing should remain eligible"
 
 
-def test_failed_turn_stays_eligible_for_retry(tmp_path):
+def test_failed_turn_under_cap_stays_eligible_for_retry(tmp_path):
     db = str(tmp_path / "ent.db")
     _seed(db)
     conn = sqlite3.connect(db)
     E._ensure_extraction_status_column(conn)
-    # A failed row (status='failed') must remain eligible — retryable.
+    # A failed row still under MAX_ENTITY_ATTEMPTS must remain eligible —
+    # transient failures (LM Studio OOM-reload 500s) should retry.
     conn.execute(
         "INSERT INTO entity_extraction_queue(memory_id,attempts,last_attempt_at,status)"
         " VALUES('empty-turn',1,'now','failed')"
@@ -78,7 +79,47 @@ def test_failed_turn_stays_eligible_for_retry(tmp_path):
     conn.commit()
     conn.close()
     eligible = {r[0] for r in E._query_eligible_rows(Path(db), ("note",), None, None, True)}
-    assert "empty-turn" in eligible, "failed turn should stay eligible for retry"
+    assert "empty-turn" in eligible, "failed turn under the retry cap should stay eligible"
+
+
+def test_failed_turn_past_cap_not_reselected(tmp_path):
+    # A row that has failed MAX_ENTITY_ATTEMPTS times is terminal — it must NOT
+    # be re-selected, or it loops forever (the "same item over and over" bug: a
+    # deterministically-failing row at the top of the worst-first ORDER BY gets
+    # re-sent to the LLM every pass).
+    db = str(tmp_path / "ent.db")
+    _seed(db)
+    conn = sqlite3.connect(db)
+    E._ensure_extraction_status_column(conn)
+    conn.execute(
+        "INSERT INTO entity_extraction_queue(memory_id,attempts,last_attempt_at,status)"
+        " VALUES('empty-turn',?,'now','failed')",
+        (E.MAX_ENTITY_ATTEMPTS,),
+    )
+    conn.commit()
+    conn.close()
+    eligible = {r[0] for r in E._query_eligible_rows(Path(db), ("note",), None, None, True)}
+    assert "empty-turn" not in eligible, "failed turn past the retry cap was re-selected (loop bug)"
+
+
+def test_ctx_error_turn_not_reselected(tmp_path):
+    # A row marked 'ctx_error' (server returned 'Context size has been
+    # exceeded' — usually a too-small per-sequence KV slot, not oversized
+    # content) is terminal on the FIRST hit — excluded regardless of attempt
+    # count, so it never burns the retry budget re-sending a payload the server
+    # will keep rejecting while loaded that way.
+    db = str(tmp_path / "ent.db")
+    _seed(db)
+    conn = sqlite3.connect(db)
+    E._ensure_extraction_status_column(conn)
+    conn.execute(
+        "INSERT INTO entity_extraction_queue(memory_id,attempts,last_attempt_at,status)"
+        " VALUES('empty-turn',1,'now','ctx_error')"
+    )
+    conn.commit()
+    conn.close()
+    eligible = {r[0] for r in E._query_eligible_rows(Path(db), ("note",), None, None, True)}
+    assert "empty-turn" not in eligible, "ctx_error turn was re-selected (loop bug)"
 
 
 def test_ensure_status_column_idempotent(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the cognitive loop re-sending the same work to the local LLM every ~11s ("same item over and over"). Root cause was **three stacked, independent bugs**:

### 1. Chatlog noise-prune never converged (the real loop)
`chatlog_prune.run` re-selected rows it had already decayed. DECAY lowers importance to ~0.06 and sets `valid_to`, but `classify()` still tags `importance <= generic_imp_max (0.3)` as `generic_low` noise, so the same ~5000 aged rows were re-decayed every pass forever (`suppress=5000 soft-delete=0 capped=True`). The gate `has_chatlog_prune_work` compounded it — keyed only on `importance <= 0.3`, it stayed `True` after the backlog drained, re-firing the pass to do nothing.

**Fix:** per-row convergence guard skips already-decayed rows in the DECAY tier, but still lets them reach the PRUNE/soft-delete tier once aged past `prune_days` (suppression is a way-station to deletion, not a dead end). Gate also excludes already-decayed rows.

### 2. Entity-extraction queue retried failures forever
`_query_eligible_rows` excluded `status='done'` but not `'failed'`, with no attempt cap, so any deterministically-failing row (worst-first `ORDER BY LENGTH(content) DESC`) was re-sent every pass.

**Fix:** `MAX_ENTITY_ATTEMPTS` cap on failed rows, plus a terminal `ctx_error` status for "Context size has been exceeded" 500s (cause-neutral — usually a too-small per-sequence KV slot, not oversized content; recoverable by clearing the status).

### 3. Daemonize parent could survive on Windows
Under `pythonw.exe` (no console), the status `print()`/`flush()` before `os._exit(0)` could raise and leave the bootstrap parent alive alongside the detached worker.

**Fix:** guard the I/O so nothing can prevent the parent's hard exit.

## Cross-backend
All SQL dialected for SQLite / Postgres / future MariaDB. Key gotcha handled: SQLite stores an unset `valid_to` as `NULL` OR `''` (loose TEXT typing); PG/MariaDB use `NULL` only — a bare `IS NULL` would undercount on SQLite.

## Tests
- Convergence: second prune run is a no-op; a decayed-then-aged row still prunes.
- Entity: attempt-cap + `ctx_error` exclusion.
- All green on SQLite (20 passed across the affected suites).

## Verified live
Post-fix log shows `suppress=0 soft-delete=1..4997 capped=False` — draining then steady state (backlog: 25,702 soft-deleted / 35,596 decayed of 74,312 chat_log rows); zero context-overflow 500s.

## Out of band
The duplicate-loop trigger (AgentOS_CognitiveLoop firing on Boot AND Logon) was a scheduled-task config fix, applied separately (Boot trigger dropped + `MultipleInstances=IgnoreNew`).