### PR TITLE
Stop the embed server opening a stray console window on Windows

### DIFF
--- a/bin/doctor/shared_embedder_probe.py
+++ b/bin/doctor/shared_embedder_probe.py
@@ -346,12 +346,28 @@ def _fix_start_server() -> bool:
     # is always safe (never a second CUDA context). Detached so it outlives doctor.
     try:
         kwargs: dict[str, Any] = {}
+        exe = sys.executable
         if sys.platform == "win32":
-            kwargs["creationflags"] = 0x00000008  # DETACHED_PROCESS
+            # pythonw.exe (GUI subsystem) = the OS never allocates a console, so
+            # there is no window and no flash. DETACHED_PROCESS alone does NOT
+            # suppress one: it detaches the child from THIS console but still
+            # lets the OS give a console-subsystem python.exe its own. That left
+            # a stray terminal window titled with the interpreter path sitting
+            # on the user's desktop for as long as the embed server ran — and
+            # closing it killed their embedder. Observed 2026-08-10.
+            #
+            # CREATE_NO_WINDOW belts-and-braces the guarantee. Same pattern as
+            # dashboard_server._daemonize, which got this right.
+            pyw = sys.executable.replace("python.exe", "pythonw.exe")
+            if os.path.exists(pyw):
+                exe = pyw
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NO_WINDOW | subprocess.DETACHED_PROCESS
+            )
         else:
             kwargs["start_new_session"] = True
         subprocess.Popen(  # noqa: S603 — fixed argv, our own script
-            [sys.executable, script, "--port", str(_PORT)],
+            [exe, script, "--port", str(_PORT)],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **kwargs,
         )
         print(f"  [fix] launched embed server on {_DEFAULT_URL} (loading may take a few seconds).")


### PR DESCRIPTION
## Description

`m3 doctor --fix` started the shared embed server with `sys.executable` (**python.exe** — the *console-subsystem* interpreter) and `DETACHED_PROCESS` alone.

`DETACHED_PROCESS` **does not suppress a console.** It detaches the child from the *current* console, but the OS still allocates a fresh one for a console-subsystem binary. The result was a terminal window titled

```
C:\Users\<user>\pipx\venvs\m3-memory\Scripts\python.exe
```

sitting on the user's desktop for as long as the embed server ran — **and closing it, which is the obvious thing to do with a stray window, killed their embedder.**

Reported by a user 2026-08-10 after a `doctor --fix` restarted the server.

## The fix

Launch under **pythonw.exe** (GUI subsystem — the OS never allocates a console, so no window and no flash) with `CREATE_NO_WINDOW | DETACHED_PROCESS`. Falls back to `sys.executable` if `pythonw.exe` is absent, and is a no-op off Windows where `start_new_session` already detaches and there is no console window to speak of.

This is the pattern `dashboard_server._daemonize` and `m3_cognitive_loop` **already use** — the embed server was simply missing it.

### Blast radius

Checked every spawn site: this was the **only** one missing the guard. The cognitive loop (`CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` + pythonw re-exec) and the dashboard both already pair the flags correctly.

## Verification

Live, on the machine that reported it:

1. Killed the windowed `python.exe` server
2. Restarted through the patched path
3. Replacement runs as **`pythonw.exe`**, **no window**, still serving `:8082` (health **200**)

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **318 passed** in the embedder/doctor batch
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale in the code comment
- [x] No new warnings introduced

The one batch failure (`test_zero_lag_write`, which asserts behaviour *"without an embedder"*) reproduces identically on a clean tree in the same batch and passes in isolation — pre-existing ordering pollution, unrelated to this change.

## Related issues
Closes #