### PR TITLE
Fix silent exit-1 in setup verification; add Windows E2E diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,23 @@ jobs:
           --config-root "$M3_E2E_ROOT/config" \
           --engine-root "$M3_E2E_ROOT/engine"
 
+    # The Windows lane has never been green and its failure mode is a SILENT
+    # one: the log ends at "Step 5/5" with exit 1 and no verdict. Print the
+    # doctor's own exit code and output on that runner so the next failure
+    # names itself instead of needing another CI round-trip to diagnose.
+    - name: Diagnose verification (Windows only, never fails the job)
+      if: runner.os == 'Windows'
+      shell: bash
+      env:
+        M3_E2E_ROOT: ${{ runner.temp }}/m3-e2e
+      run: |
+        export M3_CONFIG_ROOT="$M3_E2E_ROOT/config"
+        export M3_ENGINE_ROOT="$M3_E2E_ROOT/engine"
+        echo "--- m3 doctor (scoped, as setup runs it) ---"
+        m3 doctor --skip-shared-embedder --skip-cascade; echo "doctor exit=$?"
+        echo "--- engine root ---"
+        ls -la "$M3_E2E_ROOT/engine" || true
+
     # Belt-and-braces: setup's own exit code already encodes this, but assert
     # the resulting install is independently usable rather than trusting the
     # installer to grade its own work.

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -2543,6 +2543,26 @@ def _step_doctor(plan=None) -> bool:
         _warn("Re-run `m3 doctor` after fixing, or `m3 doctor --fix` for the "
               "issues that self-repair.")
         return False
+    except BaseException as e:  # noqa: BLE001 — see below; re-raises KeyboardInterrupt
+        # ANY other failure here used to escape _step_doctor and kill the whole
+        # wizard with a bare `exit 1` and NO output — setup printed
+        # "Step 5/5: verifying the install (m3 doctor)" and then simply died,
+        # with no summary, no verdict, and an exit code the wizard never
+        # produces itself (it returns 0/2/3). Observed on windows-latest, where
+        # the E2E lane has never been green: the log ends mid-step with
+        # "##[error]Process completed with exit code 1".
+        #
+        # A verification step that can die without saying why is the exact
+        # silent-failure class the doctor exists to catch (§3). The install
+        # itself already SUCCEEDED at this point, so the correct outcome is
+        # "installed but unverified" (exit 3) with the cause NAMED — never a
+        # silent exit 1.
+        if isinstance(e, (KeyboardInterrupt, SystemExit)):
+            raise
+        _warn(f"VERIFICATION COULD NOT RUN — {type(e).__name__}: {e}")
+        _warn("The install itself completed; only the `m3 doctor` check failed "
+              "to execute. Run `m3 doctor` manually to see the real state.")
+        return False
 
 
 # ── orchestrator ──────────────────────────────────────────────────────────────

--- a/tests/test_setup_post_install_verify.py
+++ b/tests/test_setup_post_install_verify.py
@@ -147,3 +147,35 @@ def test_doctor_without_a_plan_checks_everything(wizard, monkeypatch):
     argv = _captured_argv(wizard, monkeypatch, None)
     assert "--skip-shared-embedder" not in argv
     assert "--skip-cascade" not in argv
+
+
+def test_step_doctor_survives_a_non_calledprocess_failure(wizard, monkeypatch):
+    """A doctor that fails to EXECUTE must not kill the wizard silently.
+
+    Only CalledProcessError was caught, so any other failure (OSError spawning
+    the child, a crash before it wrote a byte) escaped _step_doctor and exited
+    the process 1 — a code the wizard never returns itself (0/2/3). On
+    windows-latest, where the E2E lane has never been green, the log ended
+    mid-step: "Step 5/5: verifying the install (m3 doctor)" followed straight by
+    "##[error]Process completed with exit code 1" — no summary, no verdict, no
+    cause. §3: fail loud, never silent.
+
+    The install has already succeeded by this point, so the right outcome is
+    "installed but unverified" (False -> exit 3) with the reason named.
+    """
+    def boom(*a, **k):
+        raise OSError(8, "Exec format error")
+    monkeypatch.setattr(wizard, "_run", boom)
+    assert wizard._step_doctor() is False, (
+        "a doctor that cannot run must be reported, not allowed to kill setup"
+    )
+
+
+def test_step_doctor_still_propagates_keyboard_interrupt(wizard, monkeypatch):
+    """Ctrl-C must stay interruptible — the catch-all must not swallow it."""
+    def interrupt(*a, **k):
+        raise KeyboardInterrupt
+    monkeypatch.setattr(wizard, "_run", interrupt)
+    import pytest as _pytest
+    with _pytest.raises(KeyboardInterrupt):
+        wizard._step_doctor()


### PR DESCRIPTION
## Description

The **Windows E2E lane has never been green** — 12 runs back, every one red. After `--force-quiesce` (#114) cleared the preflight abort, the failure moved to Step 5/5 and became *invisible*:

```
==> Step 5/5: verifying the install (m3 doctor)
##[error]Process completed with exit code 1
```

No doctor output. No summary. No verdict. And **exit 1 is a code the wizard never produces itself** — it returns 0 (clean), 2 (aborted), or 3 (installed but unverified).

### Root cause of the silence

`_step_doctor` caught **only** `CalledProcessError`. Any other failure — an `OSError` spawning the child, a crash before it wrote a byte — escaped the function and killed the whole wizard with a bare `exit 1`.

A verification step that can die without saying why is precisely the silent-failure class the doctor exists to catch (§3). The install has already **succeeded** at that point, so the correct outcome is "installed but unverified" (exit 3) with the cause **named**. `KeyboardInterrupt` and `SystemExit` still propagate — Ctrl-C stays interruptible.

### ⚠️ Scope: this makes the failure diagnosable, it does not claim to fix it

**The underlying Windows cause is still unknown.** I am not asserting otherwise. What this PR guarantees is that the next Windows run *names* its failure instead of dying mutely.

To get that answer without another blind round-trip, a **Windows-only diagnostic step** prints the doctor's own exit code, its output, and the engine-root listing. It is gated `if: runner.os == 'Windows'` and **cannot fail the job**.

I could not reproduce this locally — the failure is specific to the Windows runner's environment, and this box is a working Windows install where the same commands succeed.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **10 passed**; the new non-CalledProcessError test fails on the pre-fix wizard
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale in code comments + commit
- [x] No new warnings introduced

Workflow YAML re-validated after the edit.

## Related issues
Closes #