### PR TITLE
fix(deps): bump postcss to >=8.5.12 in the example frontend

### DIFF
--- a/examples/homelab-dashboard/frontend/package-lock.json
+++ b/examples/homelab-dashboard/frontend/package-lock.json
@@ -2383,9 +2383,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2522,9 +2522,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -2542,7 +2542,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/examples/homelab-dashboard/frontend/package.json
+++ b/examples/homelab-dashboard/frontend/package.json
@@ -29,6 +29,7 @@
   },
   "overrides": {
     "vite": "^8.0.0-beta.13",
-    "brace-expansion": "^2.0.3"
+    "brace-expansion": "^2.0.3",
+    "postcss": ">=8.5.12"
   }
 }


### PR DESCRIPTION
Clears **Dependabot alert #15** — the repo's only open alert, and its only HIGH.

## The finding
`postcss` — *arbitrary file read / information disclosure via attacker-controlled `sourceMappingURL` in CSS comments*. Vulnerable `<= 8.5.11`, patched in `8.5.12`.

## Scope
`examples/homelab-dashboard/frontend` — an **example** subproject, not the m3 package. `postcss` is transitive (a `vite` build-tool dep), so the fix is an `overrides: { "postcss": ">=8.5.12" }` entry (durable across lockfile regen) rather than a direct-dep bump.

Regenerated lockfile: postcss `8.5.10 → 8.5.22`, and its own dep `nanoid 3.3.11 → 3.3.16` rides along (same-major patch). Nothing else churned. `node_modules` stays gitignored.

## Impact
Low for m3 in practice — a build-tool dep in a demo, not shipped in the wheel, not on any runtime path — but it's the HIGH banner surfaced on every push, so clearing it is worth the two-line change.

## Gate
`npm ci && npm run build` in that dir passes (tsc + vite build, ✓ 200ms); `npm audit` reports **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)