### PR TITLE
doctor: detect embedder-model mismatch

### DIFF
--- a/bin/doctor/shared_embedder_probe.py
+++ b/bin/doctor/shared_embedder_probe.py
@@ -385,6 +385,48 @@ def _fix_register_task() -> bool:
     return rc == 0
 
 
+def _norm_model_tag(tag: str) -> str:
+    """Collapse known-equivalent embedder tags to a family key. The store
+    legitimately holds two bge-m3 aliases (the GGUF filename and the API/space
+    tag) for the SAME weights, so they must compare equal; only a genuinely
+    different family (e.g. nomic-embed) counts as a mismatch."""
+    t = (tag or "").strip().lower()
+    return "bge-m3" if ("bge-m3" in t or "bge_m3" in t) else t
+
+
+def _classify_embed_model(cfg: "dict | None", body: dict) -> "tuple[str | None, list[str]]":
+    """Compare the PINNED embed_model (env ``M3_EMBED_MODEL`` > the seeded
+    ``embed_model`` in .embed_config.json) against what the server actually
+    serves. The pin is the store's contract for which model owns its vector
+    space, so a served model in a different family means new embeds land in a
+    foreign space — the mismatch the user asked doctor to catch.
+
+    Deterministic + hermetic on purpose: it reads only the config/env and the
+    server-health body already fetched by run() — NEVER the live DB (a real-DB
+    read here would make the probe's verdict depend on machine state, §3). When no
+    model is pinned there is nothing to compare, so it stays quiet. Returns
+    (token, lines): token in {'model-mismatch', None}; lines are printable rows."""
+    pinned = ((os.environ.get("M3_EMBED_MODEL") or "").strip()
+              or (cfg or {}).get("embed_model") or "").strip()
+    served = str((body or {}).get("model") or "").strip()
+    try:
+        served_dim = int((body or {}).get("dim") or 0)
+    except (TypeError, ValueError):
+        served_dim = 0
+
+    if pinned and served and _norm_model_tag(pinned) != _norm_model_tag(served):
+        return "model-mismatch", [
+            f"  model    : [WARN] pinned embed_model='{pinned}' but the server serves "
+            f"'{served}' — a foreign model writes an INCOMPATIBLE vector space.",
+            "             fix: point the shared server at the model your store was "
+            "built with (embed_model in .embed_config.json / M3_EMBED_MODEL), or re-embed.",
+        ]
+    if pinned and served:
+        return None, [f"  model    : OK — server '{served}' matches pin '{pinned}' "
+                      f"(dim={served_dim or '?'})."]
+    return None, []
+
+
 def run(brief: bool = False, fix: bool = False) -> int:
     """Check config + server + keep-alive task. Return non-zero if shared mode is
     not fully healthy. With fix=True, repair what's repairable first."""
@@ -404,6 +446,12 @@ def run(brief: bool = False, fix: bool = False) -> int:
     health, body = _server_health(url)
     if health in ("down", "bad-scheme"):
         problems.append("server-down")
+
+    # 2b. Embedder-model identity: does the served model match the stored vector
+    #     space? A foreign model silently writes an incompatible space — tracked
+    #     SEPARATELY from `problems` because it is not `--fix`-repairable (it needs
+    #     a repoint or a re-embed, not a config rewrite).
+    model_token, model_lines = _classify_embed_model(cfg, body)
 
     # 3. Keep-alive: a Rust OS service OR the Python scheduled task must exist so
     #    the server survives a crash/reboot. Flag only if NEITHER is present.
@@ -491,6 +539,8 @@ def run(brief: bool = False, fix: bool = False) -> int:
     else:
         print(f"  server   : OK (model={body.get('model')}, dim={body.get('dim')}, "
               f"status={health})")
+        for _ln in model_lines:
+            print(_ln)
 
     if ka_kind == "rust-service":
         print("  keepalive: OK — Rust m3-embed-server OS service "
@@ -525,8 +575,13 @@ def run(brief: bool = False, fix: bool = False) -> int:
     else:
         print("  inproc   : OK — no M3_EMBED_GGUF leak (clients defer to the server).")
 
-    if healthy:
+    if healthy and model_token is None:
         print("  status   : OK — shared mode fully configured and serving.")
+    elif healthy and model_token is not None:
+        # Config/server/keep-alive are fine; the embedder MODEL is the concern.
+        # Not `--fix`-repairable — it needs a repoint or a re-embed (see above).
+        print("  status   : [WARN] shared mode wired, but embedder-model mismatch "
+              "(see model line above) — not auto-fixable.")
     elif manual_only:
         # Don't tell the user to run --fix for the one thing it can't fix; the
         # exact manual command is printed in the inproc block above.
@@ -536,4 +591,7 @@ def run(brief: bool = False, fix: bool = False) -> int:
     elif not fix:
         print()
         print("  Run `m3 doctor --fix` to repair the above automatically.")
-    return 0 if healthy else 1
+    # A model mismatch is a real problem even when config/server/keep-alive pass,
+    # so it lowers the verbose exit code — but it is reported (above), never
+    # folded into the `--fix` problem list it cannot repair.
+    return 0 if (healthy and model_token is None) else 1

--- a/m3_memory/embedder_admin.py
+++ b/m3_memory/embedder_admin.py
@@ -809,6 +809,9 @@ def seed_shared_config(
       server instead of opening its own CUDA context.
     - Records ``fallback_url`` (where the shared server listens) and, when known,
       ``gguf_path`` (which model the SERVER should load — clients never load it).
+    - Records ``embed_model`` (the tag the shared server serves) so ``m3 doctor``
+      can flag an embedder-model mismatch (a foreign model would write an
+      incompatible vector space).
     - overwrite=False (default) preserves an existing file's keys, only filling in
       what's missing, so a hand-tuned config is never clobbered.
 
@@ -833,8 +836,18 @@ def seed_shared_config(
     desired = dict(existing)
     desired["disable_inproc_embedder"] = True
     desired.setdefault("fallback_url", url)
+    # Record the model the shared server serves so `m3 doctor` can catch an
+    # embedder-model mismatch (a foreign model silently writes an incompatible
+    # vector space). NOTE: we deliberately do NOT pin a primary `embed_url` here —
+    # the shared :8082 server is the tier-2 fallback (spoken via /embedding); the
+    # primary HTTP tier posts to /embeddings, which :8082 does not serve, so
+    # pinning the primary at :8082 would 404 and break the real fallback. Keeping
+    # :8082 supervised (launchd KeepAlive) is what keeps embedding on it.
     if gguf_path:
         desired.setdefault("gguf_path", gguf_path.replace("\\", "/"))
+        desired.setdefault("embed_model", os.path.basename(gguf_path))
+    else:
+        desired.setdefault("embed_model", "bge-m3-GGUF-Q4_K_M.gguf")
     desired["_comment"] = (
         "Route all m3 processes to the shared GPU embedder "
         "(bin/embed_server_inproc.py) so only ONE CUDA context exists. "

--- a/tests/test_embedder_model_mismatch.py
+++ b/tests/test_embedder_model_mismatch.py
@@ -1,0 +1,95 @@
+"""Embedder-model mismatch detection in `m3 doctor`.
+
+`seed_shared_config` records the served `embed_model` in .embed_config.json (the
+installer / `m3 setup` / `m3 embedder shared` / `m3 doctor --fix` all call it), and
+the shared-embedder probe cross-checks that pin against what :8082 actually serves
+— warning loudly when a foreign model would write an INCOMPATIBLE vector space.
+(It deliberately does NOT pin a primary `embed_url`: the shared server is the
+tier-2 fallback via /embedding; pinning the primary at :8082 would 404.) All
+hermetic — tmp config root, config/env only, never a live server/GPU/DB.
+"""
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_BIN = _ROOT / "bin"
+for _p in (str(_ROOT), str(_BIN)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from doctor import shared_embedder_probe as P  # noqa: E402
+
+from m3_memory import embedder_admin as EA  # noqa: E402
+
+# ── seed_shared_config: the single source of truth all three surfaces call ──────
+
+def test_seed_records_embed_model_and_fallback(tmp_path):
+    path, wrote = EA.seed_shared_config(str(tmp_path))
+    assert wrote is True
+    data = json.loads(Path(path).read_text())
+    assert data["embed_model"] == "bge-m3-GGUF-Q4_K_M.gguf"  # what :8082 serves
+    assert data["fallback_url"] == "http://127.0.0.1:8082"
+    # Deliberately NO primary `embed_url` pin (that would 404 the primary tier).
+    assert "embed_url" not in data
+
+
+def test_seed_embed_model_from_gguf_basename(tmp_path):
+    gguf = "/models/deepsweet/bge-m3-GGUF-Q4_K_M/bge-m3-GGUF-Q4_K_M.gguf"
+    path, _ = EA.seed_shared_config(str(tmp_path), gguf_path=gguf)
+    data = json.loads(Path(path).read_text())
+    assert data["embed_model"] == "bge-m3-GGUF-Q4_K_M.gguf"
+
+
+def test_seed_preserves_hand_tuned_values(tmp_path):
+    # A user pinned a custom model; overwrite=False must not clobber it.
+    cfg = tmp_path / ".embed_config.json"
+    cfg.write_text(json.dumps({"embed_model": "custom-embedder"}))
+    path, _ = EA.seed_shared_config(str(tmp_path))
+    data = json.loads(Path(path).read_text())
+    assert data["embed_model"] == "custom-embedder"
+
+
+# ── model-family normalization (bge-m3 aliases are the SAME weights) ────────────
+
+def test_norm_tag_collapses_bge_m3_aliases():
+    assert P._norm_model_tag("bge-m3-GGUF-Q4_K_M.gguf") == "bge-m3"
+    assert P._norm_model_tag("text-embedding-bge-m3") == "bge-m3"
+    assert P._norm_model_tag("nomic-embed-text") == "nomic-embed-text"
+
+
+# ── doctor cross-check: pinned embed_model vs served (hermetic, no DB) ──────────
+
+def _classify(monkeypatch, *, pinned, served_model, served_dim=1024):
+    monkeypatch.delenv("M3_EMBED_MODEL", raising=False)   # env would override the pin
+    cfg = {"embed_model": pinned} if pinned else {}
+    return P._classify_embed_model(cfg, {"model": served_model, "dim": served_dim})
+
+
+def test_bge_m3_alias_is_not_a_mismatch(monkeypatch):
+    # Pin is the API tag; server serves the GGUF tag — same bge-m3 weights.
+    token, _lines = _classify(monkeypatch, pinned="text-embedding-bge-m3",
+                              served_model="bge-m3-GGUF-Q4_K_M.gguf")
+    assert token is None
+
+
+def test_pinned_vs_foreign_served_is_warned(monkeypatch):
+    token, lines = _classify(monkeypatch, pinned="text-embedding-bge-m3",
+                             served_model="nomic-embed-text")
+    assert token == "model-mismatch"
+    assert any("INCOMPATIBLE" in ln for ln in lines)
+
+
+def test_env_pin_overrides_config(monkeypatch):
+    monkeypatch.setenv("M3_EMBED_MODEL", "nomic-embed-text")
+    token, _ = P._classify_embed_model({"embed_model": "bge-m3-GGUF-Q4_K_M.gguf"},
+                                       {"model": "bge-m3-GGUF-Q4_K_M.gguf", "dim": 1024})
+    assert token == "model-mismatch"   # env pin (nomic) diverges from served bge-m3
+
+
+def test_no_pin_stays_quiet(monkeypatch):
+    # Nothing pinned -> nothing to compare -> no verdict, no noise (the existing
+    # doctor tests seed no embed_model and must stay green).
+    token, lines = _classify(monkeypatch, pinned="", served_model="bge")
+    assert token is None
+    assert lines == []

--- a/tests/test_shared_embedder_probe.py
+++ b/tests/test_shared_embedder_probe.py
@@ -19,6 +19,16 @@ if _BIN not in sys.path:
 from doctor import shared_embedder_probe as P  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _clear_embed_env(monkeypatch):
+    """Keep these verdict tests hermetic (§3): the probe's model cross-check reads
+    M3_EMBED_MODEL, and a developer shell may export the shared-embedder pins
+    (M3_EMBED_URL/M3_EMBED_MODEL). Clear them so the config the test writes — not
+    the ambient environment — decides the outcome."""
+    for var in ("M3_EMBED_MODEL", "M3_EMBED_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture
 def cfg_root(monkeypatch, tmp_path):
     monkeypatch.setenv("M3_CONFIG_ROOT", str(tmp_path))


### PR DESCRIPTION
## Why
Salvaged the one genuinely-correct part of the reverted `embed-url-model-self-default` branch. That branch's premise — pinning the **primary** embedder at `:8082` — was wrong: the shared server is the tier-2 fallback (spoken via `/embedding`), while the primary HTTP tier posts to `/embeddings` (404 on :8082), so the pin broke the real fallback. The actual fix for the original symptom (LM Studio getting hammered) was keeping `:8082` supervised via its launchd KeepAlive service.

## What
- **`shared_embedder_probe`**: cross-check the pinned `embed_model` (from `.embed_config.json` / `M3_EMBED_MODEL`) against what `:8082` actually serves; warn loudly on a foreign-model mismatch (a foreign model silently writes an INCOMPATIBLE vector space). bge-m3 GGUF/API tags treated as equivalent aliases. Reported + exit-coded, never folded into the `--fix` problem list it can't repair. Hermetic (no live DB read).
- **`seed_shared_config`**: record `embed_model` (the served tag) so the check has a pin to compare — deliberately **not** a primary `embed_url` (that would 404).
- **Tests**: mismatch matrix + tag-alias equivalence; autouse env-clear fixture keeps existing probe tests independent of ambient `M3_EMBED_*` vars.

## Test
ruff + mypy clean; 25 doctor/embed tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)