### PR TITLE
E2E: make the Windows diagnostic actually run (needs always())

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,17 +235,26 @@ jobs:
     # doctor's own exit code and output on that runner so the next failure
     # names itself instead of needing another CI round-trip to diagnose.
     - name: Diagnose verification (Windows only, never fails the job)
-      if: runner.os == 'Windows'
+      # `always()` is REQUIRED: without it a step is skipped once an earlier one
+      # fails, and the whole point of this step is to explain the setup failure
+      # that just happened. Placed after setup, it never ran on the very runs it
+      # exists to diagnose.
+      if: always() && runner.os == 'Windows'
       shell: bash
       env:
         M3_E2E_ROOT: ${{ runner.temp }}/m3-e2e
       run: |
         export M3_CONFIG_ROOT="$M3_E2E_ROOT/config"
         export M3_ENGINE_ROOT="$M3_E2E_ROOT/engine"
-        echo "--- m3 doctor (scoped, as setup runs it) ---"
+        echo "--- m3 doctor (scoped, exactly as setup runs it) ---"
         m3 doctor --skip-shared-embedder --skip-cascade; echo "doctor exit=$?"
+        echo "--- the same invocation setup uses, via -m ---"
+        python -m m3_memory.cli doctor --skip-shared-embedder --skip-cascade
+        echo "python -m doctor exit=$?"
         echo "--- engine root ---"
         ls -la "$M3_E2E_ROOT/engine" || true
+        echo "--- config root ---"
+        ls -la "$M3_E2E_ROOT/config" || true
 
     # Belt-and-braces: setup's own exit code already encodes this, but assert
     # the resulting install is independently usable rather than trusting the


### PR DESCRIPTION
## Description

The Windows diagnostic step added in #115 **never executed on a single one of the runs it exists to explain.**

GitHub Actions skips subsequent steps once a step fails, and this one sits *after* the setup step that dies — so on every failing run it was silently skipped, and the log still ended at:

```
==> Step 5/5: verifying the install (m3 doctor)
##[error]Process completed with exit code 1
```

My placement error: a post-mortem step must be `if: always()`, or it only runs when there is nothing to post-mortem.

### Also widened, so one run yields the answer

The step now runs **both** invocation forms — the `m3` console script and the `python -m m3_memory.cli doctor` form setup actually uses (a launcher-stub vs module-invocation difference is a real Windows failure class) — prints each exit code, and lists both roots.

Still gated `runner.os == 'Windows'`, still cannot fail the job.

### Status of the underlying bug

**Unresolved, and I'm not claiming otherwise.** What is now known:

- The Windows E2E lane has never been green (12+ runs).
- `--force-quiesce` (#114) fixed the preflight abort; the failure moved later.
- The wizard dies at Step 5/5 with exit 1 — a code it never returns itself (0/2/3).
- #115's catch-all did **not** fire, so it is not a Python exception escaping `_step_doctor`; the process is being terminated.
- `taskkill` uses `/PID /F` without `/T`, so setup is not killing its own tree.

This PR is the instrument that should name it on the next run.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — workflow-only change
- [x] Lint clean — no Python touched
- [x] Type check passes — no Python touched
- [x] Documentation updated if needed — rationale in the workflow comment
- [x] No new warnings introduced

YAML re-validated; `if` condition confirmed as `always() && runner.os == 'Windows'`.

## Related issues
Closes #