### PR TITLE
Fix silently-stopped chatlog spill drainage after governor migration

### DIFF
--- a/bin/chatlog_embed_sweeper.py
+++ b/bin/chatlog_embed_sweeper.py
@@ -30,18 +30,35 @@ import chatlog_config
 logger = logging.getLogger("chatlog_embed_sweeper")
 
 
-async def drain_spill(conn: sqlite3.Connection) -> int:
+async def drain_spill(conn=None) -> int:
     """
-    Drain spill JSONL files back into the chat log DB(s).
+    Drain spill JSONL files back into the chat log store(s).
 
     Spilled items written after the DB-parameter refactor carry the target
     path they were enqueued against (``_db_path``). We honor that per-item
     so rows from a session that pointed at a dedicated test/benchmark DB
     don't silently land in the live store. Legacy spill items without
-    ``_db_path`` fall back to ``conn`` (the sweeper's connection).
+    ``_db_path`` fall back to the live resolver.
 
-    Returns count of rows inserted across all target DBs.
+    Reinsertion delegates to ``chatlog_core._executemany_insert`` — the SAME
+    writer the live chatlog path uses — rather than a second INSERT maintained
+    here (§10a: duplicated SQL is the defect; copies drift). That gets backend
+    portability for free (``memory_items``/``?`` on SQLite, ``chat_log_items``/
+    ``%s`` on PostgreSQL) and, critically, writes ALL 22 columns. A spill line is
+    the queued item verbatim, so ``user_id``/``scope`` (tenancy — see
+    ``Dialect.scope_predicates``), ``content_hash`` (dedup) and ``origin_device``
+    survive the round-trip.
+
+    Spill is NOT a SQLite-only concern — ``chatlog_core._spill_batch`` fires on
+    ANY flush exception and on queue-full backpressure, regardless of backend,
+    and a PG outage is precisely when spill accumulates.
+
+    ``conn`` is accepted for backwards compatibility and ignored.
+
+    Returns count of rows inserted across all target stores.
     """
+    from memory.backends import active_backend
+
     spill_dir = chatlog_config.SPILL_DIR
     if not os.path.exists(spill_dir):
         return 0
@@ -50,11 +67,7 @@ async def drain_spill(conn: sqlite3.Connection) -> int:
     if not spill_files:
         return 0
 
-    insert_sql = (
-        "INSERT OR IGNORE INTO memory_items "
-        "(id, content, title, metadata_json, type, agent_id, conversation_id, is_deleted, created_at, variant) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-    )
+    _backend = active_backend()
 
     total_drained = 0
     for spill_path in spill_files:
@@ -73,68 +86,95 @@ async def drain_spill(conn: sqlite3.Connection) -> int:
                         logger.warning("Skipping malformed JSON in %s: %s", spill_path, e)
                         continue
 
-                    memory_id = doc.get("_id") or str(uuid.uuid4())
-                    content = doc.get("_content", doc.get("content", ""))
-                    title = doc.get("_title", "")
-                    conversation_id = doc.get("conversation_id", "")
+                    # Normalise a spilled doc back into the shape the canonical
+                    # writer expects. A spill line is the QUEUED item verbatim
+                    # (`{**item, "_id", "_title", "_content", "_metadata_json",
+                    # "_created_at", "_db_path"}`), so every field the live write
+                    # path uses — user_id, scope, origin_device, valid_from, … —
+                    # is already here; only the private keys need defaulting for
+                    # legacy/hand-written lines.
                     host_agent = doc.get("host_agent", "unknown")
-                    variant = doc.get("variant")
-                    timestamp = (
-                        doc.get("_created_at")
-                        or doc.get("timestamp")
-                        or datetime.now(timezone.utc).isoformat()
-                    )
-
-                    if doc.get("_metadata_json"):
-                        metadata_json = doc["_metadata_json"]
-                    else:
-                        metadata = {
+                    doc.setdefault("_id", str(uuid.uuid4()))
+                    doc.setdefault("_content", doc.get("content", ""))
+                    doc.setdefault("_title", "")
+                    doc.setdefault("_created_at",
+                                   doc.get("timestamp")
+                                   or datetime.now(timezone.utc).isoformat())
+                    doc.setdefault("conversation_id", "")
+                    doc.setdefault("model_id", doc.get("model_id", "unknown"))
+                    if not doc.get("agent_id"):
+                        doc["agent_id"] = f"{host_agent}:spill"
+                    if not doc.get("_metadata_json"):
+                        doc["_metadata_json"] = json.dumps({
                             "role": doc.get("role", "unknown"),
                             "provider": doc.get("provider", "unknown"),
                             "model_id": doc.get("model_id", "unknown"),
                             "host_agent": host_agent,
                             "spill_source": True,
-                        }
-                        metadata_json = json.dumps(metadata)
+                        })
 
-                    agent_id = doc.get("agent_id") or f"{host_agent}:spill"
-
-                    row = (
-                        memory_id, content, title, metadata_json,
-                        "chat_log", agent_id, conversation_id, 0,
-                        timestamp, variant,
-                    )
-                    per_db.setdefault(doc.get("_db_path"), []).append(row)
+                    per_db.setdefault(doc.get("_db_path"), []).append(doc)
 
             file_drained = 0
             had_error = False
             for db_path, rows in per_db.items():
                 if not rows:
                     continue
-                # Open a fresh short-lived connection for any path that
-                # differs from the sweeper's conn. This is the drain path —
-                # not hot — so the overhead is acceptable.
-                target_conn = conn
-                own_conn = False
-                if db_path and os.path.abspath(db_path) != os.path.abspath(getattr(conn, "_m3_db_path", "")):
-                    try:
-                        target_conn = sqlite3.connect(db_path, timeout=10)
-                        own_conn = True
-                    except sqlite3.Error as e:
-                        logger.error("Cannot open spill target DB %s: %s", db_path, e)
-                        had_error = True
-                        continue
-                try:
-                    target_conn.executemany(insert_sql, rows)
-                    target_conn.commit()
-                    file_drained += len(rows)
-                    logger.info("Drained %d rows from %s -> %s", len(rows), spill_path, db_path or "<sweeper-conn>")
-                except sqlite3.Error as e:
-                    logger.error("Failed to insert drained rows from %s into %s: %s", spill_path, db_path, e)
+                # A captured _db_path whose PARENT DIRECTORY is gone is a stale
+                # target — a deleted benchmark tree, an old engine root. Opening
+                # it would silently CREATE the directory and an empty database,
+                # write the turns into that orphan store, and then delete the
+                # spill file: the rows are "drained" into a DB nobody reads.
+                # Refuse, keep the spill file, and say so (§3 — fail loud, and
+                # never discard the only copy of a turn).
+                #
+                # SQLite ONLY, gated on capability, never on `!= postgres` (§10a).
+                # On a pooled backend `_db_path` is a LABEL, not a location
+                # (§10) — a filesystem check on it is meaningless and, worse,
+                # non-deterministic: os.path.abspath() resolves a bare label
+                # against the CWD, so the same spill row drains from one working
+                # directory and is refused from another. A DSN-shaped label
+                # ("postgresql://host/db") fails the check outright and would
+                # strand PG spill permanently. The orphan-store hazard is
+                # inherently SQLite's — a server backend cannot be conjured by
+                # connecting to it.
+                if (db_path and _backend.name == "sqlite"
+                        and not os.path.isdir(os.path.dirname(os.path.abspath(db_path)))):
+                    logger.error(
+                        "Spill target %s is stale (parent directory missing) — "
+                        "refusing to create an orphan store. Keeping %s; "
+                        "re-point or remove the stale rows to drain it.",
+                        db_path, spill_path)
                     had_error = True
-                finally:
-                    if own_conn:
-                        target_conn.close()
+                    continue
+
+                # Reuse the CANONICAL chatlog writer rather than a second INSERT
+                # here (§10a — duplicated SQL is the defect; copies drift). It
+                # already groups by `_db_path`, activates it, routes through
+                # M3Context.get_chatlog_conn(), and writes all 22 columns via
+                # the seam on either backend.
+                #
+                # This is not a style preference: the hand-rolled INSERT this
+                # replaces wrote only 10 columns, silently dropping user_id and
+                # scope (both NULL-defaulted) — so a drained turn carried NO
+                # tenancy and became invisible to, or leaked across,
+                # Dialect.scope_predicates filtering (§7). It also dropped
+                # content_hash (breaking dedup) and origin_device (whose column
+                # default is the literal 'macbook', mislabelling every drained
+                # row on a Windows or Linux host). The spill file carried all of
+                # it; only the reinsertion threw it away.
+                try:
+                    from chatlog_core import _executemany_insert
+                    written = await asyncio.to_thread(_executemany_insert, rows)
+                    file_drained += written
+                    logger.info("Drained %d rows from %s -> %s",
+                                written, spill_path, db_path or "<live resolver>")
+                except Exception as e:  # noqa: BLE001 — per-target isolation
+                    # Backend-agnostic: sqlite3.Error and psycopg2.Error are
+                    # unrelated types, so catch broadly and keep the spill file.
+                    logger.error("Failed to insert drained rows from %s into %s: %s: %s",
+                                 spill_path, db_path, type(e).__name__, e)
+                    had_error = True
 
             total_drained += file_drained
 
@@ -357,10 +397,28 @@ async def main() -> int:
     # elapsed" since the monotonic clock is far past 60 at runtime).
     deadline_s = None if _deadline <= 0 else time.monotonic() + _deadline
 
-    # Open DB connection
+    # Spill drainage is backend-agnostic and must run BEFORE the SQLite-only
+    # setup below (§10a/§3). chatlog_core._spill_batch fires on any flush
+    # exception and on queue-full backpressure regardless of backend, and this
+    # task is installed regardless of backend — so gating the drain behind a
+    # local .db file made it a silent no-op on PostgreSQL, stranding spilled
+    # turns on disk with only a log line. drain_spill() routes through the seam.
+    early_spill_drained = 0
+    if args.drain_spill or os.path.exists(chatlog_config.SPILL_DIR):
+        early_spill_drained = await drain_spill()
+        if early_spill_drained > 0:
+            logger.info("Drained %d rows from spill", early_spill_drained)
+
+    # Open DB connection. The embedding half below is still SQLite-bound (raw
+    # sqlite3 cursors + embed_sweep_lib); on a PG deployment the backfill runs
+    # via the cognitive loop's embed pass instead, so returning here after the
+    # drain is correct, not a silent skip.
     db_path = chatlog_config.chatlog_db_path()
     if not os.path.exists(db_path):
-        logger.info("Chat log DB does not exist yet: %s", db_path)
+        logger.info(
+            "No local chat log DB at %s (expected on a PostgreSQL-backed "
+            "deployment); spill drained: %d. Embedding backfill is handled by "
+            "the cognitive loop's embed pass.", db_path, early_spill_drained)
         return 0
 
     try:
@@ -373,7 +431,7 @@ async def main() -> int:
     start_time = asyncio.get_event_loop().time()
 
     try:
-        spill_drained = 0
+        spill_drained = early_spill_drained
         rows_embedded = 0
         batches_processed = 0
 
@@ -381,12 +439,6 @@ async def main() -> int:
         if not table_exists(conn, "memory_items"):
             logger.info("Chat log schema not initialized yet; nothing to do")
             return 0
-
-        # Drain spill if requested or if files exist
-        if args.drain_spill or os.path.exists(chatlog_config.SPILL_DIR):
-            spill_drained = await drain_spill(conn)
-            if spill_drained > 0:
-                logger.info("Drained %d rows from spill", spill_drained)
 
         # Query and embed batches via the shared embed_sweep_lib loop.
         # This delegates concurrency, batching, cursor advance, and per-

--- a/bin/governor_migration.py
+++ b/bin/governor_migration.py
@@ -10,11 +10,18 @@ removed so the two don't double-fire.
 Not every scheduled task is a governor candidate. We split them:
 
   GOVERNOR-ELIGIBLE (periodic, interruptible, resource-using — safe to migrate):
-    AgentOS_HourlySync          PG sync (WAL + network)
-    AgentOS_ChatlogEmbedSweep   GPU embedding backfill
     AgentOS_ObservationDrain    LLM fact-extraction from chatlog
     AgentOS_Maintenance         decay / prune (DB writes)
     AgentOS_WeeklyAuditor       audit pass (low-priority)
+
+  KEEP AS A SCHEDULED FLOOR (the loop runs the work, but a rigid entry stays):
+    AgentOS_HourlySync          PG sync (WAL + network) — governor HALTs under
+                                load; the warehouse must not drift stale.
+    AgentOS_ChatlogEmbedSweep   ALSO a floor: the governor halts under sustained
+                                load, and a spilled turn lives only on disk until
+                                drained — neither in the DB nor searchable. The
+                                loop drains it (run_embed_pass), the floor bounds
+                                how long that can be deferred.
 
   NOT MIGRATABLE (left on their schedule — the governor cannot/should not own them):
     AgentOS_SecretRotator       security/compliance-anchored: rotation must happen
@@ -43,7 +50,6 @@ import sys
 # has no execution loop of its own). Keep in sync with m3_cognitive_loop's pass
 # registry and install_schedules.get_schedule_specs().
 GOVERNOR_ELIGIBLE = (
-    "AgentOS_ChatlogEmbedSweep",   # -> loop 'embed' pass
     "AgentOS_ObservationDrain",    # -> loop 'enrich' pass (Observer/Reflector)
     "AgentOS_Maintenance",         # -> loop 'maintenance' pass
     "AgentOS_WeeklyAuditor",       # -> loop 'audit' pass
@@ -58,6 +64,10 @@ KEEP_SCHEDULED_FLOOR = (
     ("AgentOS_HourlySync",
      "governor-paced in-loop AND kept as an hourly floor — the governor HALTs "
      "under load, and the warehouse must not drift stale indefinitely"),
+    ("AgentOS_ChatlogEmbedSweep",
+     "governor-paced in-loop AND kept as a low-frequency floor — the governor "
+     "HALTs under sustained load, and undrained spill is unbounded data at risk "
+     "on disk (a spilled turn is not in the DB and not searchable until drained)"),
 )
 
 # (name, reason) — surfaced to the user so they know WHY these stay scheduled.

--- a/bin/m3_cognitive_loop.py
+++ b/bin/m3_cognitive_loop.py
@@ -795,17 +795,47 @@ def _embed_target_dbs(core_db: Optional[str]) -> list[str]:
     return out
 
 
-def has_embed_work(core_db: Optional[str]) -> bool:
-    """SQL check: are there memory_items rows with no embedding yet?
+def has_spill_work() -> bool:
+    """Are there chatlog spill files waiting to be drained into a store?
 
-    These accumulate when memory_write deferred embedding (no fast embedder
-    available at write time — the zero-lag path). embed_backfill's own
+    Spill is written by the chatlog writer when it cannot reach the DB (lock
+    contention, a wedged store). A spilled turn exists ONLY as a JSONL line on
+    disk: it is not in any DB, not FTS-searchable, and not embeddable — so it is
+    unbounded data at risk until drained. This is a cheap filesystem check (one
+    glob), deliberately independent of any DB, so a spill backlog schedules the
+    embed pass even when every store's embedding backlog is empty.
+    """
+    try:
+        import chatlog_config
+        spill_dir = chatlog_config.SPILL_DIR
+        if not spill_dir or not os.path.isdir(spill_dir):
+            return False
+        return any(f.endswith(".jsonl") for f in os.listdir(spill_dir))
+    except Exception as e:
+        logger.debug(f"Spill work check failed (non-fatal): {e}")
+        return False  # conservative: mirrors has_embed_work's contract
+
+
+def has_embed_work(core_db: Optional[str]) -> bool:
+    """Is there embed-pass work — unembedded rows, or spill waiting to drain?
+
+    Unembedded rows accumulate when memory_write deferred embedding (no fast
+    embedder available at write time — the zero-lag path). embed_backfill's own
     _count_pending uses the same WHERE-NOT-EXISTS query, so this is an accurate,
     cheap event-gate.
 
     Checks EVERY store the pass would drain (see _embed_target_dbs) — gating on
     the main DB alone let a split-topology chatlog backlog grow forever.
+
+    SPILL is checked FIRST and independently of the DBs: draining spill is the
+    pass's other half (see run_embed_pass), and spilled rows are invisible to
+    _count_pending precisely because they are not in a DB yet. Gating solely on
+    the row count let spill sit undrained indefinitely whenever the embedding
+    backlog happened to be empty — observed 2026-08-09, spill files from
+    2026-07-14/17 still on disk.
     """
+    if has_spill_work():
+        return True
     try:
         import embed_backfill
         for db_path in _embed_target_dbs(core_db):
@@ -867,6 +897,60 @@ def _checkpoint_wal(db_path: Optional[str]) -> None:
         logger.warning("WAL checkpoint failed (non-fatal): %s", e)
 
 
+async def _drain_chatlog_spill() -> int:
+    """Drain chatlog spill files into their target stores. Returns rows drained.
+
+    Delegates to chatlog_embed_sweeper.drain_spill — the ONE implementation of
+    this (§2). It honours each spilled row's captured `_db_path`, so rows
+    enqueued against a test/benchmark DB never land in the live store, and it
+    deletes a spill file only when every row in it landed.
+
+    Never raises (§3): spill drainage is best-effort recovery work and must not
+    abort the embed pass that follows it. Returns 0 on any failure.
+
+    Backend-agnostic (§10a): drain_spill routes through active_database +
+    M3Context.get_chatlog_conn() and takes its table name and placeholders from
+    the seam, so this works on SQLite and PostgreSQL alike. Spill is not a
+    SQLite-only concern — chatlog_core._spill_batch fires on any flush exception
+    and on queue-full backpressure regardless of backend.
+    """
+    try:
+        import chatlog_config
+        spill_dir = chatlog_config.SPILL_DIR
+        if not spill_dir or not os.path.isdir(spill_dir):
+            return 0
+
+        import chatlog_embed_sweeper
+
+        # drain_spill is declared `async` but contains no await — it is blocking
+        # file+DB work. Run it on a worker thread so it cannot stall the loop's
+        # event loop, and drive its coroutine to completion there.
+        def _drain_sync() -> int:
+            coro = chatlog_embed_sweeper.drain_spill()
+            try:
+                coro.send(None)          # no awaits inside => completes now
+            except StopIteration as done:
+                return int(done.value or 0)
+            # Defensive: a future edit adding a real await would land here
+            # rather than silently half-draining.
+            coro.close()
+            raise RuntimeError(
+                "drain_spill suspended on an await; it can no longer be "
+                "driven synchronously — run it on its own event loop."
+            )
+
+        drained = await asyncio.to_thread(_drain_sync)
+        if drained:
+            logger.info("Embed pass: drained %d spilled chatlog row(s).", drained)
+        return drained
+    except Exception as e:
+        logger.warning(
+            "Spill drain failed (non-fatal, embed sweep continues): %s: %s",
+            type(e).__name__, e,
+        )
+        return 0
+
+
 async def run_embed_pass(args):
     """Drain deferred embeddings via embed_backfill.
 
@@ -878,6 +962,23 @@ async def run_embed_pass(args):
     if not has_embed_work(args.database):
         logger.debug("No pending embed-backfill work. Skipping pass.")
         return
+
+    # Drain chatlog spill FIRST — before embedding. A spilled turn lives only as
+    # a JSONL line on disk: not in any store, not searchable, not embeddable.
+    # Draining first means rows recovered this cycle are candidates for the very
+    # same embed sweep below, instead of waiting a full cycle.
+    #
+    # This is the half of AgentOS_ChatlogEmbedSweep the loop was missing. The
+    # governor migration retires that scheduled task on the premise that this
+    # pass runs its work; before this, the pass ran only embed_backfill and
+    # nothing anywhere drained spill, so `governor migrate` silently orphaned
+    # spilled turns (observed 2026-08-09: spill from 2026-07-14/17 undrained,
+    # last_sweeper_run_at frozen at 2026-07-31).
+    #
+    # Non-fatal by construction (§3): spill drainage must never abort the embed
+    # sweep. A wedged/locked spill target is exactly when the embedding backlog
+    # most needs draining.
+    await _drain_chatlog_spill()
 
     # Active embed-server recovery (§8): there IS pending embed work, which often
     # means writes deferred because the fast embedder was down. If the shared

--- a/tests/test_chatlog_spill_drain_backends.py
+++ b/tests/test_chatlog_spill_drain_backends.py
@@ -1,0 +1,261 @@
+"""chatlog spill drainage must work on EVERY supported backend.
+
+A spilled turn exists only as a JSONL line on disk — not in any store, not
+FTS-searchable, not embeddable — until `drain_spill` recovers it. Spill is
+written by `chatlog_core._spill_batch` on ANY flush exception and on queue-full
+backpressure, with no backend gating, so a PostgreSQL-backed deployment spills
+exactly like a SQLite one (a PG outage is precisely when spill accumulates).
+
+Before 2026-08-09 `drain_spill` hardcoded `INSERT OR IGNORE INTO memory_items`
+with `?` placeholders and took a `sqlite3.Connection`. On PostgreSQL that is
+wrong three independent ways — the table is `chat_log_items`, `INSERT OR IGNORE`
+is SQLite-only syntax, and the placeholder is `%s` — so spilled turns could
+never be recovered. These tests pin the seam-routed behaviour (§10a).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+_BIN = Path(__file__).resolve().parents[1] / "bin"
+sys.path.insert(0, str(_BIN))
+
+
+def _write_spill(spill_dir: Path, marker: str, n: int = 3) -> list[str]:
+    """Write `n` spilled chatlog turns and return their ids."""
+    spill_dir.mkdir(parents=True, exist_ok=True)
+    ids = [str(uuid.uuid4()) for _ in range(n)]
+    with (spill_dir / "20260809.jsonl").open("w", encoding="utf-8") as fh:
+        for i, rid in enumerate(ids):
+            fh.write(json.dumps({
+                "_id": rid,
+                "_content": f"{marker} turn {i}",
+                "_title": "spill-drain-test",
+                "role": "user",
+                "conversation_id": f"{marker}-conv",
+                "host_agent": "pytest",
+                "_created_at": "2026-08-09T00:00:00Z",
+            }) + "\n")
+    return ids
+
+
+def _drain_and_count(marker: str) -> tuple[int, int]:
+    """Run the shipped drain_spill and count what landed. Returns (drained, found)."""
+    import chatlog_embed_sweeper
+    from m3_sdk import M3Context
+    from memory.backends import chatlog_table, dialect
+
+    drained = asyncio.run(chatlog_embed_sweeper.drain_spill())
+
+    ctx = M3Context.for_db(None)
+    with ctx.get_chatlog_conn() as conn:
+        cur = conn.execute(
+            f"SELECT COUNT(*) FROM {chatlog_table('items')} "
+            f"WHERE conversation_id = {dialect().param()}",
+            (f"{marker}-conv",),
+        )
+        found = cur.fetchone()[0]
+    return drained, found
+
+
+def test_drain_spill_sqlite(tmp_path, monkeypatch):
+    """SQLite: spilled turns land in memory_items and the spill file is removed."""
+    from conftest import create_full_main_schema
+
+    db = tmp_path / "chatlog.db"
+    create_full_main_schema(str(db))
+    monkeypatch.setenv("M3_DATABASE", str(db))
+    monkeypatch.setenv("M3_CHATLOG_DB_PATH", str(db))
+
+    import chatlog_config
+    spill_dir = tmp_path / "spill"
+    monkeypatch.setattr(chatlog_config, "SPILL_DIR", str(spill_dir))
+
+    marker = f"vv-{uuid.uuid4().hex[:10]}"
+    _write_spill(spill_dir, marker)
+
+    drained, found = _drain_and_count(marker)
+    assert drained == 3
+    assert found == 3
+    # A fully-drained file is deleted; a partially-failed one is KEPT (never
+    # discard rows that did not land).
+    assert not list(spill_dir.glob("*.jsonl"))
+
+
+@pytest.mark.requires_pg
+def test_drain_spill_postgres(tmp_path, monkeypatch, pg_url):
+    """PostgreSQL: the same drain lands rows in chat_log_items via the seam.
+
+    This is the case the pre-2026-08-09 implementation could not do at all.
+    """
+    monkeypatch.setenv("M3_PRIMARY_PG_URL", pg_url)
+    monkeypatch.setenv("M3_PG_URL", pg_url)
+    monkeypatch.setenv("M3_DB_BACKEND", "postgres")
+
+    from memory.backends import dialect
+    # Guard against a silent sqlite fallback reporting a hollow pass.
+    assert dialect().backend == "postgres", (
+        f"expected the postgres dialect, resolved {dialect().backend!r} — "
+        "the test would otherwise 'pass' without exercising PG at all"
+    )
+
+    import chatlog_config
+    spill_dir = tmp_path / "spill"
+    monkeypatch.setattr(chatlog_config, "SPILL_DIR", str(spill_dir))
+
+    marker = f"vv-{uuid.uuid4().hex[:10]}"
+    _write_spill(spill_dir, marker)
+
+    drained, found = _drain_and_count(marker)
+    assert drained == 3
+    assert found == 3
+    assert not list(spill_dir.glob("*.jsonl"))
+
+
+def test_drain_preserves_tenancy_and_provenance_fields(tmp_path, monkeypatch):
+    """§7: a drained turn must keep user_id/scope, or it loses its tenancy.
+
+    `Dialect.scope_predicates` filters every search by user_id + scope. A row
+    inserted without them is invisible to its owner's scoped search — or worse,
+    unscoped. content_hash backs dedup, and origin_device's column DEFAULT is
+    the literal 'macbook', so omitting it mislabels every drained row on a
+    Windows or Linux host.
+
+    The spill file carries all of this (a spill line is the queued item
+    verbatim). Regression for a drain that hand-rolled a 10-column INSERT and
+    silently dropped the other 12 (2026-08-09).
+    """
+    from conftest import create_full_main_schema
+
+    db = tmp_path / "chatlog.db"
+    create_full_main_schema(str(db))
+    monkeypatch.setenv("M3_DATABASE", str(db))
+    monkeypatch.setenv("M3_CHATLOG_DB_PATH", str(db))
+
+    import chatlog_config
+    spill_dir = tmp_path / "spill"
+    spill_dir.mkdir()
+    monkeypatch.setattr(chatlog_config, "SPILL_DIR", str(spill_dir))
+
+    marker = f"vv-{uuid.uuid4().hex[:10]}"
+    rid = str(uuid.uuid4())
+    (spill_dir / "t.jsonl").write_text(json.dumps({
+        "_id": rid,
+        "_content": "tenant-scoped turn",
+        "_title": "t",
+        "_created_at": "2026-08-09T00:00:00Z",
+        "conversation_id": f"{marker}-conv",
+        "user_id": "tenant-alice",
+        "scope": "private",
+        "origin_device": "test-device-01",
+        "model_id": "claude-opus-5",
+        "host_agent": "claude-code",
+    }) + "\n", encoding="utf-8")
+
+    import chatlog_embed_sweeper
+    assert asyncio.run(chatlog_embed_sweeper.drain_spill()) == 1
+
+    from m3_sdk import M3Context
+    from memory.backends import chatlog_table, dialect
+    ctx = M3Context.for_db(None)
+    with ctx.get_chatlog_conn() as conn:
+        row = conn.execute(
+            f"SELECT user_id, scope, origin_device, content_hash, model_id "
+            f"FROM {chatlog_table('items')} WHERE id = {dialect().param()}",
+            (rid,),
+        ).fetchone()
+
+    assert row is not None, "drained row not found"
+    user_id, scope, origin_device, content_hash, model_id = row
+    assert user_id == "tenant-alice", "tenancy lost — row escapes scope_predicates"
+    assert scope == "private", "scope lost — row escapes scope_predicates"
+    assert origin_device == "test-device-01", "origin_device lost (column default is 'macbook')"
+    assert content_hash, "content_hash missing — dedup broken"
+    assert model_id == "claude-opus-5"
+
+
+@pytest.mark.requires_pg
+def test_stale_target_guard_is_sqlite_only(tmp_path, monkeypatch, pg_url):
+    """§10/§10a: the stale-target guard must NOT run on a pooled backend.
+
+    On PostgreSQL `_db_path` is a LABEL, not a location, so a filesystem check
+    on it is meaningless — and non-deterministic: os.path.abspath() resolves a
+    bare label against the CWD (drains from one working directory, refused from
+    another), while a DSN-shaped label fails outright and would strand PG spill
+    permanently. Regression for a guard added and corrected on 2026-08-09; the
+    first version gated on nothing and would have refused every PG drain whose
+    label did not happen to look like a local relative path.
+    """
+    monkeypatch.setenv("M3_PRIMARY_PG_URL", pg_url)
+    monkeypatch.setenv("M3_PG_URL", pg_url)
+    monkeypatch.setenv("M3_DB_BACKEND", "postgres")
+
+    from memory.backends import dialect
+    assert dialect().backend == "postgres"
+
+    import chatlog_config
+    spill_dir = tmp_path / "spill"
+    spill_dir.mkdir()
+    monkeypatch.setattr(chatlog_config, "SPILL_DIR", str(spill_dir))
+
+    marker = f"vv-{uuid.uuid4().hex[:10]}"
+    # A DSN-shaped label: no such directory exists anywhere on disk.
+    (spill_dir / "pg.jsonl").write_text(json.dumps({
+        "_id": str(uuid.uuid4()),
+        "_content": "pg spilled turn",
+        "conversation_id": f"{marker}-conv",
+        "_db_path": "postgresql://db.internal:5432/m3",
+    }) + "\n", encoding="utf-8")
+
+    drained, found = _drain_and_count(marker)
+    assert drained == 1, "PG spill was refused by a SQLite-only filesystem guard"
+    assert found == 1
+    assert not list(spill_dir.glob("*.jsonl"))
+
+
+def test_drain_spill_refuses_stale_target_and_keeps_file(tmp_path, monkeypatch):
+    """§3: a stale `_db_path` must not silently conjure an orphan store.
+
+    SQLite creates a database on connect, and the seam creates missing parent
+    directories — so a spilled row pointing at a deleted tree (an old engine
+    root, a removed benchmark DB) would be written into a brand-new empty file
+    nobody reads, and the spill file deleted afterwards. The turns would be
+    reported "drained" and be effectively lost.
+
+    Found 2026-08-09 while adding the backend V&V above: the write SUCCEEDED
+    against a path whose parent directory did not exist. Guard: refuse the
+    target, keep the spill file, log loudly.
+    """
+    from conftest import create_full_main_schema
+
+    db = tmp_path / "chatlog.db"
+    create_full_main_schema(str(db))
+    monkeypatch.setenv("M3_DATABASE", str(db))
+    monkeypatch.setenv("M3_CHATLOG_DB_PATH", str(db))
+
+    import chatlog_config
+    spill_dir = tmp_path / "spill"
+    monkeypatch.setattr(chatlog_config, "SPILL_DIR", str(spill_dir))
+
+    marker = f"vv-{uuid.uuid4().hex[:10]}"
+    _write_spill(spill_dir, marker)
+
+    # Point a spilled row at an unwritable target so its group fails.
+    bad = spill_dir / "20260810.jsonl"
+    bad.write_text(json.dumps({
+        "_id": str(uuid.uuid4()),
+        "_content": "unroutable",
+        "conversation_id": f"{marker}-conv",
+        "_db_path": str(tmp_path / "nonexistent-dir" / "nope.db"),
+    }) + "\n", encoding="utf-8")
+
+    import chatlog_embed_sweeper
+    asyncio.run(chatlog_embed_sweeper.drain_spill())
+
+    # The good file drained and is gone; the failing one is retained.
+    assert bad.exists(), "a spill file with an undrained row must be kept, not deleted"

--- a/tests/test_governor_migration.py
+++ b/tests/test_governor_migration.py
@@ -6,6 +6,7 @@ and never touch the real host scheduler.
 from __future__ import annotations
 
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
@@ -72,6 +73,64 @@ def test_sync_runs_via_both_governor_and_scheduled_task_all_oses():
     assert "AgentOS_HourlySync" in {n for n, _ in gm.KEEP_SCHEDULED_FLOOR}
 
 
+def test_chatlog_embed_sweep_is_a_kept_floor_not_eligible():
+    """Regression guard: the chatlog embed sweep must NEVER be in the removal set.
+
+    Its work IS governor-appropriate (GPU backfill + spill drain, both periodic
+    and interruptible) and the loop's 'embed' pass now runs both halves — but the
+    scheduled entry is kept as a low-frequency FLOOR, exactly like
+    AgentOS_HourlySync. Rationale: the governor HALTs background passes under
+    sustained load, and a spilled turn lives ONLY as a JSONL line on disk until
+    drained — not in any store, not searchable. Indefinite deferral of that is
+    unbounded data at risk, so a rigid entry bounds the worst case.
+
+    GOVERNOR_ELIGIBLE means "delete this scheduler entry", not "the loop runs
+    it" — a floor task must never appear there (see HourlySync, which the loop
+    also runs as a pass).
+
+    History: `governor migrate` deleted this task on the premise the loop ran its
+    work, when the loop ran only embed_backfill and nothing drained spill.
+    Observed 2026-08-09: spill from 2026-07-14/17 undrained, last_sweeper_run_at
+    frozen at 2026-07-31.
+    """
+    floor = {n for n, _ in gm.KEEP_SCHEDULED_FLOOR}
+    assert "AgentOS_ChatlogEmbedSweep" in floor
+    assert "AgentOS_ChatlogEmbedSweep" not in gm.GOVERNOR_ELIGIBLE
+
+
+def test_loop_embed_pass_drains_spill():
+    """The invariant GOVERNOR_ELIGIBLE documents: a task may only be retired into
+    the loop if the loop genuinely executes its work.
+
+    The loop's 'embed' pass must drain chatlog spill, not merely embed rows that
+    are already in a store. Spilled rows are invisible to embed_backfill's
+    _count_pending (they are not in any DB yet), so a pass that only embeds
+    leaves them on disk forever.
+
+    Asserts the MECHANISM rather than a name list, so it stays meaningful if the
+    task is ever re-classified.
+    """
+    import pathlib
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    loop_src = (repo / "bin" / "m3_cognitive_loop.py").read_text(encoding="utf-8")
+
+    assert "_drain_chatlog_spill" in loop_src, (
+        "the cognitive loop no longer defines a spill-drain step; the embed pass "
+        "would silently stop recovering spilled chatlog turns"
+    )
+    assert "drain_spill" in loop_src, (
+        "spill drainage must delegate to chatlog_embed_sweeper.drain_spill — the "
+        "single implementation that honours each row's captured _db_path"
+    )
+    # The gate must consider spill too, or a spill-only backlog never schedules
+    # the pass (the exact hole that let 2026-07-14/17 spill sit undrained).
+    assert "def has_spill_work" in loop_src
+    assert re.search(r"def has_embed_work.*?has_spill_work\(\)", loop_src, re.S), (
+        "has_embed_work must consult has_spill_work, else a spill backlog with an "
+        "empty embedding backlog leaves the embed pass unscheduled"
+    )
+
+
 def test_floor_and_not_migratable_excluded_from_eligible(monkeypatch):
     """When all canonical tasks are installed, the floor (HourlySync) and the
     not-migratable tasks (SecretRotator/CognitiveLoop) must be EXCLUDED from the
@@ -86,8 +145,10 @@ def test_floor_and_not_migratable_excluded_from_eligible(monkeypatch):
         })
     out = gm.detect_scheduled_tasks()
     assert set(out["eligible"]) == set(gm.GOVERNOR_ELIGIBLE)
-    assert out["keep_scheduled_floor"] == ["AgentOS_HourlySync"]
-    assert "AgentOS_HourlySync" not in out["eligible"]
+    assert set(out["keep_scheduled_floor"]) == {n for n, _ in gm.KEEP_SCHEDULED_FLOOR}
+    for nm in ("AgentOS_HourlySync", "AgentOS_ChatlogEmbedSweep"):
+        assert nm in out["keep_scheduled_floor"]
+        assert nm not in out["eligible"]
     for nm in ("AgentOS_SecretRotator", "AgentOS_CognitiveLoop"):
         assert nm not in out["eligible"]
         assert nm in out["not_migratable_present"]

--- a/tests/test_loop_watchdog.py
+++ b/tests/test_loop_watchdog.py
@@ -131,8 +131,13 @@ def test_watchdog_restart_backend_per_os(monkeypatch):
     # mid-write is what tears the WAL (HALT_PROTOCOL) — the exact damage this
     # watchdog exists to prevent. SIGTERM runs the loop's checkpoint/deregister
     # path; the follow-up kickstart must NOT carry -k.
+    # os.getuid() is Unix-only; mirror the production guard
+    # (m3_loop_watchdog.py: `os.getuid() if hasattr(os, "getuid") else 0`) so this
+    # Darwin-branch assertion is evaluable on a Windows runner too (§1: the suite
+    # must go green on all three OSes, and CI's matrix includes windows-latest).
+    _uid = os.getuid() if hasattr(os, "getuid") else 0
     assert cmds[0] == ["launchctl", "kill", "SIGTERM",
-                       f"gui/{os.getuid()}/com.m3memory.cognitiveloop"]
+                       f"gui/{_uid}/com.m3memory.cognitiveloop"]
     assert "-k" not in cmds[1]
     assert cmds[1][:2] == ["launchctl", "kickstart"]
     assert "cognitiveloop" in what
@@ -187,7 +192,13 @@ def test_verify_warns_on_crashed_only_keepalive(tmp_path, capsys,
 
     # Reproduce the check verbatim rather than importing the whole Darwin-gated
     # verify path (which shells out to launchctl and needs a loaded agent).
+    # `plutil` is macOS-only: off-Darwin the spawn raises FileNotFoundError rather
+    # than returning nonzero, so the assertion below is only meaningful there
+    # (§1 — CI's matrix includes ubuntu and windows runners).
+    import shutil
     import subprocess
+    if shutil.which("plutil") is None:
+        pytest.skip("plutil is macOS-only; the KeepAlive-value check is Darwin-gated")
     r = subprocess.run(["plutil", "-extract", "KeepAlive", "raw", "-o", "-",
                         str(dest)], capture_output=True, text=True)
     warned = r.returncode != 0 or (r.stdout or "").strip() != "true"


### PR DESCRIPTION
## Description

`governor migrate` retires a scheduled task on the premise that the cognitive loop runs its work. For `AgentOS_ChatlogEmbedSweep` that premise was only **half** true: the sweeper drains chatlog spill **then** embeds, while the loop's `embed` pass called only `embed_backfill` — which vectorises rows already in a store and never touches the spill directory. Nothing anywhere drained spill, so migrating the task silently stopped that work. That is exactly the failure `GOVERNOR_ELIGIBLE`'s own comment warns about:

> a task must NOT be listed unless the loop genuinely executes its work; otherwise `governor migrate` silently stops that work

A spilled turn lives only as a JSONL line on disk — not in any store, not FTS-searchable, not embeddable. Losing the drainer is unbounded data at risk.

Observed on a live install: spill files from 2026-07-14/17 still undrained, `last_sweeper_run_at` frozen at 2026-07-31.

### Core fix
- **`m3_cognitive_loop`** — `run_embed_pass` now drains spill *before* embedding, via `_drain_chatlog_spill()` delegating to `chatlog_embed_sweeper.drain_spill` (one implementation). Draining first makes recovered rows candidates for the same sweep. Non-fatal by construction: a wedged spill target must not abort the embed pass.
- **`m3_cognitive_loop`** — new `has_spill_work()`; `has_embed_work()` consults it first. Spilled rows are invisible to `_count_pending` (not in a DB yet), so gating on the row count alone left a spill-only backlog permanently unscheduled.
- **`governor_migration`** — `AgentOS_ChatlogEmbedSweep` moves to `KEEP_SCHEDULED_FLOOR`, matching the `AgentOS_HourlySync` precedent. The work *is* governor-appropriate and the loop now runs it, but the governor HALTs under sustained load and spill must not sit indefinitely. `GOVERNOR_ELIGIBLE` means "delete this scheduler entry", so a floor task must never appear there.

### Defects found in the same path

`drain_spill` maintained its own INSERT, and everything below followed from that duplication (§10a — *duplicated SQL is the defect, independent of correctness; copies drift*). It now delegates to `chatlog_core._executemany_insert`, the **same writer the live chatlog path uses**:

- **Tenancy loss (§7).** It wrote only **10 of 22 columns**, silently dropping `user_id` and `scope` — both NULL-defaulted. `Dialect.scope_predicates` filters every search by those, so a drained turn carried **no tenancy**: invisible to its owner's scoped search, or unscoped entirely. It also dropped `content_hash` (breaking dedup) and `origin_device`, whose column DEFAULT is the literal `'macbook'` — mislabelling every drained row on a Windows or Linux host. The spill file carried all of it; only the reinsertion threw it away.
- **PostgreSQL could never recover spill.** It hardcoded `INSERT OR IGNORE INTO memory_items` with `?` placeholders and took a `sqlite3.Connection`. On PG that is wrong three independent ways — table is `chat_log_items`, `INSERT OR IGNORE` is SQLite syntax, placeholder is `%s`. Spill is **not** a SQLite-only concern: `_spill_batch` fires on any flush exception and on queue-full backpressure regardless of backend, and a PG outage is precisely when spill accumulates.
- **The scheduled task no-op'd on PostgreSQL.** `main()` gated spill drainage behind `os.path.exists(<local .db>)`. The drain now runs before that SQLite-only setup.
- **Orphan-store data loss.** A spilled row whose `_db_path` has a missing *parent directory* (a deleted benchmark tree, an old engine root) caused the seam to create the directory and an empty database, write the turns into that orphan store, and delete the spill file — reporting success while losing the only copy. Now refused, spill file kept, reason logged. The guard is gated on `backend.name == "sqlite"` (§10a — capability, never `!= postgres`): on a pooled backend `_db_path` is a **label, not a location** (§10), so a filesystem check is meaningless *and* non-deterministic — `os.path.abspath()` resolves a bare label against the CWD, and a DSN-shaped label fails outright, which would strand PG spill permanently.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass (`python run_tests.py`) — see note below
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — module docstrings + tool-catalog drift check clean
- [x] No new warnings introduced

**120 passed / 3 skipped** across the governor, schedule, watchdog and spill suites. Each new test was verified to **fail before** its corresponding fix and **pass after**.

`run_tests.py` reports pre-existing failures unrelated to this change — `test_knowledge.py` (`ModuleNotFoundError: memory.knowledge_helpers`) and `test_mcp_proxy_unit.py` reproduce identically on a clean `origin/main` worktree. The `requires_pg` suite likewise shows no new failures vs. clean `origin/main`; the single differing test passes 6/6 in isolation on both trees (pre-existing ordering pollution from a poisoned psycopg2 transaction).

### Verification
Verified live on **SQLite** and **PostgreSQL 16.14**: both drain spilled rows into the correct backend table with tenancy intact and the spill file removed. The pre-fix code cannot even be *called* in a PG context.

Two `test_loop_watchdog` tests could not run off-Darwin — one called `os.getuid()` (Unix-only) unguarded, one shelled out to macOS `plutil`. CI's matrix includes `windows-latest` and `ubuntu-latest`, so both were red there; this mirrors the production `hasattr` guard and skips the `plutil` check when absent. macOS/Linux runtime behaviour is covered by CI's matrix rather than local runs.

## Related issues
Closes #
