### PR TITLE
chore(ci): add watch_pr_checks.py — fix the silent-success monitor trap

### DIFF
--- a/bin/watch_pr_checks.py
+++ b/bin/watch_pr_checks.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Watch CI checks on one or more PRs until every check is terminal, then print a
+PASS/FAIL summary and exit 0 (all green) / 1 (any failed) / 2 (timeout) / 3 (bad
+setup).
+
+WHY THIS EXISTS — the silent-success trap (incident 2026-07-24)
+---------------------------------------------------------------
+An ad-hoc monitor loop reported "ALL-GREEN" TWICE while the test job was still
+IN_PROGRESS. Two compounding causes, both about a tool being *silently absent*:
+
+  1. `gh pr checks` returned EMPTY in the monitor's shell (auth/PATH differed),
+     and the loop treated "no failure signal" as "done + passed".
+  2. A first rewrite used `jq` — which is NOT installed on the Windows dev box at
+     all — so it would exit before ever running. `gh` + Python (always present)
+     is the portable combination here.
+
+The invariant this script enforces, and the reason it is Python not shell:
+
+    DECLARE A TERMINAL/GREEN STATE ONLY ON A POSITIVE SIGNAL.
+
+An empty, failed, or unparseable query is UNKNOWN — never done, never green. The
+loop keeps waiting and SAYS "unknown", so a query problem can never masquerade as
+success. "Green" requires a real 'pass' bucket for every check from gh; "failed"
+requires a real 'fail' bucket. Uses only the stdlib (subprocess/json) so it runs
+wherever Python + gh do.
+
+Usage:
+    python bin/watch_pr_checks.py <pr> [<pr> ...] [--repo owner/name]
+                                  [--interval SECS] [--timeout SECS] [--once]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+
+
+def _query_pr(pr: str, repo: str | None) -> "list | None":
+    """Return gh's check list for a PR, or None on ANY problem (missing gh, auth
+    failure, empty output, non-JSON, wrong shape). None means UNKNOWN — the
+    caller must never read it as green. This is the guard the incident needed."""
+    cmd = ["gh", "pr", "checks", pr, "--json", "name,state,bucket"]
+    if repo:
+        cmd += ["--repo", repo]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return None  # gh not found / hung → UNKNOWN, not green
+    if out.returncode != 0 or not out.stdout.strip():
+        return None  # gh errored or produced nothing → UNKNOWN
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list) or not data:
+        return None  # empty array (no checks yet) is UNKNOWN, not "green"
+    return data
+
+
+def _summarize(checks: "list | None") -> str:
+    """One-token state for a PR: 'UNKNOWN' | 'green' | 'failed' | 'running'."""
+    if checks is None:
+        return "UNKNOWN"
+    buckets = [c.get("bucket") for c in checks]
+    if any(b == "fail" for b in buckets):
+        return "failed"
+    if any(b == "pending" for b in buckets):
+        return "running"
+    if all(b == "pass" for b in buckets):
+        return "green"
+    # Any bucket we don't recognize → treat as not-yet-terminal, never green.
+    return "running"
+
+
+def _counts(checks: "list | None") -> str:
+    if checks is None:
+        return "unknown"
+    n = {"pass": 0, "fail": 0, "pending": 0}
+    for c in checks:
+        b = c.get("bucket")
+        if b in n:
+            n[b] += 1
+    return f"pass={n['pass']} fail={n['fail']} pending={n['pending']}"
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("prs", nargs="+", help="PR numbers to watch")
+    ap.add_argument("--repo", default=None, help="owner/name (else current repo)")
+    ap.add_argument("--interval", type=float, default=45.0)
+    ap.add_argument("--timeout", type=float, default=1800.0)
+    ap.add_argument("--once", action="store_true",
+                    help="Poll once and exit (for tests / a quick check).")
+    args = ap.parse_args(argv)
+
+    start = time.monotonic()
+    while True:
+        stamp = time.strftime("%H:%M:%SZ", time.gmtime())
+        states = {}
+        for pr in args.prs:
+            checks = _query_pr(pr, args.repo)
+            states[pr] = (_summarize(checks), _counts(checks))
+        line = stamp + "  " + "  ".join(
+            f"PR#{pr}[{st} {cn}]" for pr, (st, cn) in states.items())
+        print(line, flush=True)
+
+        vals = [st for st, _ in states.values()]
+        # Terminal ONLY when every PR is a real terminal signal (green|failed).
+        # A single UNKNOWN or running keeps us waiting — the core guarantee.
+        if all(v in ("green", "failed") for v in vals):
+            if any(v == "failed" for v in vals):
+                print("RESULT: FAILED", flush=True)
+                return 1
+            print("RESULT: ALL-GREEN", flush=True)
+            return 0
+        if args.once:
+            print("RESULT: NOT-TERMINAL (--once)", flush=True)
+            return 2
+        if time.monotonic() - start >= args.timeout:
+            print(f"RESULT: TIMEOUT after {args.timeout:.0f}s "
+                  "(never reached a terminal state)", flush=True)
+            return 2
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/tools/INDEX.md
+++ b/docs/tools/INDEX.md
@@ -1,6 +1,6 @@
 # Tool inventory index
 
-_Generated 2026-08-12T00:59:01.840717+00:00._
+_Generated 2026-09-08T23:37:14.009535+00:00._
 
 Re-run `python bin/gen_tool_inventory.py` after changing any tool.
 Entries whose `sha1` no longer matches the live file need re-validation.
@@ -127,6 +127,7 @@ Entries whose `sha1` no longer matches the live file need re-validation.
 | [bin/test_unified_router.py](test_unified_router.md) | (no docstring) |  |
 | [bin/thermal_utils.py](thermal_utils.md) | (no docstring) |  |
 | [bin/unified_ai.py](unified_ai.md) | Unified chat client across Gemini, Claude, and LM Studio. |  |
+| [bin/watch_pr_checks.py](watch_pr_checks.md) | Watch CI checks on one or more PRs until every check is terminal, then print a |  |
 | [bin/web_research_bridge.py](web_research_bridge.md) | (no docstring) |  |
 | [bin/weekly_auditor.py](weekly_auditor.md) | Weekly Audit Report -- M3 Memory |  |
 | [install_os.py](install_os.md) | (no docstring) |  |

--- a/docs/tools/watch_pr_checks.md
+++ b/docs/tools/watch_pr_checks.md
@@ -1,0 +1,98 @@
+---
+tool: bin/watch_pr_checks.py
+sha1: e2908414e166
+mtime_utc: 2026-09-08T23:37:05.252666+00:00
+generated_utc: 2026-09-08T23:37:13.978705+00:00
+private: false
+---
+
+# bin/watch_pr_checks.py
+
+## Purpose
+
+Watch CI checks on one or more PRs until every check is terminal, then print a
+PASS/FAIL summary and exit 0 (all green) / 1 (any failed) / 2 (timeout) / 3 (bad
+setup).
+
+WHY THIS EXISTS — the silent-success trap (incident 2026-07-24)
+---------------------------------------------------------------
+An ad-hoc monitor loop reported "ALL-GREEN" TWICE while the test job was still
+IN_PROGRESS. Two compounding causes, both about a tool being *silently absent*:
+
+  1. `gh pr checks` returned EMPTY in the monitor's shell (auth/PATH differed),
+     and the loop treated "no failure signal" as "done + passed".
+  2. A first rewrite used `jq` — which is NOT installed on the Windows dev box at
+     all — so it would exit before ever running. `gh` + Python (always present)
+     is the portable combination here.
+
+The invariant this script enforces, and the reason it is Python not shell:
+
+    DECLARE A TERMINAL/GREEN STATE ONLY ON A POSITIVE SIGNAL.
+
+An empty, failed, or unparseable query is UNKNOWN — never done, never green. The
+loop keeps waiting and SAYS "unknown", so a query problem can never masquerade as
+success. "Green" requires a real 'pass' bucket for every check from gh; "failed"
+requires a real 'fail' bucket. Uses only the stdlib (subprocess/json) so it runs
+wherever Python + gh do.
+
+Usage:
+    python bin/watch_pr_checks.py <pr> [<pr> ...] [--repo owner/name]
+                                  [--interval SECS] [--timeout SECS] [--once]
+
+---
+
+## Entry points
+
+- `def main()` (line 87)
+- `if __name__ == "__main__"` guard
+
+---
+
+## CLI flags / arguments
+
+| Flag(s) | Help | Default | Default behavior | Type/Action | Impact when set |
+|---|---|---|---|---|---|
+| `prs` | PR numbers to watch | — |  | str |  |
+| `--repo` | owner/name (else current repo) | None |  | str |  |
+| `--interval` |  | `45.0` |  | float |  |
+| `--timeout` |  | `1800.0` |  | float |  |
+| `--once` | Poll once and exit (for tests / a quick check). | `False` |  | store_true |  |
+
+---
+
+## Environment variables read
+
+_(none detected)_
+
+---
+
+## Calls INTO this repo (intra-repo imports)
+
+_(none detected)_
+
+---
+
+## Calls OUT (external side-channels)
+
+**subprocess**
+
+- `subprocess.run()  → `cmd`` (line 47)
+
+
+---
+
+## Notable external imports
+
+_(only stdlib)_
+
+---
+
+## File dependencies (repo paths referenced)
+
+_(none detected)_
+
+---
+
+## Re-validation
+
+If the `sha1` above differs from the current file's sha1, the inventory is stale — re-read the tool, confirm flags/env vars/entry-points/calls still match, and regenerate via `python bin/gen_tool_inventory.py`.

--- a/tests/test_watch_pr_checks.py
+++ b/tests/test_watch_pr_checks.py
@@ -1,0 +1,121 @@
+"""Regression tests for bin/watch_pr_checks.py — the silent-success guard.
+
+Incident 2026-07-24: a monitor reported ALL-GREEN twice while CI was still
+running, because an empty `gh` query was read as success. These tests lock in
+the invariant that fixed it: an empty / failed / unparseable query is UNKNOWN,
+NEVER green, and the watch loop only terminates on a positive terminal signal.
+"""
+import os
+import subprocess
+import sys
+
+_HERE = os.path.dirname(__file__)
+_BIN = os.path.normpath(os.path.join(_HERE, "..", "bin"))
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+import watch_pr_checks as W  # noqa: E402
+
+# ── _summarize: the core classifier ─────────────────────────────────────────
+
+def test_none_is_unknown_never_green():
+    """THE incident: an empty/failed query must NOT read as green."""
+    assert W._summarize(None) == "UNKNOWN"
+
+
+def test_all_pass_is_green():
+    checks = [{"bucket": "pass"}, {"bucket": "pass"}]
+    assert W._summarize(checks) == "green"
+
+
+def test_any_fail_is_failed():
+    checks = [{"bucket": "pass"}, {"bucket": "fail"}, {"bucket": "pass"}]
+    assert W._summarize(checks) == "failed"
+
+
+def test_any_pending_is_running():
+    checks = [{"bucket": "pass"}, {"bucket": "pending"}]
+    assert W._summarize(checks) == "running"
+
+
+def test_unrecognized_bucket_is_not_green():
+    """An unknown bucket must fail safe to running, never green."""
+    assert W._summarize([{"bucket": "pass"}, {"bucket": "weird"}]) == "running"
+
+
+# ── _query_pr: every failure mode collapses to None (UNKNOWN) ────────────────
+
+def _fake_run(returncode=0, stdout=""):
+    def _run(*a, **k):
+        return subprocess.CompletedProcess(a[0] if a else [], returncode,
+                                           stdout=stdout, stderr="")
+    return _run
+
+
+def test_query_empty_stdout_is_none(monkeypatch):
+    monkeypatch.setattr(W.subprocess, "run", _fake_run(0, ""))
+    assert W._query_pr("1", None) is None
+
+
+def test_query_nonzero_rc_is_none(monkeypatch):
+    """gh auth failure / not-a-repo → None, not a false green."""
+    monkeypatch.setattr(W.subprocess, "run", _fake_run(1, "some error"))
+    assert W._query_pr("1", None) is None
+
+
+def test_query_non_json_is_none(monkeypatch):
+    monkeypatch.setattr(W.subprocess, "run", _fake_run(0, "not json at all"))
+    assert W._query_pr("1", None) is None
+
+
+def test_query_empty_array_is_none(monkeypatch):
+    """No checks reported yet is UNKNOWN, not green."""
+    monkeypatch.setattr(W.subprocess, "run", _fake_run(0, "[]"))
+    assert W._query_pr("1", None) is None
+
+
+def test_query_gh_missing_is_none(monkeypatch):
+    def _raise(*a, **k):
+        raise OSError("gh not found")
+    monkeypatch.setattr(W.subprocess, "run", _raise)
+    assert W._query_pr("1", None) is None
+
+
+def test_query_valid_returns_list(monkeypatch):
+    monkeypatch.setattr(W.subprocess, "run",
+                        _fake_run(0, '[{"name":"t","state":"SUCCESS","bucket":"pass"}]'))
+    result = W._query_pr("1", None)
+    assert isinstance(result, list) and result[0]["bucket"] == "pass"
+
+
+# ── main loop: --once never declares terminal on UNKNOWN ─────────────────────
+
+def test_main_once_unknown_is_not_terminal(monkeypatch, capsys):
+    """The end-to-end guarantee: a PR whose query is UNKNOWN does NOT exit green.
+    A single --once poll returns 2 (not-terminal), exactly as the incident
+    required — silence/absence is never success."""
+    monkeypatch.setattr(W, "_query_pr", lambda pr, repo: None)
+    rc = W.main(["99", "--once"])
+    assert rc == 2
+    assert "ALL-GREEN" not in capsys.readouterr().out
+
+
+def test_main_once_all_green_exits_zero(monkeypatch):
+    monkeypatch.setattr(W, "_query_pr", lambda pr, repo: [{"bucket": "pass"}])
+    assert W.main(["99", "--once"]) == 0
+
+
+def test_main_once_any_fail_exits_one(monkeypatch):
+    def q(pr, repo):
+        return [{"bucket": "fail"}] if pr == "100" else [{"bucket": "pass"}]
+    monkeypatch.setattr(W, "_query_pr", q)
+    assert W.main(["99", "100", "--once"]) == 1
+
+
+def test_main_mixed_unknown_and_green_is_not_terminal(monkeypatch):
+    """If ANY watched PR is UNKNOWN, the whole run is not terminal — you can't
+    declare victory while blind to one PR."""
+    def q(pr, repo):
+        return [{"bucket": "pass"}] if pr == "99" else None
+    monkeypatch.setattr(W, "_query_pr", q)
+    assert W.main(["99", "100", "--once"]) == 2


### PR DESCRIPTION
A small, tested tool for watching CI checks on PRs — written to fix a real failure mode.

## The incident it fixes (2026-07-24)
An ad-hoc monitor loop reported **ALL-GREEN twice while the test job was still `IN_PROGRESS`**, nearly greenlighting a merge on an unfinished suite. Two compounding causes, both a tool silently absent in a shell context:

1. `gh pr checks` returned **empty** in the monitor's shell (auth/PATH differed), and the loop treated *no failure signal* as *done + passed* — the classic silent-success trap.
2. A first shell rewrite used `jq`, which isn't installed on the Windows dev box at all — it would exit before running.

## The fix
`bin/watch_pr_checks.py` — stdlib only (runs wherever Python + `gh` do), enforcing **one invariant**:

> Declare a terminal/green state ONLY on a positive signal.

Every query failure mode (missing `gh`, auth error, empty output, non-JSON, empty array, unrecognized bucket) collapses to **UNKNOWN**, which is never terminal and never green — the loop keeps waiting and *says so*. "Green" requires a real `pass` bucket for every check; "failed" requires a real `fail` bucket. If **any** watched PR is UNKNOWN, the whole run is non-terminal — you can't declare victory while blind to one PR.

## Usage
```
python bin/watch_pr_checks.py <pr> [<pr>...] --repo owner/name [--once]
```

## Tests
15 tests (`tests/test_watch_pr_checks.py`) lock in the incident: `_summarize(None) → UNKNOWN`, every `_query_pr` failure mode → `None`, and the end-to-end guarantee that a `--once` poll over an UNKNOWN PR returns non-terminal with no ALL-GREEN. **The false-green bug can't recur without a test going red.**

_(Fittingly, this tool is available to watch its own PR's checks.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)