### PR TITLE
harden entity extraction: follow the loaded model by name

### DIFF
--- a/bin/llm_failover.py
+++ b/bin/llm_failover.py
@@ -222,9 +222,24 @@ def discover_model_sync(
     except Exception as e:  # noqa: BLE001 — discovery is best-effort by contract
         logger.warning(f"[llm_failover] sync discovery {endpoint}: {type(e).__name__}: {e}")
         return None
-    # Both OpenAI-shaped servers and Ollama return {"data": [...]}; Ollama's
-    # native (non-/v1) listing uses {"models": [...]}. Accept either rather than
-    # asserting a shape we have not verified against every server.
+    best = _pick_best_model(data)
+    if best is None:
+        logger.warning(f"[llm_failover] sync discovery {endpoint}: no usable models")
+        return None
+    _SYNC_MODEL_CACHE[endpoint] = best
+    logger.info(f"[llm_failover] sync discovery {endpoint} -> {best}")
+    return best
+
+
+def _pick_best_model(data: dict) -> Optional[str]:
+    """From a /models response, return the largest usable GENERATIVE model id, or
+    None. Embedders (EMBED_EXCLUSIONS) and LLM_EXCLUSIONS are filtered out and the
+    winner is the largest by :func:`parse_model_size`. Shared by
+    discover_model_sync and discover_model_async so the two cannot drift (§10a).
+
+    Both OpenAI-shaped servers and Ollama return {"data": [...]}; Ollama's native
+    (non-/v1) listing uses {"models": [...]}. Accept either rather than asserting a
+    shape we have not verified against every server."""
     models = data.get("data", data.get("models", [])) or []
     usable = []
     for m in models:
@@ -237,11 +252,49 @@ def discover_model_sync(
             continue
         usable.append(mid)
     if not usable:
-        logger.warning(f"[llm_failover] sync discovery {endpoint}: no usable models")
         return None
-    best = max(usable, key=parse_model_size)
-    _SYNC_MODEL_CACHE[endpoint] = best
-    logger.info(f"[llm_failover] sync discovery {endpoint} -> {best}")
+    return max(usable, key=parse_model_size)
+
+
+async def discover_model_async(
+    client: "httpx.AsyncClient",
+    endpoint: str,
+    token: Optional[str] = None,
+    *,
+    timeout: float = 5.0,
+    fresh: bool = False,
+) -> Optional[str]:
+    """Async sibling of :func:`discover_model_sync` — pick the largest usable
+    model on ``endpoint`` by asking it, over the caller's AsyncClient so it does
+    NOT block the event loop. Same filter/pick contract (shared _pick_best_model)
+    and same token/auth handling (default LM_API_TOKEN, header omitted when
+    absent).
+
+    ``fresh=True`` bypasses the per-endpoint cache and re-queries every call — for
+    a long-running loop that must follow a model swapped mid-run (e.g. the entity
+    extractor's per-pass resolution). ``fresh=False`` (default) caches per-endpoint
+    like the sync version. Returns None when unreachable / nothing usable —
+    "caller decides"; never turn None back into a hardcoded name."""
+    if not fresh:
+        cached = _SYNC_MODEL_CACHE.get(endpoint)
+        if cached is not None:
+            return cached
+    try:
+        tok = token if token is not None else _default_lm_token()
+        headers = _auth_headers(tok)
+        r = await client.get(f"{endpoint.rstrip('/')}/models", headers=headers, timeout=timeout)
+        r.raise_for_status()
+        data = r.json()
+    except Exception as e:  # noqa: BLE001 — discovery is best-effort by contract
+        logger.warning(f"[llm_failover] async discovery {endpoint}: {type(e).__name__}: {e}")
+        return None
+    best = _pick_best_model(data)
+    if best is None:
+        logger.warning(f"[llm_failover] async discovery {endpoint}: no usable models")
+        return None
+    if not fresh:
+        _SYNC_MODEL_CACHE[endpoint] = best
+    logger.info(f"[llm_failover] async discovery {endpoint} -> {best}")
     return best
 
 

--- a/bin/m3_entities.py
+++ b/bin/m3_entities.py
@@ -181,32 +181,26 @@ def _load_vocab(path: Optional[Path]) -> tuple[frozenset[str], frozenset[str]]:
 async def _discover_loaded_model_async(
     client: httpx.AsyncClient, url: str, token: "str | None"
 ) -> "str | None":
-    """Best-effort id of a model currently loaded at ``url``'s server, so a
-    blank-model profile can follow the loaded model BY NAME.
+    """Id of a model currently loaded at ``url``'s server, so a blank-model
+    profile can follow the loaded model BY NAME.
 
-    A blank ``model`` only works on LM Studio when exactly ONE model is loaded
-    AND JIT loading is on; with several loaded, or JIT off, the server rejects it
+    A blank ``model`` only works on LM Studio when exactly ONE model is loaded AND
+    JIT loading is on; with several loaded, or JIT off, the server rejects it
     (``Invalid model identifier ""`` -> 404) and every extraction pass HTTP-fails.
-    Sending the discovered name is robust to both. Queries ``{base}/models``
-    FRESH (no cache) via the async client so a model swap between passes is picked
-    up; returns None on any failure so the caller keeps the blank model (never
-    worse than before). ``base`` is derived from the profile url, which ends in
-    /messages (anthropic) or /chat/completions (openai)."""
+    Sending the discovered name is robust to both. Delegates to the shared
+    ``llm_failover.discover_model_async`` seam (fresh=True, so a model swap between
+    passes is picked up; same embedder-filtering + largest-model pick as
+    everywhere else). Derives the OpenAI-style base from the profile url (which
+    ends in /messages for anthropic or /chat/completions for openai). Returns None
+    on any failure so the caller keeps the blank model."""
+    base = url.rstrip("/")
+    for suffix in ("/chat/completions", "/messages"):
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+            break
     try:
-        base = url.rstrip("/")
-        for suffix in ("/chat/completions", "/messages"):
-            if base.endswith(suffix):
-                base = base[: -len(suffix)]
-                break
-        headers: dict[str, str] = {}
-        tok = (token or "").strip()
-        if tok:
-            headers["Authorization"] = f"Bearer {tok}"
-        r = await client.get(f"{base}/models", headers=headers, timeout=5.0)
-        r.raise_for_status()
-        ids = [m.get("id") for m in (r.json().get("data") or [])
-               if isinstance(m, dict) and m.get("id")]
-        return ids[0] if ids else None
+        from llm_failover import discover_model_async
+        return await discover_model_async(client, base, token, fresh=True)
     except Exception:  # noqa: BLE001 — discovery is advisory; keep the blank model
         return None
 

--- a/bin/m3_entities.py
+++ b/bin/m3_entities.py
@@ -178,6 +178,39 @@ def _load_vocab(path: Optional[Path]) -> tuple[frozenset[str], frozenset[str]]:
     return mc.load_entity_vocab(str(path))
 
 
+async def _discover_loaded_model_async(
+    client: httpx.AsyncClient, url: str, token: "str | None"
+) -> "str | None":
+    """Best-effort id of a model currently loaded at ``url``'s server, so a
+    blank-model profile can follow the loaded model BY NAME.
+
+    A blank ``model`` only works on LM Studio when exactly ONE model is loaded
+    AND JIT loading is on; with several loaded, or JIT off, the server rejects it
+    (``Invalid model identifier ""`` -> 404) and every extraction pass HTTP-fails.
+    Sending the discovered name is robust to both. Queries ``{base}/models``
+    FRESH (no cache) via the async client so a model swap between passes is picked
+    up; returns None on any failure so the caller keeps the blank model (never
+    worse than before). ``base`` is derived from the profile url, which ends in
+    /messages (anthropic) or /chat/completions (openai)."""
+    try:
+        base = url.rstrip("/")
+        for suffix in ("/chat/completions", "/messages"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        headers: dict[str, str] = {}
+        tok = (token or "").strip()
+        if tok:
+            headers["Authorization"] = f"Bearer {tok}"
+        r = await client.get(f"{base}/models", headers=headers, timeout=5.0)
+        r.raise_for_status()
+        ids = [m.get("id") for m in (r.json().get("data") or [])
+               if isinstance(m, dict) and m.get("id")]
+        return ids[0] if ids else None
+    except Exception:  # noqa: BLE001 — discovery is advisory; keep the blank model
+        return None
+
+
 def _build_extractor(
     profile: Profile,
     token: str,
@@ -192,6 +225,22 @@ def _build_extractor(
     The returned callable is exactly the shape memory_core's
     _run_entity_extractor expects.
     """
+    # Resolve the effective model ONCE per pass (this factory is rebuilt each
+    # pass in _run_db). A blank/sentinel model means "follow the loaded model":
+    # discovered BY NAME (see _discover_loaded_model_async) so it survives >1
+    # loaded model / JIT-off, which reject an empty model id. Lazy + cached for
+    # this pass's rows; falls back to "" (prior behaviour) when discovery fails.
+    _resolved: dict[str, str] = {}
+
+    async def _effective_model() -> str:
+        m = (profile.model or "").strip()
+        if m.lower() in ("default", "auto", "loaded", "any"):
+            m = ""
+        if m:
+            return m
+        if "v" not in _resolved:
+            _resolved["v"] = await _discover_loaded_model_async(client, profile.url, token) or ""
+        return _resolved["v"]
 
     async def call(content: str) -> dict:
         if not content or len(content.strip()) < 8:
@@ -217,9 +266,7 @@ def _build_extractor(
         # it. LM Studio accepts an empty `model` field and serves the loaded
         # model; the key is always present since some builds 400 on its
         # absence. (Non-local backends should pin a real id in the profile.)
-        _model = (profile.model or "").strip()
-        if _model.lower() in ("default", "auto", "loaded", "any"):
-            _model = ""
+        _model = await _effective_model()  # resolved once per pass; follows the loaded model
         backend = getattr(profile, "backend", "anthropic") or "anthropic"
         if backend == "openai":
             messages = []

--- a/tests/test_entity_model_discovery.py
+++ b/tests/test_entity_model_discovery.py
@@ -1,12 +1,15 @@
-"""Entity-extractor blank-model hardening (m3_entities._discover_loaded_model_async).
+"""Blank-model hardening for entity extraction.
 
 A blank/sentinel `model` in an SLM profile means "follow the loaded model". The
 old code sent an empty `model` and relied on LM Studio routing to the single
 loaded model — which 404s ("Invalid model identifier \"\"") whenever >1 model is
-loaded or JIT loading is off. These tests pin the fix: discover the loaded model
-BY NAME from `{base}/models`, derive that base from the profile url (anthropic
-/messages OR openai /chat/completions), and degrade to None (caller keeps "")
-on any failure. Hermetic — a fake async client, no real server (CI-safe).
+loaded or JIT loading is off. The fix discovers the loaded model BY NAME through
+the shared `llm_failover` seam (async sibling of discover_model_sync).
+
+Covers: `llm_failover.discover_model_async` (largest usable pick, embedder
+filtering, fresh=cache-bypass, failure->None) and `m3_entities`'s base-url
+derivation + delegation with fresh=True. Hermetic — a fake async client, no real
+server (CI-safe).
 """
 import asyncio
 import sys
@@ -16,6 +19,7 @@ _BIN = str(Path(__file__).resolve().parents[1] / "bin")
 if _BIN not in sys.path:
     sys.path.insert(0, _BIN)
 
+import llm_failover as LF  # noqa: E402
 import m3_entities as E  # noqa: E402
 
 
@@ -27,47 +31,80 @@ class _Resp:
         return None
 
     def json(self):
-        return {"data": self._data}
+        return self._data
 
 
 class _Client:
     """Fake httpx.AsyncClient capturing the GET it receives."""
-    def __init__(self, data, capture):
-        self._data = data
-        self._cap = capture
+    def __init__(self, resp_json, capture=None):
+        self._j = resp_json
+        self._cap = capture if capture is not None else {}
 
     async def get(self, url, headers=None, timeout=None):
         self._cap["url"] = url
         self._cap["headers"] = headers or {}
-        return _Resp(self._data)
+        return _Resp(self._j)
 
 
-def test_discovers_first_loaded_model_and_strips_anthropic_suffix():
+# ── llm_failover.discover_model_async (the shared seam) ─────────────────────────
+
+def test_async_picks_usable_and_filters_embedders(monkeypatch):
+    monkeypatch.setattr(LF, "_SYNC_MODEL_CACHE", {})
     cap = {}
-    client = _Client([{"id": "qwen/qwen3.5-9b"}, {"id": "google/gemma-4-26b-a4b"}], cap)
-    got = asyncio.run(E._discover_loaded_model_async(
-        client, "http://127.0.0.1:1234/v1/messages", "tok"))
-    assert got == "qwen/qwen3.5-9b"                       # first loaded model, by name
-    assert cap["url"] == "http://127.0.0.1:1234/v1/models"  # /messages -> /models
-    assert cap["headers"].get("Authorization") == "Bearer tok"
-
-
-def test_openai_suffix_also_derives_v1_models():
-    cap = {}
-    asyncio.run(E._discover_loaded_model_async(
-        _Client([{"id": "m"}], cap), "http://127.0.0.1:1234/v1/chat/completions", None))
+    # embedder must be excluded; the generative model is the only usable one.
+    client = _Client({"data": [{"id": "text-embedding-bge-m3"}, {"id": "qwen/qwen3.5-9b"}]}, cap)
+    got = asyncio.run(LF.discover_model_async(client, "http://127.0.0.1:1234/v1", "tok", fresh=True))
+    assert got == "qwen/qwen3.5-9b"
     assert cap["url"] == "http://127.0.0.1:1234/v1/models"
-    assert "Authorization" not in cap["headers"]          # no token -> no auth header
 
 
-def test_no_models_loaded_returns_none():
-    assert asyncio.run(E._discover_loaded_model_async(
-        _Client([], {}), "http://x/v1/messages", None)) is None
+def test_async_fresh_bypasses_cache_but_default_uses_it(monkeypatch):
+    monkeypatch.setattr(LF, "_SYNC_MODEL_CACHE", {"http://x/v1": "STALE-MODEL"})
+    client = _Client({"data": [{"id": "qwen/qwen3-8b"}]})
+    # fresh=True ignores the (stale) cache and re-queries
+    assert asyncio.run(LF.discover_model_async(client, "http://x/v1", "t", fresh=True)) == "qwen/qwen3-8b"
+    # fresh=False returns the cached value
+    assert asyncio.run(LF.discover_model_async(client, "http://x/v1", "t", fresh=False)) == "STALE-MODEL"
 
 
-def test_any_failure_returns_none():
+def test_async_failure_returns_none(monkeypatch):
+    monkeypatch.setattr(LF, "_SYNC_MODEL_CACHE", {})
+
     class _Boom:
         async def get(self, *a, **k):
             raise RuntimeError("server down")
-    assert asyncio.run(E._discover_loaded_model_async(
-        _Boom(), "http://x/v1/messages", "t")) is None
+    assert asyncio.run(LF.discover_model_async(_Boom(), "http://x/v1", "t", fresh=True)) is None
+
+
+# ── m3_entities: derive the OpenAI-style base + delegate fresh ───────────────────
+
+def test_entities_strips_anthropic_suffix_and_forces_fresh(monkeypatch):
+    seen = {}
+
+    async def _fake(client, endpoint, token, *, fresh=False):
+        seen["endpoint"] = endpoint
+        seen["fresh"] = fresh
+        return "MODEL-X"
+    monkeypatch.setattr(LF, "discover_model_async", _fake)
+    got = asyncio.run(E._discover_loaded_model_async(object(), "http://127.0.0.1:1234/v1/messages", "tok"))
+    assert got == "MODEL-X"
+    assert seen["endpoint"] == "http://127.0.0.1:1234/v1"   # /messages stripped -> base
+    assert seen["fresh"] is True                            # per-pass fresh (survives swaps)
+
+
+def test_entities_strips_openai_suffix(monkeypatch):
+    seen = {}
+
+    async def _fake(client, endpoint, token, *, fresh=False):
+        seen["endpoint"] = endpoint
+        return "M"
+    monkeypatch.setattr(LF, "discover_model_async", _fake)
+    asyncio.run(E._discover_loaded_model_async(object(), "http://127.0.0.1:1234/v1/chat/completions", None))
+    assert seen["endpoint"] == "http://127.0.0.1:1234/v1"
+
+
+def test_entities_discovery_failure_keeps_none(monkeypatch):
+    async def _boom(*a, **k):
+        raise RuntimeError("nope")
+    monkeypatch.setattr(LF, "discover_model_async", _boom)
+    assert asyncio.run(E._discover_loaded_model_async(object(), "http://x/v1/messages", "t")) is None

--- a/tests/test_entity_model_discovery.py
+++ b/tests/test_entity_model_discovery.py
@@ -1,0 +1,73 @@
+"""Entity-extractor blank-model hardening (m3_entities._discover_loaded_model_async).
+
+A blank/sentinel `model` in an SLM profile means "follow the loaded model". The
+old code sent an empty `model` and relied on LM Studio routing to the single
+loaded model — which 404s ("Invalid model identifier \"\"") whenever >1 model is
+loaded or JIT loading is off. These tests pin the fix: discover the loaded model
+BY NAME from `{base}/models`, derive that base from the profile url (anthropic
+/messages OR openai /chat/completions), and degrade to None (caller keeps "")
+on any failure. Hermetic — a fake async client, no real server (CI-safe).
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+_BIN = str(Path(__file__).resolve().parents[1] / "bin")
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+import m3_entities as E  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"data": self._data}
+
+
+class _Client:
+    """Fake httpx.AsyncClient capturing the GET it receives."""
+    def __init__(self, data, capture):
+        self._data = data
+        self._cap = capture
+
+    async def get(self, url, headers=None, timeout=None):
+        self._cap["url"] = url
+        self._cap["headers"] = headers or {}
+        return _Resp(self._data)
+
+
+def test_discovers_first_loaded_model_and_strips_anthropic_suffix():
+    cap = {}
+    client = _Client([{"id": "qwen/qwen3.5-9b"}, {"id": "google/gemma-4-26b-a4b"}], cap)
+    got = asyncio.run(E._discover_loaded_model_async(
+        client, "http://127.0.0.1:1234/v1/messages", "tok"))
+    assert got == "qwen/qwen3.5-9b"                       # first loaded model, by name
+    assert cap["url"] == "http://127.0.0.1:1234/v1/models"  # /messages -> /models
+    assert cap["headers"].get("Authorization") == "Bearer tok"
+
+
+def test_openai_suffix_also_derives_v1_models():
+    cap = {}
+    asyncio.run(E._discover_loaded_model_async(
+        _Client([{"id": "m"}], cap), "http://127.0.0.1:1234/v1/chat/completions", None))
+    assert cap["url"] == "http://127.0.0.1:1234/v1/models"
+    assert "Authorization" not in cap["headers"]          # no token -> no auth header
+
+
+def test_no_models_loaded_returns_none():
+    assert asyncio.run(E._discover_loaded_model_async(
+        _Client([], {}), "http://x/v1/messages", None)) is None
+
+
+def test_any_failure_returns_none():
+    class _Boom:
+        async def get(self, *a, **k):
+            raise RuntimeError("server down")
+    assert asyncio.run(E._discover_loaded_model_async(
+        _Boom(), "http://x/v1/messages", "t")) is None


### PR DESCRIPTION
## Why
Entity extraction silently HTTP-failed (`0 processed, N HTTP-fail` per pass) whenever more than one model was loaded in LM Studio, or JIT loading was off. The SLM entity profiles use `model: ""` (a sentinel meaning "follow the loaded model") and relied on LM Studio routing an empty model id to the single loaded model. LM Studio only does that with **exactly one** model loaded **and** JIT on; otherwise it returns `not_found_error: Invalid model identifier ""` → 404, and every extraction request fails.

Observed live: a multi-model LMS session → constant `/v1/messages` 404s; reducing to a single loaded model made it recover — confirming the empty-model-id root cause.

## What
- `_build_extractor` now resolves the **effective model once per pass** (the factory is rebuilt each pass). A blank/sentinel model triggers `_discover_loaded_model_async`, which asks `{base}/models` — base derived from the profile url (anthropic `/messages` or openai `/chat/completions`) — and sends the loaded model **by name**.
- Robust to **>1 loaded model** and **JIT-off**; **re-resolved every pass** so a mid-run model swap is picked up; **degrades to `""`** (prior behaviour) if discovery fails — never worse than before.
- Uses the pass's existing async `httpx` client (non-blocking; no new global state).

## Test
`tests/test_entity_model_discovery.py` — base-url derivation for both wire formats, first-loaded-model pick, and the no-models / failure → `None` fallbacks. ruff + mypy clean; existing entity suites (70 tests) green.

## Follow-up (not in this PR)
The shipped `entities_local_*` profiles set `model: ""`; with this change that's now robust, but pinning a concrete id in the profile is still the most explicit option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)