### PR TITLE
setup: never kill this install's own ancestry when quiescing writers

### DIFF
--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -1136,8 +1136,41 @@ def _kill_stuck_writers(stuck, *, allow_sudo: bool = False) -> bool:
     killer = _kill_process_windows if is_win else _kill_process_posix
     elevate = _runas_kill_windows if is_win else _sudo_kill_posix
     how = "UAC" if is_win else "sudo"
+
+    # NEVER kill our own ancestry — the branch we are sitting on. A DB-writer can
+    # legitimately register at a generation ABOVE this code: launched from the
+    # `m3` console script, setup is several generations deep
+    #     m3.exe -> python (UTF-8 re-exec) -> setup -> ...
+    # so a writer registered at the shim or re-exec generation is an ancestor,
+    # and killing it ends the run mid-install. m3_halt.kill_stale_daemons learned
+    # this on 2026-07-27 (console output stopped after agent wiring, exit 1, no
+    # traceback, ONLY under the console-script launcher) and protects the full
+    # chain; this second kill path never got the same guard.
+    #
+    # Cross-platform on purpose: POSIX kills with os.kill, and killing an
+    # ancestor there is just as fatal — this is not a Windows-only hazard.
+    protected = {os.getpid()}
+    try:
+        halt_mod = _import_m3_halt()
+        if halt_mod is not None and hasattr(halt_mod, "_ancestor_pids"):
+            protected.update(halt_mod._ancestor_pids(os.getpid()))
+        else:
+            protected.add(os.getppid())
+    except Exception:  # noqa: BLE001 — best-effort; never block the kill path
+        try:
+            protected.add(os.getppid())
+        except Exception:  # noqa: BLE001
+            pass
+
     all_ok = True
     for p in stuck:
+        if p.pid in protected:
+            # Loud, not silent (§3): the caller's quiesce is genuinely incomplete
+            # and the install may still hit a lock — but sawing off our own branch
+            # is strictly worse than proceeding.
+            _warn(f"    refusing to kill {p.role} (pid {p.pid}) — it is this "
+                  f"install's own parent process")
+            continue
         if killer(p.pid):
             _ok(f"    stopped {p.role} (pid {p.pid})")
             continue

--- a/tests/test_setup_kill_protects_ancestors.py
+++ b/tests/test_setup_kill_protects_ancestors.py
@@ -1,0 +1,90 @@
+"""`_kill_stuck_writers` must never kill this install's own ancestry.
+
+A DB-writer can legitimately register at a generation ABOVE the wizard. Launched
+from the `m3` console script, setup sits several generations deep:
+
+    m3.exe -> python (UTF-8 re-exec) -> setup -> ...
+
+so a writer registered at the shim or re-exec generation is an ANCESTOR of the
+running install. Killing it ends the run mid-install — the 2026-07-27 signature
+was console output stopping after agent wiring, exit 1, no traceback, and ONLY
+under the console-script launcher (`python -m m3_memory.cli setup`, which lacks
+those two generations, completed fine).
+
+m3_halt.kill_stale_daemons learned that and protects the full ancestor chain.
+The wizard's own second kill path never got the same guard. This is
+cross-platform: POSIX kills via os.kill, where killing an ancestor is equally
+fatal — not a Windows-only hazard.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT))
+
+from m3_memory import setup_wizard as sw  # noqa: E402
+
+
+class _Proc:
+    def __init__(self, pid, role="mcp"):
+        self.pid = pid
+        self.role = role
+
+
+@pytest.fixture
+def killed(monkeypatch):
+    """Record kill attempts instead of performing them."""
+    seen = []
+    monkeypatch.setattr(sw, "_kill_process_windows", lambda pid: (seen.append(pid), True)[1])
+    monkeypatch.setattr(sw, "_kill_process_posix", lambda pid: (seen.append(pid), True)[1])
+    return seen
+
+
+def test_never_kills_self(killed, monkeypatch):
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: None)
+    ok = sw._kill_stuck_writers([_Proc(os.getpid())])
+    assert os.getpid() not in killed, "the installer killed its own process"
+    assert ok is True
+
+
+def test_never_kills_the_parent(killed, monkeypatch):
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: None)
+    sw._kill_stuck_writers([_Proc(os.getppid())])
+    assert os.getppid() not in killed, "the installer killed its own parent"
+
+
+def test_protects_the_full_ancestor_chain(killed, monkeypatch):
+    """Not just {self, parent} — the launcher can be several generations up."""
+    fake = types.ModuleType("m3_halt")
+    fake._ancestor_pids = lambda pid, **kw: {111111, 222222, 333333}
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: fake)
+
+    sw._kill_stuck_writers([_Proc(p) for p in (111111, 222222, 333333)])
+    assert killed == [], f"killed an ancestor: {killed}"
+
+
+def test_still_kills_a_genuine_stranger(killed, monkeypatch):
+    """The guard must not neuter the kill path it protects."""
+    fake = types.ModuleType("m3_halt")
+    fake._ancestor_pids = lambda pid, **kw: {111111}
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: fake)
+
+    ok = sw._kill_stuck_writers([_Proc(999999, role="cognitive-loop")])
+    assert killed == [999999], "a non-ancestor writer must still be stopped"
+    assert ok is True
+
+
+def test_ancestor_lookup_failure_still_protects_self(killed, monkeypatch):
+    """A broken m3_halt must degrade to {self, parent}, never to 'kill anything'."""
+    def boom():
+        raise RuntimeError("payload unavailable")
+    monkeypatch.setattr(sw, "_import_m3_halt", boom)
+
+    sw._kill_stuck_writers([_Proc(os.getpid())])
+    assert os.getpid() not in killed


### PR DESCRIPTION
## Description

`_kill_stuck_writers` — the `--force-quiesce` kill path — has **no ancestor guard**.

A DB-writer can legitimately register at a generation **above** the wizard. Launched from the `m3` console script, setup sits several generations deep:

```
m3.exe -> python (UTF-8 re-exec) -> setup -> ...
```

So a writer registered at the shim or re-exec generation is an **ancestor of the running install**, and killing it ends the run mid-install.

### This exact bug already happened once

`m3_halt.kill_stale_daemons` learned it on **2026-07-27**: console output stopped after agent wiring, exit 1, no traceback, and **only** under the console-script launcher — while `python -m m3_memory.cli setup` (which lacks those two generations) completed and exited 0. Same code, different launcher.

It protects the full chain via `_ancestor_pids`. The wizard's **second** kill path never got the same guard. This closes that gap by reusing the same helper.

**Cross-platform on purpose:** POSIX kills with `os.kill`, where killing an ancestor is equally fatal. Not a Windows-only hazard.

Degrades to `{self, parent}` if `m3_halt` is unavailable — never to "kill anything". Refusal is **loud** (§3): the quiesce is genuinely incomplete and the install may still hit a lock, so it says so — but sawing off our own branch is strictly worse than proceeding.

## ⚠️ Not a fix for the open Windows E2E failure

I am **not** claiming this resolves it, and I checked before writing that: the force-quiesce path kills with `taskkill /PID /F` **without `/T`**, and `/F` alone does not cascade to children (verified directly). So it cannot be taking setup down that way.

This is a **latent** footgun found by re-reading the kill paths during a design-philosophy pass — owned now rather than noted.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **89 setup tests**; 5 new regression tests, **4 of which fail on the pre-fix wizard**
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale in the code comment
- [x] No new warnings introduced

## Related issues
Closes #