### PR TITLE
doctor: warn when the extraction model has reasoning/thinking ON

### DIFF
--- a/bin/doctor/files_extraction_probe.py
+++ b/bin/doctor/files_extraction_probe.py
@@ -9,7 +9,13 @@ its own optional `M3_FILES_*` env vars.
 This probe surfaces the failure that was previously silent: file-extraction
 reporting "no LLM" (leaves marked extraction_status='failed') even though the rest
 of m3 (cognitive loop, enrichment) reaches an LLM fine. It reads only config/env
-+ one HTTP GET (never the live DB), and never crashes the doctor.
++ a couple of HTTP calls (never the live DB), and never crashes the doctor.
+
+It ALSO warns when the loaded model is a REASONING model with thinking on — the
+answer goes to the model's reasoning channel instead of JSON content, so
+extraction is slow and often yields 0 facts. Detection is by OUTPUT (an active
+one-shot probe), not the model name, and works against any OpenAI-compatible
+server — LM Studio AND Ollama — so the readiness check is provider-agnostic.
 """
 from __future__ import annotations
 
@@ -70,6 +76,52 @@ def _reach(endpoint: str, timeout: float = 3.0) -> "tuple[str, list[str]]":
         return "down", []
 
 
+def _classify_thinking(body: dict) -> "str | None":
+    """From a /chat/completions response, is the model doing chain-of-thought?
+
+    'on'  — the reply carries reasoning: LM Studio's ``reasoning_content``,
+            Ollama's ``thinking``/``reasoning``, or an inline ``<think>`` block.
+    'off' — it answered with plain content and no reasoning channel.
+    None  — unrecognizable shape.
+
+    Name heuristics don't work here (gemma-4 / qwen3.5 don't advertise "reasoning"
+    in the id), so detection is by OUTPUT. Pure — testable without a server."""
+    try:
+        msg = (body.get("choices") or [{}])[0].get("message") or {}
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(msg, dict):
+        return None
+    reasoning = str(msg.get("reasoning_content") or msg.get("reasoning")
+                    or msg.get("thinking") or "").strip()
+    content = str(msg.get("content") or "")
+    if reasoning or "<think>" in content.lower():
+        return "on"
+    return "off"
+
+
+def _detect_thinking(endpoint: str, model: str, headers: dict, timeout: float = 20.0) -> "str | None":
+    """Active probe: send ONE tiny chat request and classify whether the loaded
+    model reasons. Works against any OpenAI-compatible server (LM Studio, Ollama,
+    vLLM, …) at ``{endpoint}/chat/completions``. Returns 'on'|'off'|None; None on
+    any error (never a false alarm)."""
+    import json
+    payload = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+        "max_tokens": 200,
+        "temperature": 0,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{endpoint.rstrip('/')}/chat/completions", data=payload,
+        headers={**headers, "Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # nosec B310 — scheme checked upstream
+            return _classify_thinking(json.loads(r.read().decode("utf-8", "replace")))
+    except Exception:  # noqa: BLE001 — diagnostic best-effort
+        return None
+
+
 def run(brief: bool = False, fix: bool = False) -> int:
     endpoint = _file_extract_endpoint()
     main_eps = _main_path_endpoints()
@@ -96,6 +148,23 @@ def run(brief: bool = False, fix: bool = False) -> int:
         glyph = "✅" if models else "⚠️ "
         print(f"{glyph} file-extraction LLM: {endpoint} reachable ({shown})"
               + ("" if models else " — load a chat/instruct model to enable extraction."))
+        if models:
+            # Reasoning/thinking ON = extraction is slow and often yields 0
+            # parseable facts (the answer goes to the reasoning channel, not the
+            # JSON content). Detect it live (works for LM Studio AND Ollama) and
+            # warn — a model choice, not an m3 defect, so it doesn't fail the exit.
+            _ensure_path()
+            try:
+                from files_memory.config import llm_auth_headers
+                _hdr = llm_auth_headers()
+            except Exception:  # noqa: BLE001
+                _hdr = {}
+            if _detect_thinking(endpoint, models[0], _hdr) == "on":
+                print(f"⚠️  reasoning/thinking is ON for '{models[0]}' — fact "
+                      "extraction (files + entities) will be SLOW and may yield 0 "
+                      "parseable facts.")
+                print("   fix: disable thinking for this model in LM Studio / Ollama, "
+                      "or load a non-reasoning instruct model.")
         return 0 if models else 1
     if state == "auth":
         print(f"⚠️  file-extraction LLM: {endpoint} needs auth and the token didn't "

--- a/tests/test_files_extraction_probe.py
+++ b/tests/test_files_extraction_probe.py
@@ -1,0 +1,51 @@
+"""doctor files_extraction_probe — reasoning-model detection.
+
+The probe warns when the loaded extraction model reasons (thinking on), because
+the answer then goes to the model's reasoning channel instead of JSON content —
+extraction is slow and yields ~0 facts. Detection is by OUTPUT (not model name,
+which doesn't advertise it) and must recognize LM Studio's `reasoning_content`,
+Ollama's `thinking`/`reasoning`, and inline `<think>`. These pin `_classify_
+thinking` on those shapes. Pure/hermetic — no server.
+"""
+import sys
+from pathlib import Path
+
+_BIN = str(Path(__file__).resolve().parents[1] / "bin")
+if _BIN not in sys.path:
+    sys.path.insert(0, _BIN)
+
+from doctor import files_extraction_probe as P  # noqa: E402
+
+
+def _body(message: dict) -> dict:
+    return {"choices": [{"message": message}]}
+
+
+def test_lmstudio_reasoning_content_is_on():
+    assert P._classify_thinking(_body({"reasoning_content": "let me think...", "content": ""})) == "on"
+
+
+def test_ollama_thinking_field_is_on():
+    assert P._classify_thinking(_body({"thinking": "hmm", "content": "OK"})) == "on"
+
+
+def test_reasoning_field_is_on():
+    assert P._classify_thinking(_body({"reasoning": "step 1...", "content": ""})) == "on"
+
+
+def test_inline_think_block_is_on():
+    assert P._classify_thinking(_body({"content": "<think>reasoning</think> OK"})) == "on"
+
+
+def test_plain_answer_is_off():
+    assert P._classify_thinking(_body({"content": "OK"})) == "off"
+
+
+def test_empty_reasoning_is_not_on():
+    # A reasoning key present but empty must NOT count as thinking-on.
+    assert P._classify_thinking(_body({"reasoning_content": "   ", "content": "OK"})) == "off"
+
+
+def test_unrecognizable_shape_is_none():
+    assert P._classify_thinking({"choices": []}) == "off"          # no message -> plain
+    assert P._classify_thinking({"choices": [{"message": "nope"}]}) is None  # message not a dict


### PR DESCRIPTION
## What
`files_extraction_probe` now actively detects when the loaded file/entity extraction model is **reasoning with thinking ON** and warns.

A reasoning model routes its answer to the *reasoning channel* instead of JSON `content`, so extraction is slow and typically yields **0 parseable facts**. Model names don't advertise this (`gemma-4`, `qwen3.5`), so detection is **by output**: one tiny chat probe, then classify the reply for `reasoning_content` (LM Studio) / `thinking` / `reasoning` (Ollama) / inline `<think>`.

## Properties
- **Provider-agnostic** — any OpenAI-compatible server (LM Studio, Ollama, vLLM).
- **Advisory** — warns, does not fail the exit code (it's a model choice, not an m3 defect).
- **Never false-alarms** — any probe error returns `None` (silent).

## Validated live
- gemma-4-26b thinking **off** → `✅ reachable`, silent.
- gemma-4-26b thinking **on** → `⚠️ reasoning/thinking is ON … will be SLOW and may yield 0 parseable facts`.

Hermetic unit tests cover `_classify_thinking` across all four reasoning shapes + the empty/plain/malformed cases.