### PR TITLE
Route file fact-extraction through m3's shared LLM + secret seams

### DIFF
--- a/bin/doctor/files_extraction_probe.py
+++ b/bin/doctor/files_extraction_probe.py
@@ -1,0 +1,106 @@
+"""Doctor probe: can file fact-extraction reach an LLM?
+
+Inline/queue file-extraction (`m3 files files_ingest --extract_mode inline|queue`,
+`files_extract_pending`) needs a chat/instruct LLM. The endpoint is resolved by
+`files_memory.extract._llm_endpoint()`, which — after the seam fix — falls back to
+the SHARED `llm_failover` resolution (auto-probes LM Studio :1234) instead of only
+its own optional `M3_FILES_*` env vars.
+
+This probe surfaces the failure that was previously silent: file-extraction
+reporting "no LLM" (leaves marked extraction_status='failed') even though the rest
+of m3 (cognitive loop, enrichment) reaches an LLM fine. It reads only config/env
++ one HTTP GET (never the live DB), and never crashes the doctor.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+from urllib.parse import urlparse
+
+
+def _payload_bin() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _ensure_path() -> None:
+    b = _payload_bin()
+    if b not in sys.path:
+        sys.path.insert(0, b)
+
+
+def _file_extract_endpoint() -> "str | None":
+    try:
+        _ensure_path()
+        from files_memory.extract import _llm_endpoint
+        return _llm_endpoint()
+    except Exception:  # noqa: BLE001 — diagnostic best-effort
+        return None
+
+
+def _main_path_endpoints() -> list[str]:
+    try:
+        _ensure_path()
+        from llm_failover import LLM_ENDPOINTS
+        return list(LLM_ENDPOINTS or [])
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _reach(endpoint: str, timeout: float = 3.0) -> "tuple[str, list[str]]":
+    """Return (state, models). state in {'ok','auth','down','bad-scheme'}."""
+    if urlparse(endpoint).scheme not in ("http", "https"):
+        return "bad-scheme", []
+    try:
+        _ensure_path()
+        from files_memory.config import llm_auth_headers
+        headers = llm_auth_headers()
+    except Exception:  # noqa: BLE001
+        headers = {}
+    req = urllib.request.Request(f"{endpoint.rstrip('/')}/models", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # nosec B310 — scheme checked
+            import json
+            body = json.loads(r.read().decode("utf-8", "replace"))
+        models = [m.get("id", "") for m in body.get("data", []) if isinstance(m, dict)]
+        return "ok", [m for m in models if m]
+    except urllib.error.HTTPError as e:  # type: ignore[attr-defined]
+        return ("auth" if e.code in (401, 403) else "down"), []
+    except Exception:  # noqa: BLE001
+        return "down", []
+
+
+def run(brief: bool = False, fix: bool = False) -> int:
+    endpoint = _file_extract_endpoint()
+    main_eps = _main_path_endpoints()
+
+    # Regression guard: file-extraction blind while the main path has an LLM.
+    if not endpoint:
+        if main_eps:
+            print("❌ file-extraction LLM: NONE resolved, but the main path has "
+                  f"{main_eps[0]} — inline/queue extraction will no-op (leaves "
+                  "marked 'failed').")
+            print("   fix: file-extraction should fall back to llm_failover "
+                  "(bin/files_memory/extract.py::_llm_endpoint).")
+            return 1
+        print("file-extraction LLM: none configured (no LLM anywhere) — fact "
+              "extraction is off; embeddings + keyword search still work.")
+        return 0
+
+    if brief:
+        return 0
+
+    state, models = _reach(endpoint)
+    if state == "ok":
+        shown = ", ".join(models[:3]) if models else "no models loaded"
+        glyph = "✅" if models else "⚠️ "
+        print(f"{glyph} file-extraction LLM: {endpoint} reachable ({shown})"
+              + ("" if models else " — load a chat/instruct model to enable extraction."))
+        return 0 if models else 1
+    if state == "auth":
+        print(f"⚠️  file-extraction LLM: {endpoint} needs auth and the token didn't "
+              "resolve — set LM_API_TOKEN in the OS keyring (headless-safe).")
+        return 1
+    print(f"⚠️  file-extraction LLM: {endpoint} not reachable — inline/queue "
+          "extraction will no-op until it serves.")
+    return 1

--- a/bin/files_memory/config.py
+++ b/bin/files_memory/config.py
@@ -261,10 +261,17 @@ def llm_auth_headers() -> dict[str, str]:
     """Authorization headers for the OpenAI-compat LLM endpoint.
 
     LM Studio with API auth enabled rejects (or silently empties) requests
-    that omit `Authorization: Bearer <token>`. The token lives in env var
-    LM_API_TOKEN (mirrored from the OS keyring at session start). Returns an
-    empty dict when no token is set, so tokenless endpoints (Ollama, an
-    auth-disabled LM Studio) keep working unchanged.
+    that omit `Authorization: Bearer <token>`. Resolve the token through the
+    SHARED, headless-safe resolver (env -> OS keyring -> keychain -> vault, with
+    the LM_STUDIO_API_KEY alias) rather than reading os.environ alone: launchd/
+    systemd/task launchers do NOT inherit the shell's LM_API_TOKEN (§3), so an
+    env-only read 401s in every background context (cognitive loop, MCP server).
+    Returns an empty dict when no token resolves, so tokenless endpoints (Ollama,
+    an auth-disabled LM Studio) keep working unchanged.
     """
-    token = (os.environ.get("LM_API_TOKEN") or "").strip()
+    try:
+        from auth_utils import get_api_key  # canonical resolver (see m3_sdk.get_secret)
+        token = (get_api_key("LM_API_TOKEN") or "").strip()
+    except Exception:  # noqa: BLE001 — resolver import failure -> fall back to env
+        token = (os.environ.get("LM_API_TOKEN") or "").strip()
     return {"Authorization": f"Bearer {token}"} if token else {}

--- a/bin/files_memory/extract.py
+++ b/bin/files_memory/extract.py
@@ -92,13 +92,33 @@ Rules:
 
 
 def _llm_endpoint() -> Optional[str]:
-    """Read LLM endpoint from env. None = no LLM available."""
-    return (
+    """Resolve the extraction LLM endpoint.
+
+    Explicit per-purpose overrides win (M3_FILES_EXTRACT_URL > M3_FILES_SUMMARY_URL
+    > M3_LMSTUDIO_URL). Otherwise fall back to m3's SHARED ``llm_failover``
+    resolution — which auto-probes LM Studio (:1234) by default and honors
+    M3_LLM_URL / LLM_ENDPOINTS_CSV — so file extraction uses the SAME LLM the rest
+    of m3 (cognitive loop, enrichment) already does, instead of reporting "no LLM"
+    whenever the optional overrides are unset. The fallback is headless-safe: the
+    LM Studio default is a code constant in llm_failover, not a shell env var, so
+    launchd/systemd/task launchers resolve it too (§3). None only when no endpoint
+    is configured or discoverable anywhere."""
+    override = (
         os.environ.get("M3_FILES_EXTRACT_URL")
         or os.environ.get("M3_FILES_SUMMARY_URL")
         or os.environ.get("M3_LMSTUDIO_URL")
-        or None
     )
+    if override:
+        return override
+    try:
+        import sys as _sys
+        _bin = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if _bin not in _sys.path:
+            _sys.path.insert(0, _bin)
+        from llm_failover import LLM_ENDPOINTS
+        return LLM_ENDPOINTS[0] if LLM_ENDPOINTS else None
+    except Exception:  # noqa: BLE001 — resolver import/probe failure -> no LLM
+        return None
 
 
 def _llm_model() -> Optional[str]:

--- a/bin/llm_failover.py
+++ b/bin/llm_failover.py
@@ -146,6 +146,20 @@ def _auth_headers(token: str | None) -> dict:
     return {"Authorization": f"Bearer {tok}"} if tok else {}
 
 
+def _default_lm_token() -> "str | None":
+    """The default LM token when a caller passes none — resolved through the
+    SHARED, headless-safe resolver (env -> keyring -> keychain -> vault, with the
+    LM_STUDIO_API_KEY alias), NOT os.environ alone. Headless launchers (launchd/
+    systemd/task) don't inherit the shell's LM_API_TOKEN (§3), so an env-only
+    default 401s against an auth-enabled LM Studio in every background context —
+    the exact failure mode that motivated m3_sdk.get_secret."""
+    try:
+        from auth_utils import get_api_key  # lazy: auth_utils vault reads route via M3Context
+        return get_api_key("LM_API_TOKEN")
+    except Exception:  # noqa: BLE001 — resolver failure -> env fallback
+        return os.environ.get("LM_API_TOKEN")
+
+
 def discover_model_sync(
     endpoint: str,
     token: Optional[str] = None,
@@ -196,7 +210,7 @@ def discover_model_sync(
     try:
         import httpx
 
-        tok = token if token is not None else os.environ.get("LM_API_TOKEN")
+        tok = token if token is not None else _default_lm_token()
         headers = _auth_headers(tok)
         r = httpx.get(
             f"{endpoint.rstrip('/')}/models",

--- a/bin/m3_sdk.py
+++ b/bin/m3_sdk.py
@@ -134,6 +134,24 @@ from m3_halt import (  # noqa: E402,F401
     register_process,
 )
 
+
+def get_secret(service: str) -> "str | None":
+    """Canonical, headless-safe secret/API-token resolver — the ONE entry point
+    every m3 caller should use for LM_API_TOKEN and friends.
+
+    Resolves env -> OS keyring -> native keychain -> encrypted SQLite vault (with
+    the LM_API_TOKEN->LM_STUDIO_API_KEY alias), so it works in headless launchers
+    (launchd/systemd/task) that never inherit the shell env (§3). Do NOT read
+    os.environ for a token directly or shell out to `security find-generic-
+    password` — that reinvents this seam env-only and breaks headless (§1/§4).
+
+    Lazy re-export of auth_utils.get_api_key (lazy because auth_utils routes vault
+    reads back through M3Context — a top-level import would cycle); this mirrors
+    M3Context.get_secret, which is the context-bound wrapper around the same fn."""
+    from auth_utils import get_api_key
+    return get_api_key(service)
+
+
 # name -> submodules whose namespace must observe a rebind of that name. The
 # first entry is the canonical read source used by the facade's own __getattr__.
 _ROUTED = {

--- a/bin/macbook_status_server.py
+++ b/bin/macbook_status_server.py
@@ -41,17 +41,15 @@ def get_iface_ip(iface: str):
 
 
 def get_lm_token() -> str:
-    """Resolve LM Studio API token from env or keychain."""
-    token = os.environ.get("LM_API_TOKEN") or os.environ.get("LM_STUDIO_API_KEY")
-    if not token:
-        try:
-            token = subprocess.run(
-                ["security", "find-generic-password", "-s", "LM_STUDIO_API_KEY", "-w"],
-                capture_output=True, text=True, timeout=3
-            ).stdout.strip()
-        except Exception:
-            pass
-    return token or ""
+    """Resolve LM Studio API token via the shared, headless-safe resolver
+    (m3_sdk.get_secret: env -> keyring -> keychain -> vault, LM_STUDIO_API_KEY
+    alias). Replaces a hand-rolled env + `security find-generic-password` path
+    that was macOS-only and env-first (§1/§4 — don't reinvent the secret seam)."""
+    try:
+        from m3_sdk import get_secret
+        return get_secret("LM_API_TOKEN") or ""
+    except Exception:  # noqa: BLE001 — resolver import failure -> env fallback
+        return os.environ.get("LM_API_TOKEN") or os.environ.get("LM_STUDIO_API_KEY") or ""
 
 
 def check_lm_studio():

--- a/bin/memory_doctor.py
+++ b/bin/memory_doctor.py
@@ -233,6 +233,14 @@ def main() -> int:
         from doctor import cascade_probe
         exit_code = max(exit_code, cascade_probe.run(brief=brief))
 
+        # File fact-extraction reaches an LLM? (Surfaces the previously-silent
+        # "file-extraction says no LLM while the main path has one" gap.)
+        try:
+            from doctor import files_extraction_probe
+            exit_code = max(exit_code, files_extraction_probe.run(brief=brief))
+        except Exception:  # noqa: BLE001 — a probe must never crash the doctor
+            pass
+
     if not args.skip_embed_server:
         from doctor import embed_server_probe
         # Rust-side probe doesn't bump exit code on its own — operators

--- a/bin/mission_control.py
+++ b/bin/mission_control.py
@@ -73,25 +73,14 @@ if IS_WIN:
 
 # ── Auth ──────────────────────────────────────────────────────────────────────
 def get_api_token() -> str | None:
-    token = os.getenv("LM_API_TOKEN") or os.getenv("LM_STUDIO_API_KEY")
-    if token:
-        return token
-    if IS_MAC:
-        try:
-            return subprocess.check_output(
-                ["security", "find-generic-password", "-s", "LM_STUDIO_API_KEY", "-w"],
-                stderr=subprocess.DEVNULL,
-            ).decode().strip()
-        except Exception:
-            pass
+    # Shared, headless-safe resolver (env -> keyring -> keychain -> vault, with
+    # the LM_STUDIO_API_KEY alias) — replaces a hand-rolled env + `security` +
+    # keyring path (§1/§4 — don't reinvent the secret seam; see m3_sdk.get_secret).
     try:
-        import keyring
-        val = keyring.get_password("LM_STUDIO_API_KEY", "LM_STUDIO_API_KEY")
-        if val:
-            return val
-    except Exception:
-        pass
-    return None
+        from m3_sdk import get_secret
+        return get_secret("LM_API_TOKEN")
+    except Exception:  # noqa: BLE001 — resolver import failure -> env fallback
+        return os.getenv("LM_API_TOKEN") or os.getenv("LM_STUDIO_API_KEY")
 
 
 API_TOKEN = None

--- a/bin/promote_pipeline.py
+++ b/bin/promote_pipeline.py
@@ -19,7 +19,7 @@ import urllib.parse
 import urllib.request
 from collections import defaultdict
 
-from m3_sdk import getenv_compat
+from m3_sdk import get_secret, getenv_compat
 
 cp = importlib.util.module_from_spec(
     s := importlib.util.spec_from_file_location("cp", os.path.join(os.path.dirname(__file__), "chatlog_prune.py")))
@@ -44,7 +44,9 @@ DISQUALIFY = re.compile(r"\b(ETA|r/s|tok/s|windows? done|poll(ing)?|workers? ali
 
 LM_URL = getenv_compat("M3_LM_URL", "LM_URL", "http://localhost:1234/v1/chat/completions")
 LM_MODEL = getenv_compat("M3_LM_MODEL", "LM_MODEL", "google/gemma-4-26b-a4b")
-LM_TOKEN = os.environ.get("LM_API_TOKEN", "")
+# Headless-safe token via the shared resolver (env -> keyring -> vault), not
+# os.environ alone — a launchd/systemd promotion run lacks the shell env (§3).
+LM_TOKEN = get_secret("LM_API_TOKEN") or ""
 
 
 def select(db: str, min_age=14.0, lo=120, hi=4000):

--- a/tests/test_secret_resolver_seam.py
+++ b/tests/test_secret_resolver_seam.py
@@ -1,0 +1,103 @@
+"""Secret-resolver seam: one canonical, headless-safe token resolver.
+
+The LM token (and friends) must resolve through ONE shared path
+(`m3_sdk.get_secret` -> `auth_utils.get_api_key`: env -> keyring -> keychain ->
+vault, LM_STUDIO_API_KEY alias) so it works in headless launchers that never
+inherit the shell env (§3). These tests pin that facade, the file-extraction
+LLM-endpoint fallback, and guard against re-introducing hand-rolled/env-only
+token reads (the fragmentation that caused the headless bug).
+"""
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_BIN = _ROOT / "bin"
+for _p in (str(_ROOT), str(_BIN)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# ── facade: m3_sdk.get_secret is the one entry point ────────────────────────────
+
+def test_m3_sdk_exposes_get_secret(monkeypatch):
+    import m3_sdk
+    assert callable(m3_sdk.get_secret)
+    monkeypatch.setenv("SOME_TEST_SECRET", "s3cr3t")
+    assert m3_sdk.get_secret("SOME_TEST_SECRET") == "s3cr3t"
+
+
+def test_get_secret_lm_alias(monkeypatch):
+    # The LM_API_TOKEN -> LM_STUDIO_API_KEY alias lives in the shared resolver.
+    import m3_sdk
+    monkeypatch.delenv("LM_API_TOKEN", raising=False)
+    monkeypatch.setenv("LM_STUDIO_API_KEY", "tok-alias")
+    assert m3_sdk.get_secret("LM_API_TOKEN") == "tok-alias"
+
+
+# ── file-extraction resolves an LLM via the shared llm_failover fallback ─────────
+
+def test_extract_endpoint_falls_back_to_shared_resolver(monkeypatch):
+    for v in ("M3_FILES_EXTRACT_URL", "M3_FILES_SUMMARY_URL", "M3_LMSTUDIO_URL",
+              "M3_LLM_URL", "M3_LLM_ENDPOINTS_CSV", "LLM_ENDPOINTS_CSV"):
+        monkeypatch.delenv(v, raising=False)
+    from files_memory.extract import _llm_endpoint, llm_available
+    # With no override, it must fall back to llm_failover's default (LM Studio),
+    # not report "no LLM" — the whole point of the seam fix.
+    ep = _llm_endpoint()
+    assert ep and "1234" in ep, f"expected LM Studio fallback, got {ep!r}"
+    assert llm_available() is True
+
+
+def test_extract_endpoint_override_wins(monkeypatch):
+    monkeypatch.setenv("M3_FILES_EXTRACT_URL", "http://example.test:9/v1")
+    from files_memory.extract import _llm_endpoint
+    assert _llm_endpoint() == "http://example.test:9/v1"
+
+
+def test_llm_auth_headers_resolves_token(monkeypatch):
+    monkeypatch.setenv("LM_API_TOKEN", "tok-xyz")
+    from files_memory.config import llm_auth_headers
+    assert llm_auth_headers() == {"Authorization": "Bearer tok-xyz"}
+
+
+# ── guard: no module reinvents the token seam (env-only / hand-rolled keychain) ──
+
+_ALLOWED = {"auth_utils.py"}  # the resolver itself owns the native keychain path
+
+
+def test_no_handrolled_lm_keychain_subprocess():
+    """No module may shell out to `security find-generic-password` for the LM
+    Studio key — that reinvents the cross-platform resolver env-only/macOS-only.
+    Use m3_sdk.get_secret / auth_utils.get_api_key instead. Matches the actual
+    subprocess arg-list form so a docstring MENTIONING the old pattern is fine."""
+    # e.g. ["security", "find-generic-password", ...] near LM_STUDIO_API_KEY
+    call = re.compile(r"""["']security["']\s*,\s*["']find-generic-password""")
+    offenders = []
+    for py in _BIN.rglob("*.py"):
+        if py.name in _ALLOWED or py.name.startswith("test_"):
+            continue
+        txt = py.read_text(encoding="utf-8", errors="replace")
+        if call.search(txt) and "LM_STUDIO_API_KEY" in txt:
+            offenders.append(str(py.relative_to(_BIN)))
+    assert not offenders, (
+        "hand-rolled LM keychain lookup (use m3_sdk.get_secret): " + ", ".join(offenders)
+    )
+
+
+def test_migrated_sites_route_through_resolver():
+    """The previously-fragmented sites now go through the canonical resolver.
+    (A bare os.environ read may survive only inside an except-branch fallback.)"""
+    checks = {
+        "macbook_status_server.py": "get_secret",
+        "mission_control.py": "get_secret",
+        "promote_pipeline.py": "get_secret",
+        "files_memory/config.py": "get_api_key",   # low-level: impl directly
+        "llm_failover.py": "get_api_key",           # low-level: impl directly
+    }
+    for rel, needle in checks.items():
+        txt = (_BIN / rel).read_text(encoding="utf-8")
+        assert needle in txt, f"{rel} should resolve the LM token via {needle}(...)"
+        # And must not shell out for the key anymore.
+        assert '"find-generic-password"' not in txt and "'find-generic-password'" not in txt, \
+            f"{rel} still shells out to security find-generic-password"


### PR DESCRIPTION
## Why
File fact-extraction reported "no LLM" whenever the optional `M3_FILES_*` override vars were unset — even though the rest of m3 (cognitive loop, enrichment) reaches LM Studio zero-config. `extract._llm_endpoint()` read only its own env vars and never fell back to the shared `llm_failover` resolver, and `llm_auth_headers()` read `LM_API_TOKEN` from `os.environ` alone (absent in headless launchd/systemd launchers — §3). Same reinvent-the-seam pattern behind ~4 divergent LM-token resolvers across the tree.

## What
- **`extract._llm_endpoint()`** falls back to `llm_failover`'s resolved endpoint (auto-probes LM Studio :1234) when no override is set — headless-safe (the default is a code constant, not shell env).
- **`llm_auth_headers()`** resolves the token via the shared `env → keyring → keychain → vault` resolver, not `os.environ` alone.
- **New `m3_sdk.get_secret`** — the one canonical secret resolver (lazy re-export of `auth_utils.get_api_key`).
- **Migrated** the fragmented env-only / hand-rolled token sites: `llm_failover` (its env-only default 401'd headless for *every* LLM call), `macbook_status_server` + `mission_control` (dropped `security find-generic-password`), `promote_pipeline`.
- **New doctor probe** `files_extraction_probe` flags "file-extraction can't reach an LLM though the main path can."
- **Guard test** bans new hand-rolled/env-only LM reads.

## Test
ruff + mypy clean on all touched files; new seam tests (7) + `test_llm_failover` (4) + doctor/embed suites (25) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)