### PR TITLE
ci(security): clear DefectDojo CI-workflow findings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           # Idempotent: if a file for this version is already on PyPI (e.g. a
           # re-run, or a future duplicate trigger), skip it instead of failing
@@ -117,7 +117,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -205,10 +205,15 @@ jobs:
       - name: Create the Release
         env:
           GH_TOKEN: ${{ github.token }}
+          # Inject the version as an ENV var, not by interpolating ${{ }} into the
+          # script text — GitHub expands run-block expressions BEFORE the shell
+          # runs, so a crafted value could inject shell (zizmor template-injection).
+          # Read as "$VERSION" below so it is a shell variable, not code.
+          VERSION: ${{ steps.notes.outputs.version }}
         run: |
           set -euo pipefail
-          TAG="v${{ steps.notes.outputs.version }}"
-          TITLE=$(grep -m1 "^## \[${{ steps.notes.outputs.version }}\]" CHANGELOG.md \
+          TAG="v${VERSION}"
+          TITLE=$(grep -m1 "^## \[${VERSION}\]" CHANGELOG.md \
                   | sed -E 's/^## \[[^]]*\] — [0-9-]+ — //' || true)
           [ -n "$TITLE" ] && TITLE="$TAG — $TITLE" || TITLE="$TAG"
           # Idempotent: if the Release already exists (manual pre-creation, re-run),

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -44,6 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Don't persist GITHUB_TOKEN into .git/config — it can leak via uploaded
+          # artifacts (zizmor artipacked). This job only reads the repo, so it
+          # needs no persisted credential. Matches every checkout in publish.yml.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
Three pre-existing CI-workflow security findings from a DefectDojo scan, all in `.github/workflows/`. Fixed on a dedicated branch (kept separate from any feature work).

Each fix was **re-scanned and verified** — zizmor and grype both report **0 findings** on the fixed tree.

## 1. zizmor `template-injection` ×2 — `publish.yml` (github-release job)
The release step interpolated `${{ steps.notes.outputs.version }}` directly into a shell `run:` block. GitHub expands run-block expressions **before** the shell runs, so a crafted tag/version could inject shell.
**Fix:** pass the value through `env: VERSION:` and read `"$VERSION"` as a shell variable. Identical behavior for well-formed versions.

## 2. grype GHSA-vxmw-7h4f-hqxh (LOW) — `publish.yml`
`pypa/gh-action-pypi-publish` was pinned to an old SHA (`release/v1` @ `cef2210`).
**Fix:** bumped both pins (publish-pypi + testpypi) to `v1.14.1` @ `ba38be9` — annotated tag dereferenced to its commit, SHA-pinned with a version comment per the repo's action-pinning convention.

## 3. zizmor `artipacked` — `star-history.yml`
The `actions/checkout` step didn't set `persist-credentials: false`, so `GITHUB_TOKEN` persists into `.git/config` and can leak via uploaded artifacts.
**Fix:** added `persist-credentials: false` (the job only reads the repo). Every checkout in `publish.yml` already does this; this file just missed it.

## Notes
Both workflows validated as well-formed YAML. No behavior change to the publish pipeline beyond the action version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)