### PR TITLE
Release 2026.8.19.11 — chatlog spill drainage, three CVEs, and a CI that had stopped telling the truth

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.10",
+  "version": "2026.8.19.11",
   "description": "Give Antigravity a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.10",
+  "version": "2026.8.19.11",
   "description": "Give Claude Code a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,92 @@ the policy is forward-going only.
 
 ### None pending
 
+## [2026.8.19.11] — 2026-08-10 — a silently-stopped chatlog drain, three CVEs, and a CI that had stopped telling the truth
+
+> Every fix here came from one thread: `m3 doctor` reported a stale
+> `last_write_at`, and pulling on it surfaced a chatlog subsystem that had
+> silently stopped recovering data, then a security scan that had never
+> actually run, then a test suite that was green for the wrong reasons.
+
+### Fixed
+
+- **`governor migrate` silently stopped chatlog spill drainage.** The migration
+  retires a scheduled task on the premise that the cognitive loop runs its work.
+  For `AgentOS_ChatlogEmbedSweep` that was only half true: the sweeper drains
+  spill **then** embeds, while the loop's `embed` pass called only
+  `embed_backfill` — which vectorises rows already in a store and never touches
+  the spill directory. Nothing anywhere drained spill. A spilled turn lives only
+  as a JSONL line on disk: not in any store, not FTS-searchable, not embeddable.
+  The loop now drains spill before embedding, `has_embed_work` consults spill
+  (a spill-only backlog previously never scheduled the pass), and the task is
+  kept as a low-frequency scheduled floor because the governor HALTs under load.
+
+- **Spill could never be recovered on PostgreSQL.** `drain_spill` hardcoded
+  `INSERT OR IGNORE INTO memory_items` with `?` placeholders and took a
+  `sqlite3.Connection` — wrong three independent ways on PG (the table is
+  `chat_log_items`, `INSERT OR IGNORE` is SQLite syntax, the placeholder is
+  `%s`). Spill is **not** a SQLite-only concern: it fires on any flush exception
+  and on queue-full backpressure regardless of backend, and a PG outage is
+  precisely when it accumulates. Reinsertion now delegates to the canonical
+  chatlog writer, which also fixes a **tenancy defect**: the hand-rolled INSERT
+  wrote 10 of 22 columns, dropping `user_id` and `scope`, so a recovered turn
+  carried no tenancy and escaped `scope_predicates` filtering. It also dropped
+  `content_hash` (dedup) and `origin_device`, whose column default mislabelled
+  every drained row on Windows and Linux.
+
+- **The scheduled sweep no-op'd entirely on PostgreSQL** — it gated spill
+  drainage behind the existence of a local `.db` file.
+
+- **A stale `_db_path` could conjure an orphan store.** A spilled row pointing at
+  a deleted tree caused the seam to create the directory and an empty database,
+  write the turns there, and delete the spill file — reporting success while
+  losing the only copy. Now refused, the file kept, the reason logged.
+
+### Security
+
+- **`cryptography` 48.0.1 → >=50.0.0** — three advisories: a PKCS#7
+  Bleichenbacher oracle (PYSEC-2026-3552), exponential path-building DoS
+  (PYSEC-2026-3553), and a wildcard-DNS escape from `permittedSubtrees`
+  (PYSEC-2026-3554). The existing `<49` cap structurally blocked all three
+  fixes. **These were live because the security job never reached `pip-audit`:**
+  a Bandit `B310` finding on a hardcoded HTTPS literal failed the step first, so
+  a green-looking gate had been hiding real CVEs behind a lint error.
+
+- **Example frontend:** `js-yaml` (high), `postcss` (medium) and
+  `brace-expansion` (high) advisories cleared; `npm audit` reports 0. Two of the
+  three already had `overrides` that predated their advisory — satisfied
+  constraints that read as "handled" while the installed version stayed
+  vulnerable.
+
+### Changed
+
+- **CI verification no longer grades subsystems the install declined.**
+  `m3 setup --no-shared-embedder` printed "SKIPPED (not installed). This is
+  fine" and then failed the run on the absence it had just requested. A
+  verification that fails on a supported configuration measures the wrong thing
+  and trains people to ignore it.
+
+- **`m3 setup` can no longer die silently during verification.** `_step_doctor`
+  caught only `CalledProcessError`; any other failure escaped and killed the
+  wizard with a bare `exit 1` — a code the wizard never returns itself (0/2/3).
+  It now reports "installed but unverified" with the cause named.
+
+- **Four tests were green for the wrong reasons** and are now hermetic: two
+  shelled out to a real binary or the network, one asserted a hardcoded tool
+  count that had rotted 63 → 110, and one compared Windows path separators
+  against forward-slash literals. `mcp_proxy` also moved off FastAPI's
+  deprecated `on_event`, which under `filterwarnings = ["error"]` had been
+  erroring out all 12 tests in its suite at import.
+
+### Known issues
+
+- **The Windows E2E lane is still red and has never been green.** `m3 setup`
+  exits 1 at the verification step with no output on either stream, while the
+  identical command exits 0 standalone and as a spawned child. Every hypothesis
+  tested so far is eliminated by measurement; the next step is capturing the
+  child's streams inside `_step_doctor`. The ubuntu and macOS E2E lanes and all
+  six test-matrix jobs are green.
+
 ## [2026.8.19.10] — 2026-08-09 — the Anthropic wire, and a truncated reply is no longer "no result"
 
 > Supersedes 2026.8.19.9, which shipped the same code with an inaccurate

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.8.19.10",
+  "version": "2026.8.19.11",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.8.19.10"
+version = "2026.8.19.11"
 description = "Give your AI agent a memory — local-first, private, easy to install. Guided setup wizard; works out of the box on your own machine, no cloud. For everyday agent users, homelabs, and developers alike · 99.2% LongMemEval-S retrieval @ k=10 · Works with Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · any MCP agent (native + one-command plugins) · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first memory — 100+ tools, 99.2% LongMemEval-S retrieval@10, hybrid search, GDPR, no cloud.",
-  "version": "2026.8.19.10",
+  "version": "2026.8.19.11",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.8.19.10",
+      "version": "2026.8.19.11",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Description

Cuts **2026.8.19.11**, releasing the nine commits that have accumulated on `main` since 2026.8.19.10.

Version bumped in `pyproject.toml` (the single source of truth) and synced to all four derived manifests via `bin/sync_manifest_versions.py`. `--check` and `tests/test_tool_count_drift.py` both pass, so no manifest can ship stale.

### What ships

**Fixed**
- `governor migrate` **silently stopped chatlog spill drainage** — the loop's `embed` pass ran `embed_backfill` but nothing anywhere drained spill. A spilled turn lives only as a JSONL line on disk: in no store, unsearchable, unembeddable.
- **Spill could never be recovered on PostgreSQL** — `drain_spill` hardcoded SQLite-only SQL. Reinsertion now delegates to the canonical chatlog writer, which also fixes a **tenancy defect**: the hand-rolled INSERT wrote 10 of 22 columns, dropping `user_id`/`scope`, so a recovered turn escaped `scope_predicates` filtering.
- The scheduled sweep **no-op'd entirely on PostgreSQL**.
- A stale `_db_path` could **conjure an orphan store** and delete the spill file — reporting success while losing the only copy.

**Security**
- `cryptography` 48.0.1 → **>=50.0.0** (PYSEC-2026-3552 / 3553 / 3554). The `<49` cap structurally blocked all three fixes. These were live because **the security job never reached `pip-audit`** — a Bandit `B310` finding failed the step first, so a green-looking gate had been hiding real CVEs behind a lint error.
- Example frontend: `js-yaml` (high), `postcss` (medium), `brace-expansion` (high) cleared; `npm audit` reports 0.

**Changed**
- CI verification no longer grades subsystems the install declined.
- `m3 setup` can no longer die silently during verification.
- Four tests were green for the wrong reasons and are now hermetic; `mcp_proxy` moved off FastAPI's deprecated `on_event` (12 import-time errors).

### ⚠️ Known issue shipping with this release

**The Windows E2E lane is still red and has never been green** — it predates this work. `m3 setup` exits 1 at verification with no output on either stream, while the identical command exits 0 standalone and as a spawned child. Every hypothesis so far is eliminated by measurement; the next step is capturing the child's streams inside `_step_doctor`.

Ubuntu and macOS E2E and **all six test-matrix jobs are green** — this release does not regress that lane, it inherits it. Documented under **Known issues** in the changelog rather than omitted.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — version-sync gate (9), catalog drift (11), `--check` in sync
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — CHANGELOG entry incl. Known issues
- [x] No new warnings introduced

Diff audited for PII / local paths / secrets / bench data before push: clean.

## Related issues
Closes #