### PR TITLE
setup: capture and report the doctor's output when verification fails

### DIFF
--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -2518,6 +2518,72 @@ def _step_governor_migration(plan: SetupPlan, *, non_interactive: bool = False,
     return result
 
 
+def _doctor_failure_telemetry(argv: list, rc: "int | None") -> None:
+    """After a FAILED verification, re-run the doctor CAPTURED and report what it
+    actually emitted. Diagnostic only — never changes the verdict, never raises.
+
+    Why this exists: on windows-latest the E2E lane has never been green, and its
+    failure mode is invisible. `_run` STREAMS the child's stdout/stderr, and on
+    that runner the setup step ends with
+
+        ==> Step 5/5: verifying the install (m3 doctor)
+        ##[error]Process completed with exit code 1
+
+    — not one byte from either stream, on a step whose ubuntu twin streams the
+    entire doctor report. Meanwhile the SAME argv run standalone on that runner,
+    and re-run as a child with the parent's UTF-8 re-exec sentinel set, both exit
+    0 and print normally. Streaming is exactly what loses the evidence when a
+    child dies before its output is flushed through the inherited handles.
+
+    Capturing sidesteps that: pipes are ours, so whatever the child wrote (or the
+    traceback it died on) lands in a string we can print, even when the streamed
+    copy vanished. A second run is cheap next to an unexplained failure, and the
+    doctor is read-only in this mode.
+
+    Best-effort by construction (§3): if even the captured re-run dies, we say so
+    with the exception type rather than swallowing it — a diagnostic that can fail
+    silently would be repeating the bug it exists to explain.
+    """
+    _warn(f"  [telemetry] verification exited {rc}; re-running captured to "
+          f"recover what it emitted...")
+    try:
+        cp = subprocess.run(  # noqa: S603 — same fixed argv we just ran
+            argv, capture_output=True, text=True, errors="backslashreplace",
+            timeout=180,
+        )
+    except subprocess.TimeoutExpired:
+        _warn("  [telemetry] the captured re-run TIMED OUT after 180s — the "
+              "doctor is hanging, not exiting.")
+        return
+    except BaseException as e:  # noqa: BLE001 — diagnostic must never mask the verdict
+        if isinstance(e, (KeyboardInterrupt, SystemExit)):
+            raise
+        _warn(f"  [telemetry] the captured re-run could not start: "
+              f"{type(e).__name__}: {e}")
+        return
+
+    out = (cp.stdout or "").strip()
+    err = (cp.stderr or "").strip()
+    _warn(f"  [telemetry] captured rc={cp.returncode} "
+          f"stdout={len(out)}B stderr={len(err)}B")
+    # Tail, not head: a traceback's useful end is the last lines, and a doctor
+    # report's verdict lines come last too.
+    for label, blob in (("stdout", out), ("stderr", err)):
+        if not blob:
+            continue
+        tail = blob.splitlines()[-25:]
+        _warn(f"  [telemetry] --- {label} (last {len(tail)} line(s)) ---")
+        for line in tail:
+            _warn(f"  [telemetry] | {line}")
+    if not out and not err:
+        # The signature we are hunting: the child produced NOTHING even when we
+        # own the pipes. That rules out "output was lost in the stream" and
+        # points at the process dying before it writes at all.
+        _warn("  [telemetry] the captured re-run ALSO produced no output on "
+              "either stream — the child is dying before it writes, not losing "
+              "its output in transit.")
+
+
 def _step_doctor(plan=None) -> bool:
     """Final verification — DOES the install actually work?
 
@@ -2570,11 +2636,12 @@ def _step_doctor(plan=None) -> bool:
         _run(argv)
         _ok("verification passed — m3 is installed and working")
         return True
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
         _warn("VERIFICATION FAILED — the install completed but m3 is not fully "
               "healthy. The doctor output above names each issue and its fix.")
         _warn("Re-run `m3 doctor` after fixing, or `m3 doctor --fix` for the "
               "issues that self-repair.")
+        _doctor_failure_telemetry(argv, e.returncode)
         return False
     except BaseException as e:  # noqa: BLE001 — see below; re-raises KeyboardInterrupt
         # ANY other failure here used to escape _step_doctor and kill the whole
@@ -2595,6 +2662,7 @@ def _step_doctor(plan=None) -> bool:
         _warn(f"VERIFICATION COULD NOT RUN — {type(e).__name__}: {e}")
         _warn("The install itself completed; only the `m3 doctor` check failed "
               "to execute. Run `m3 doctor` manually to see the real state.")
+        _doctor_failure_telemetry(argv, None)
         return False
 
 

--- a/tests/test_setup_post_install_verify.py
+++ b/tests/test_setup_post_install_verify.py
@@ -179,3 +179,53 @@ def test_step_doctor_still_propagates_keyboard_interrupt(wizard, monkeypatch):
     import pytest as _pytest
     with _pytest.raises(KeyboardInterrupt):
         wizard._step_doctor()
+
+
+# ── failure telemetry ────────────────────────────────────────────────────────
+
+def test_telemetry_surfaces_captured_output(wizard, capsys):
+    """A failing doctor's output must be recoverable even when streaming lost it.
+
+    `_run` streams the child's stdio. On windows-latest the setup step ends with
+    "Step 5/5" then `exit 1` and NOT ONE BYTE from either stream, while the same
+    argv run standalone on that runner exits 0 and prints normally. Capturing
+    owns the pipes, so whatever the child wrote lands somewhere we can print.
+    """
+    import sys as _sys
+    argv = [_sys.executable, "-c",
+            "import sys; print('verdict line'); print('why', file=sys.stderr); sys.exit(1)"]
+    wizard._doctor_failure_telemetry(argv, 1)
+    cap = capsys.readouterr()
+    blob = cap.out + cap.err
+    assert "verdict line" in blob
+    assert "why" in blob
+    assert "captured rc=1" in blob
+
+
+def test_telemetry_names_the_no_output_case(wizard, capsys):
+    """Silence under CAPTURE is itself the finding — say so, don't just print 0B.
+
+    It distinguishes "the output was lost in transit" from "the child died
+    before writing", which is the open question on the Windows E2E lane.
+    """
+    import sys as _sys
+    wizard._doctor_failure_telemetry([_sys.executable, "-c", "import sys; sys.exit(1)"], 1)
+    blob = "".join(capsys.readouterr())
+    assert "dying before it writes" in blob
+
+
+def test_telemetry_never_raises_on_a_bad_command(wizard, capsys):
+    """Diagnostics must not mask the verdict they are explaining (§3)."""
+    wizard._doctor_failure_telemetry(["definitely-not-a-real-binary-xyz"], 1)
+    assert "could not start" in "".join(capsys.readouterr())
+
+
+def test_failed_verification_still_returns_false_with_telemetry(wizard, monkeypatch):
+    """Telemetry is additive: the verdict is unchanged."""
+    import subprocess as _sp
+
+    def boom(*a, **k):
+        raise _sp.CalledProcessError(1, "doctor")
+    monkeypatch.setattr(wizard, "_run", boom)
+    monkeypatch.setattr(wizard, "_doctor_failure_telemetry", lambda *a, **k: None)
+    assert wizard._step_doctor() is False


### PR DESCRIPTION
## Description

Telemetry for the open **Windows E2E failure**, which has never been green and whose failure mode is *invisible*:

```
==> Step 5/5: verifying the install (m3 doctor)
##[error]Process completed with exit code 1
```

**Not one byte from either stream** — on a step whose ubuntu twin streams the entire doctor report. The same argv run standalone on that runner, and re-run as a child with the parent's UTF-8 re-exec sentinel set, both exit 0 and print normally.

### Why capture

`_run` **streams** the child's stdio through inherited handles — exactly what loses the evidence if the child dies before that output is flushed. On a failed verification we now re-run the doctor **captured** and print what it actually emitted: the pipes are ours, so whatever it wrote (or the traceback it died on) lands in a string we can show. A second read-only run is cheap next to an unexplained failure.

### The important branch is the empty one

If the captured re-run **also** produces nothing, that is itself the finding, and it is stated outright:

> *the child is dying before it writes, not losing its output in transit*

That distinguishes the two remaining hypotheses — which is the whole point. Everything else is already eliminated **by measurement**:

| Ruled out | By |
|---|---|
| a doctor verdict | both standalone forms exit 0 |
| an exception escaping `_step_doctor` | the catch-all never fired |
| a killed process tree | `taskkill /PID /F`, no `/T` — and `/F` alone does not cascade (verified) |
| missing roots in the child | setup exports them before spawning |
| a cp1252 encode crash | `reconfigure()` handles it, verified rc=0 with glyphs |
| the UTF-8 re-exec sentinel | rc 0, stderr empty, as a child |

## Safety

Wired into **both** failure paths — `CalledProcessError` (with its rc) and the catch-all from the silent-exit-1 fix.

Diagnostic only: never changes the verdict, never raises, bounds itself with `timeout=180`, and reports the exception type if even the captured re-run cannot start (§3 — a diagnostic that fails silently would be repeating the bug it exists to explain). Tails rather than heads the output, since a traceback's useful end and a doctor report's verdict lines are both last.

## Type of change
- [x] Bug fix (non-breaking) — instrumentation toward one
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **98 setup tests**; 4 new (output surfaced, no-output case **named**, bad command does not raise, verdict unchanged)
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale in the docstring
- [x] No new warnings introduced

## Related issues
Closes #