### PR TITLE
fix(deps): clear js-yaml (high), postcss (medium) and brace-expansion (high) advisories

### DIFF
--- a/examples/homelab-dashboard/frontend/package-lock.json
+++ b/examples/homelab-dashboard/frontend/package-lock.json
@@ -462,6 +462,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "9.39.3",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
@@ -1343,9 +1366,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1974,29 +1997,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -2383,9 +2383,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2522,9 +2522,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2542,7 +2542,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/examples/homelab-dashboard/frontend/package.json
+++ b/examples/homelab-dashboard/frontend/package.json
@@ -29,7 +29,8 @@
   },
   "overrides": {
     "vite": "^8.0.0-beta.13",
-    "brace-expansion": "^2.0.3",
-    "postcss": ">=8.5.12"
+    "brace-expansion": "^2.1.4",
+    "postcss": ">=8.5.23",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
## Description

Clears **both open Dependabot alerts** on `main`, plus a **third** that `npm audit` catches but the alert list did not surface. All three are dev-only transitive dependencies of the `homelab-dashboard` example, pinned through `overrides`.

| Package | Sev | Advisory | Was | Now |
|---|---|---|---|---|
| `js-yaml` | **high** | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution; CVE-2026-59870 fix not backported | 4.3.0 | **4.3.1** |
| `postcss` | medium | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) — incomplete fix of GHSA-6g55-p6wh-862q; attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset | 8.5.22 | **8.5.26** |
| `brace-expansion` | **high** | DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | 2.1.2 | **≥2.1.4** |

Two of the three had **stale overrides that predate their advisory**: `postcss` was pinned `>=8.5.12` (PR #99) and `brace-expansion` `^2.0.3`. Both constraints were satisfied while the installed version remained vulnerable — worth noting as a pattern, since a satisfied override reads as "handled" at a glance.

`brace-expansion` was not in the Dependabot alert list; it turned up running `npm audit` to verify the other two.

### One trap worth flagging

`js-yaml` is pinned **`^4.3.1`, not `>=4.3.1`**. The open-ended form resolved to **5.2.3** — a major bump outside the `^4.1.1` range declared by its only dependent, `@eslint/eslintrc`. The caret keeps it on the 4.x line the dependent supports while still clearing the advisory.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — `npm audit`: **0 vulnerabilities** (was 3 findings)
- [x] Lint clean — `npm run lint` runs clean **through `@eslint/eslintrc`**, the `js-yaml` consumer, confirming the 4.3.1 pin is compatible
- [x] Type check passes — `npm run build` (`tsc -b && vite build`) succeeds, vite 8.0.0-beta.16, 17 modules transformed
- [x] Documentation updated if needed — n/a (lockfile + manifest only)
- [x] No new warnings introduced

Only `package.json` and `package-lock.json` change; `node_modules/` and `dist/` are gitignored. The example app's 6 pre-existing ESLint errors (`no-explicit-any`, `no-unused-vars`, `no-empty`) reproduce identically on the original lockfile and are untouched here — they are example-app code quality, not dependency breakage.

## Related issues
Closes #
