### PR TITLE
E2E diagnostic: reproduce the doctor call as a child and capture both streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,26 @@ jobs:
         echo "--- the same invocation setup uses, via -m ---"
         python -m m3_memory.cli doctor --skip-shared-embedder --skip-cascade
         echo "python -m doctor exit=$?"
+        # The setup step's child dies writing NOTHING — not one byte reaches the
+        # log, on a step whose ubuntu twin streams the full doctor report. The
+        # steps above run that same command standalone and both exit 0, so the
+        # difference is the CHILD-OF-SETUP context, not the command. Reproduce
+        # it: spawn exactly as _step_doctor does, with the parent's re-exec
+        # sentinel present, and CAPTURE both streams instead of streaming them.
+        echo "--- as a CHILD, with the parent's UTF-8 re-exec sentinel set ---"
+        cat > "$RUNNER_TEMP/probe_child.py" <<'PYEOF'
+        import os, subprocess, sys
+        argv = [sys.executable, "-m", "m3_memory.cli", "doctor",
+                "--skip-shared-embedder", "--skip-cascade"]
+        print("sentinel:", os.environ.get("_M3_UTF8_REEXEC"))
+        r = subprocess.run(argv, capture_output=True, text=True,
+                           errors="backslashreplace")
+        print("rc:", r.returncode)
+        print("stdout[:400]:", repr(r.stdout[:400]))
+        print("stderr[:800]:", repr(r.stderr[:800]))
+        PYEOF
+        sed -i 's/^        //' "$RUNNER_TEMP/probe_child.py"
+        _M3_UTF8_REEXEC=1 python "$RUNNER_TEMP/probe_child.py" || true
         echo "--- engine root ---"
         ls -la "$M3_E2E_ROOT/engine" || true
         echo "--- config root ---"


### PR DESCRIPTION
## Description

The first diagnostic (#116) answered one question and sharpened the next. **Both standalone forms of the verification command exit 0** on the Windows runner:

```
m3 doctor --skip-shared-embedder --skip-cascade        -> doctor exit=0
python -m m3_memory.cli doctor --skip-... --skip-...   -> exit=0
```

Yet inside setup, the same command dies having written **nothing** — not one byte, in a step whose ubuntu twin streams the entire doctor report. The failure is not the command and not the doctor: it is the **child-of-setup context**.

### Hypotheses eliminated, each by measurement

| Theory | Ruled out by |
|---|---|
| a doctor verdict | both standalone forms exit 0 |
| a Python exception escaping `_step_doctor` | the catch-all from #115 never fired |
| a killed process tree | `taskkill` uses `/PID /F`, no `/T` |
| missing roots in the child | setup exports them to `os.environ` before spawning |
| cp1252 `UnicodeEncodeError` on the doctor's glyphs | `reconfigure()` fallback handles it even with the sentinel set — verified locally, rc=0, glyphs printed |

### What is still untested

`m3 setup` enters through `cli.py`, so it **re-execs and sets `_M3_UTF8_REEXEC=1`** in its environment. The doctor child inherits that sentinel and therefore **skips its own re-exec**, running in a different interpreter mode than either standalone invocation above.

This step reproduces exactly that — same argv, sentinel set — and **captures** stdout/stderr rather than streaming them, so a child that dies before writing to a stream still surfaces its error.

Windows-only, `if: always()`, cannot fail the job.

## Type of change
- [x] Bug fix (non-breaking) — diagnostic instrumentation toward one
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — workflow-only change
- [x] Lint clean — no Python touched
- [x] Type check passes — no Python touched
- [x] Documentation updated if needed — reasoning in the workflow comment + commit
- [x] No new warnings introduced

YAML validated; heredoc balance and the dedent both verified locally (a YAML-indented heredoc body would otherwise be an `IndentationError`).

## Related issues
Closes #