### PR TITLE
Add `m3 stop`; make the upgrade advice safe on Windows

### DIFF
--- a/m3_memory/cli.py
+++ b/m3_memory/cli.py
@@ -250,15 +250,90 @@ def _warn_if_pypi_newer() -> None:
             return [int(p) for p in v.split(".") if p.isdigit()]
 
         if _key(latest) > _key(installed):
+            # The upgrade line is OS-specific ON PURPOSE. A bare
+            # `pipx upgrade m3-memory` is unsafe on Windows in two ways, both
+            # observed on a real install (2026-08-10):
+            #
+            #  1. pip serves the index page from its HTTP cache, so pipx reports
+            #     "already at latest version" while PyPI is serving a newer one.
+            #     --no-cache-dir is the only reliable way to see a fresh release.
+            #  2. pip UNINSTALLS before it installs. Windows holds an open .exe
+            #     against deletion, so with m3 running (MCP servers, cognitive
+            #     loop, dashboard, embed server) the upgrade deletes the package
+            #     and then fails on `[WinError 32] ... Scripts\\m3.exe`, leaving
+            #     NO m3 installed: `m3` then dies with ModuleNotFoundError. pip
+            #     also leaves ~-prefixed junk dirs behind from the half-undone
+            #     uninstall.
+            #
+            # `m3 stop` quiesces the writers first, which makes the upgrade a
+            # normal one. POSIX replaces a running binary's inode happily, so
+            # the plain form stays correct there.
+            if os.name == "nt":
+                upgrade = ("       m3 stop                                     "
+                           "# release the file locks first\n"
+                           "       pipx upgrade m3-memory --pip-args=--no-cache-dir\n"
+                           "       m3 setup")
+            else:
+                upgrade = "       pipx upgrade m3-memory      # then: m3 setup"
             print(
                 f"\n[m3] A newer release is on PyPI: {latest} (you have {installed}).\n"
                 f"     `m3 update` only re-syncs the payload for your INSTALLED version —\n"
                 f"     it does NOT upgrade the package. To upgrade:\n"
-                f"       pipx upgrade m3-memory      # then: m3 setup",
+                f"{upgrade}",
                 file=sys.stderr,
             )
     except Exception:  # noqa: BLE001 — advisory only, never fail the command
         pass
+
+
+def _cmd_stop(args: argparse.Namespace) -> int:
+    """`m3 stop` — quiesce every m3 DB-writer for this engine root.
+
+    Exists because `pipx upgrade m3-memory` is unsafe while m3 is running on
+    Windows: pip uninstalls before it installs, Windows holds an open .exe
+    against deletion, and the upgrade therefore deletes the package and then
+    fails on `[WinError 32] ... Scripts\\m3.exe` — leaving NO m3 installed.
+    Stopping the writers first turns that into an ordinary upgrade.
+
+    Also the honest answer to "how do I shut m3 down", which previously had
+    none: users reached for `taskkill`/`pkill` by name, which is the
+    substring-kill footgun kill_stale_daemons exists to avoid.
+
+    Delegates to m3_halt.kill_stale_daemons: precise-PID only, never a
+    name sweep, never its own pid or parent chain.
+    """
+    script = _resolve_bin_script("m3_halt.py")
+    if script is None:
+        print("Error: m3_halt.py not found (payload not installed?). "
+              "Run `mcp-memory install-m3`.", file=sys.stderr)
+        return 1
+    bin_dir = str(script.parent)
+    if bin_dir not in sys.path:
+        sys.path.insert(0, bin_dir)
+    import m3_halt as halt  # type: ignore
+
+    results = halt.kill_stale_daemons(timeout=getattr(args, "timeout", 8.0))
+    if not results:
+        print("[m3] nothing to stop — no m3 DB-writers running.")
+        return 0
+
+    killed = [r for r in results if r.get("killed")]
+    failed = [r for r in results if not r.get("killed")]
+    for r in killed:
+        print(f"  stopped {r.get('role', '?')} (pid {r.get('pid')})")
+    for r in failed:
+        print(f"  [!] could NOT stop {r.get('role', '?')} (pid {r.get('pid')}): "
+              f"{r.get('error') or 'unknown'}", file=sys.stderr)
+
+    print(f"[m3] stopped {len(killed)}/{len(results)} writer(s).")
+    if failed:
+        # Almost always an elevated writer an unprivileged shell cannot touch.
+        # Say so and exit non-zero — a partial stop must not read as success
+        # (§3), because the caller's next step is an upgrade that will fail.
+        print("[m3] some writers survived — an upgrade may still hit a file "
+              "lock. Re-run from an elevated shell.", file=sys.stderr)
+        return 1
+    return 0
 
 
 def _cmd_update(args: argparse.Namespace) -> int:
@@ -1185,6 +1260,18 @@ Examples:
         help="Wipe and reinstall the system payload (alias for install-m3 --force).",
     )
     p_reinstall.set_defaults(func=_cmd_reinstall)
+
+    p_stop = subparsers.add_parser(
+        "stop",
+        help="Stop every running m3 DB-writer (cognitive loop, embed server, "
+             "dashboard, MCP). Run this before `pipx upgrade` on Windows.",
+    )
+    p_stop.add_argument(
+        "--timeout", type=float, default=8.0, metavar="SECONDS",
+        help="Seconds to wait for a writer to exit before reporting it stuck "
+             "(default: 8).",
+    )
+    p_stop.set_defaults(func=_cmd_stop)
 
     p_update = subparsers.add_parser(
         "update",

--- a/tests/test_cli_stop_command.py
+++ b/tests/test_cli_stop_command.py
@@ -1,0 +1,96 @@
+r"""`m3 stop` — quiesce m3's DB-writers before an upgrade.
+
+Why this command exists: `pipx upgrade m3-memory` is unsafe while m3 is running
+on Windows. pip UNINSTALLS before it installs, Windows holds an open .exe
+against deletion, so the upgrade deletes the package and then fails on
+`[WinError 32] ... Scripts\m3.exe` — leaving NO m3 installed (`m3` then dies
+with ModuleNotFoundError) plus ~-prefixed junk dirs from the half-undone
+uninstall. Observed on a real install 2026-08-10.
+
+The contract this pins:
+  - delegates to m3_halt.kill_stale_daemons (precise-PID; never a name sweep)
+  - "nothing running" is exit 0, not an error
+  - a PARTIAL stop is exit 1 — it must not read as success, because the
+    caller's next step is an upgrade that will then fail (§3)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT))
+
+from m3_memory import cli  # noqa: E402
+
+
+@pytest.fixture
+def fake_halt(monkeypatch):
+    """Install a stub m3_halt so the test never touches real processes."""
+    mod = types.ModuleType("m3_halt")
+    mod.calls = []
+
+    def kill_stale_daemons(engine_root=None, *, timeout=8.0):
+        mod.calls.append(timeout)
+        return mod.results
+
+    mod.kill_stale_daemons = kill_stale_daemons
+    mod.results = []
+    monkeypatch.setitem(sys.modules, "m3_halt", mod)
+    monkeypatch.setattr(cli, "_resolve_bin_script",
+                        lambda name: Path(_ROOT / "bin" / "m3_halt.py"))
+    return mod
+
+
+def _run(timeout=8.0):
+    return cli._cmd_stop(argparse.Namespace(timeout=timeout))
+
+
+def test_nothing_running_is_success(fake_halt, capsys):
+    fake_halt.results = []
+    assert _run() == 0
+    assert "nothing to stop" in capsys.readouterr().out
+
+
+def test_all_stopped_is_success(fake_halt, capsys):
+    fake_halt.results = [
+        {"pid": 1, "role": "cognitive-loop", "killed": True, "error": None},
+        {"pid": 2, "role": "embed-server", "killed": True, "error": None},
+    ]
+    assert _run() == 0
+    out = capsys.readouterr().out
+    assert "stopped cognitive-loop (pid 1)" in out
+    assert "stopped 2/2 writer(s)" in out
+
+
+def test_partial_stop_is_a_failure(fake_halt, capsys):
+    """A survivor means the upgrade will still hit a file lock — say so, loudly.
+
+    Reporting 0 here would hand the user a green light into the exact failure
+    this command exists to prevent.
+    """
+    fake_halt.results = [
+        {"pid": 1, "role": "cognitive-loop", "killed": True, "error": None},
+        {"pid": 2, "role": "mcp", "killed": False, "error": "AccessDenied"},
+    ]
+    assert _run() == 1, "a partial stop must not report success"
+    cap = capsys.readouterr()
+    assert "could NOT stop mcp (pid 2)" in cap.err
+    assert "AccessDenied" in cap.err
+    assert "elevated" in cap.err
+
+
+def test_timeout_is_forwarded(fake_halt):
+    fake_halt.results = []
+    _run(timeout=2.5)
+    assert fake_halt.calls == [2.5]
+
+
+def test_missing_payload_reports_and_fails(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_resolve_bin_script", lambda name: None)
+    assert cli._cmd_stop(argparse.Namespace(timeout=8.0)) == 1
+    assert "m3_halt.py not found" in capsys.readouterr().err


### PR DESCRIPTION
## Description

`pipx upgrade m3-memory` — **the command m3 itself tells users to run** — breaks the install on Windows. Hit on a real install 2026-08-10, twice over.

### 1. pip's index cache hides new releases

pipx reported *"m3-memory is already at latest version 2026.8.19.10"* while PyPI was serving **2026.8.19.11**. `pip index versions` agreed — until `--no-cache-dir` was passed, at which point it immediately saw `.11`.

### 2. The upgrade deletes the package and then fails

pip **uninstalls before it installs**. Windows holds an open `.exe` against deletion, so with m3 running (MCP servers, cognitive loop, dashboard, embed server — **16 processes**) the upgrade failed with:

```
[WinError 32] The process cannot access the file because it is being
used by another process: ...\Scripts\m3.exe
```

…**after** the uninstall had already completed. Result: no m3 installed. `m3 --version` died with `ModuleNotFoundError: No module named 'm3_memory.cli'`, `pip show` returned nothing, and `site-packages` held `~`-prefixed junk dirs from the half-undone uninstall — **some from earlier `m3_core_rs` upgrades**, so this had happened before and left debris.

The wizard already solves this: `m3 setup` quiesces DB-writers in preflight. A bare `pipx upgrade` bypasses the wizard entirely and gets none of that protection.

## The fix

**New `m3 stop`** — quiesces every m3 DB-writer for this engine root. Delegates to `m3_halt.kill_stale_daemons`: precise-PID only, **never a name/substring sweep** (the 2026-06-30 substring-kill incident), never its own pid or parent chain.

It is also the honest answer to *"how do I shut m3 down"*, which previously had none — users reached for `taskkill`/`pkill` by name, which is exactly that footgun.

A **partial stop exits 1** (§3). Reporting success there would hand the user a green light into the very failure this command exists to prevent.

**The upgrade nudge is now OS-specific.** Windows gets:
```
m3 stop
pipx upgrade m3-memory --pip-args=--no-cache-dir
m3 setup
```
POSIX keeps the plain form — replacing a running binary's inode is fine there, so the extra ceremony would be noise.

## Verification

End to end **on the machine that broke**: `m3 stop` found and stopped all three registered writers by role+pid, after which the exact pip operation that had failed (uninstall + reinstall over a live install) completed cleanly.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — 5 new: nothing-running, all-stopped, **partial-stop-is-failure**, timeout forwarding, missing payload
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — help text + code comments carry the rationale
- [x] No new warnings introduced

## Related issues
Closes #