### PR TITLE
E2E: the Windows lane HANGS — bound the doctor, cap the job, trace the path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,11 @@ jobs:
   # platform-specific (Windows file locks, venv launcher stubs, POSIX-only
   # asyncio signal handlers), so a single-OS lane would have missed them.
   e2e-install:
+    # A HANG must not burn a 6-hour runner. The Windows lane sat in_progress for
+    # 25+ minutes on a step whose ubuntu/macOS twins finish in well under 10 —
+    # the failure mode is a BLOCK, not a crash, and without a cap every failing
+    # run costs six hours and delays the post-mortem steps that explain it.
+    timeout-minutes: 25
     name: E2E install + upgrade on ${{ matrix.os }}
     needs: [lint, typecheck, matrix-setup]
     runs-on: ${{ matrix.os }}
@@ -213,6 +218,10 @@ jobs:
         # the point is the install path itself, not hook wiring into a client
         # that is not there.
         M3_E2E_ROOT: ${{ runner.temp }}/m3-e2e
+        # Breadcrumbs to a FILE: the Windows failure kills setup with no output
+        # on either stream, so anything relying on the dying process flushing
+        # its own stdio is precisely what cannot be trusted here.
+        M3_TRACE_FILE: ${{ runner.temp }}/m3-setup-trace.log
       run: |
         mkdir -p "$M3_E2E_ROOT/config" "$M3_E2E_ROOT/engine"
         # --no-native-wheel: runners have no GPU and a source build is slow;
@@ -234,6 +243,14 @@ jobs:
     # one: the log ends at "Step 5/5" with exit 1 and no verdict. Print the
     # doctor's own exit code and output on that runner so the next failure
     # names itself instead of needing another CI round-trip to diagnose.
+    - name: Dump the setup trace (always — this is the post-mortem)
+      if: always()
+      shell: bash
+      run: |
+        f="${{ runner.temp }}/m3-setup-trace.log"
+        echo "--- setup trace ($f) ---"
+        if [ -f "$f" ]; then cat "$f"; else echo "(no trace file written)"; fi
+
     - name: Diagnose verification (Windows only, never fails the job)
       # `always()` is REQUIRED: without it a step is skipped once an earlier one
       # fails, and the whole point of this step is to explain the setup failure

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -2525,10 +2525,18 @@ def _step_governor_migration(plan: SetupPlan, *, non_interactive: bool = False,
     return result
 
 
-# Wall-clock cap on the post-install `m3 doctor` verification. Generous enough
-# for a cold run that migrates a fresh DB and warms an embedder, short enough
-# that a hung probe surfaces as a failed verification instead of a hung install.
-_DOCTOR_TIMEOUT_S = 300.0
+# Wall-clock cap on the post-install `m3 doctor` verification.
+#
+# 60s = 10x the MEASURED cost. A real doctor run is ~6s warm and ~5s cold (fresh
+# roots, migrations applied, no embedder reachable — the E2E case), so this is an
+# order of magnitude of headroom for a slow or loaded host while still surfacing
+# a hang in a minute rather than an hour.
+#
+# Deliberately the same ORDER as --quiesce-timeout (30s): if 30s is long enough
+# to declare a DB-writer stuck and start killing it, a verification that reads
+# the same machine has no business waiting ten times longer. The first draft used
+# 300s, which was 50x the real cost and inconsistent with that existing budget.
+_DOCTOR_TIMEOUT_S = 60.0
 
 
 def _trace(msg: str) -> None:
@@ -2592,11 +2600,11 @@ def _doctor_failure_telemetry(argv: list, rc: "int | None") -> None:
     try:
         cp = subprocess.run(  # noqa: S603 — same fixed argv we just ran
             argv, capture_output=True, text=True, errors="backslashreplace",
-            timeout=180,
+            timeout=_DOCTOR_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
-        _warn("  [telemetry] the captured re-run TIMED OUT after 180s — the "
-              "doctor is hanging, not exiting.")
+        _warn(f"  [telemetry] the captured re-run TIMED OUT after "
+              f"{_DOCTOR_TIMEOUT_S:.0f}s — the doctor is hanging, not exiting.")
         return
     except BaseException as e:  # noqa: BLE001 — diagnostic must never mask the verdict
         if isinstance(e, (KeyboardInterrupt, SystemExit)):

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -690,12 +690,19 @@ def _detect_governor_eligible_tasks() -> list[str]:
 
 # ── execution phase ───────────────────────────────────────────────────────────
 
-def _run(cmd: list[str], *, check: bool = True, env: "dict | None" = None) -> subprocess.CompletedProcess:
+def _run(cmd: list[str], *, check: bool = True, env: "dict | None" = None,
+         timeout: "float | None" = None) -> subprocess.CompletedProcess:
     """Shell out, streaming output. Returns the completed process.
 
     `env`, when given, replaces the child's environment (used to strip
-    PYTHONPATH so a stale repo payload can't shadow the installed package)."""
-    return subprocess.run(cmd, check=check, env=env)
+    PYTHONPATH so a stale repo payload can't shadow the installed package).
+
+    `timeout`, when given, bounds the wall-clock wait and raises
+    subprocess.TimeoutExpired. Callers that shell out to something which can
+    BLOCK — rather than merely fail — must pass one: a setup step that waits
+    forever is indistinguishable from a hung machine, and on CI it burns the
+    whole runner (GitHub's default job cap is 6 hours)."""
+    return subprocess.run(cmd, check=check, env=env, timeout=timeout)
 
 
 def _import_m3_halt():
@@ -2518,6 +2525,42 @@ def _step_governor_migration(plan: SetupPlan, *, non_interactive: bool = False,
     return result
 
 
+# Wall-clock cap on the post-install `m3 doctor` verification. Generous enough
+# for a cold run that migrates a fresh DB and warms an embedder, short enough
+# that a hung probe surfaces as a failed verification instead of a hung install.
+_DOCTOR_TIMEOUT_S = 300.0
+
+
+def _trace(msg: str) -> None:
+    """Unbuffered breadcrumb to BOTH stderr and a file. Debug instrumentation.
+
+    Why a file and not just a print: the failure being chased kills the setup
+    process with NO output on either stream, so anything that relies on the
+    dying process flushing its own stdio is exactly what we cannot trust. The
+    file is opened, written, flushed and closed per call — so the last line on
+    disk names the last boundary that was reached, even if the process is
+    terminated a microsecond later.
+
+    Best-effort and silent on failure: instrumentation must never be the thing
+    that breaks the run it is instrumenting.
+    """
+    try:
+        line = f"[trace] {msg}"
+        print(line, file=sys.stderr, flush=True)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        path = os.environ.get("M3_TRACE_FILE")
+        if not path:
+            return
+        with open(path, "a", encoding="utf-8", errors="backslashreplace") as fh:
+            fh.write(f"{line}\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+    except Exception:  # noqa: BLE001 — never break the run to record it
+        pass
+
+
 def _doctor_failure_telemetry(argv: list, rc: "int | None") -> None:
     """After a FAILED verification, re-run the doctor CAPTURED and report what it
     actually emitted. Diagnostic only — never changes the verdict, never raises.
@@ -2632,10 +2675,28 @@ def _step_doctor(plan=None) -> bool:
         # a reader would connect to the exit code. Declining the embedder means
         # declining what depends on it.
         argv.append("--skip-cascade")
+    _trace(f"doctor: about to spawn argv={argv}")
+    _trace(f"doctor: sys.executable={sys.executable!r} "
+           f"utf8_mode={sys.flags.utf8_mode} "
+           f"sentinel={os.environ.get('_M3_UTF8_REEXEC')!r}")
     try:
-        _run(argv)
+        # BOUNDED (§3): verification must not be able to hang the install. The
+        # doctor probes live endpoints (embedder, LLM, warehouse) and a probe
+        # that blocks — rather than failing — would otherwise stall setup
+        # forever. Observed on windows-latest: the E2E job sat in_progress for
+        # 25+ minutes on this step while its ubuntu/macOS twins finish in well
+        # under 10, i.e. the failure mode there is a BLOCK, not a crash.
+        cp = _run(argv, timeout=_DOCTOR_TIMEOUT_S)
+        _trace(f"doctor: _run returned rc={getattr(cp, 'returncode', '?')}")
         _ok("verification passed — m3 is installed and working")
         return True
+    except subprocess.TimeoutExpired:
+        _trace("doctor: TIMED OUT")
+        _warn(f"VERIFICATION TIMED OUT after {_DOCTOR_TIMEOUT_S:.0f}s — `m3 doctor` "
+              "did not finish. The install itself completed; a probe is hanging, "
+              "not failing.")
+        _warn("Run `m3 doctor --verbose` by hand to see which probe blocks.")
+        return False
     except subprocess.CalledProcessError as e:
         _warn("VERIFICATION FAILED — the install completed but m3 is not fully "
               "healthy. The doctor output above names each issue and its fix.")
@@ -2792,11 +2853,16 @@ def run_setup(args: argparse.Namespace) -> int:
         if plan.use_shared_embedder:
             _step_shared_embedder(plan, non_interactive=args.non_interactive)
         _step_wire_agents(plan, non_interactive=args.non_interactive)
+        _trace("after wire_agents")
         _step_install_dashboard(plan)
+        _trace("after install_dashboard")
         governor_result = _step_governor_migration(
             plan, non_interactive=args.non_interactive, gui=getattr(args, "gui_child", False))
+        _trace("after governor_migration")
         verified = _step_doctor(plan)
+        _trace(f"after step_doctor -> verified={verified}")
         _summary(plan, governor_result, verified=verified)
+        _trace("after summary")
         # Exit 3 = "installed but not verified healthy". Distinct from 0
         # (clean) and from 2 (aborted, nothing installed) so a scripted
         # installer can tell "did not finish" from "finished but the result is

--- a/tests/test_setup_post_install_verify.py
+++ b/tests/test_setup_post_install_verify.py
@@ -229,3 +229,41 @@ def test_failed_verification_still_returns_false_with_telemetry(wizard, monkeypa
     monkeypatch.setattr(wizard, "_run", boom)
     monkeypatch.setattr(wizard, "_doctor_failure_telemetry", lambda *a, **k: None)
     assert wizard._step_doctor() is False
+
+
+def test_verification_timeout_is_bounded_and_named(wizard, monkeypatch, capsys):
+    """A hanging doctor must fail the verification, not hang the install.
+
+    The doctor probes live endpoints (embedder, LLM, warehouse). A probe that
+    BLOCKS rather than fails would stall setup forever — and on CI that burns
+    the whole runner (GitHub's default job cap is 6 hours). Observed on
+    windows-latest: the E2E job sat in_progress for 25+ minutes on this step
+    while its ubuntu/macOS twins finish in well under 10.
+    """
+    import subprocess as _sp
+
+    monkeypatch.setattr(wizard, "_DOCTOR_TIMEOUT_S", 0.5)
+    monkeypatch.setattr(wizard, "_doctor_failure_telemetry", lambda *a, **k: None)
+
+    def hang(cmd, **kw):
+        raise _sp.TimeoutExpired(cmd, 0.5)
+    monkeypatch.setattr(wizard, "_run", hang)
+
+    assert wizard._step_doctor() is False, "a hung doctor must fail verification"
+    blob = "".join(capsys.readouterr())
+    assert "TIMED OUT" in blob
+    assert "hanging, not failing" in blob
+
+
+def test_run_forwards_a_timeout(wizard, monkeypatch):
+    """_run must actually pass the timeout through to subprocess."""
+    seen = {}
+
+    def fake(cmd, **kw):
+        seen.update(kw)
+        class _CP:
+            returncode = 0
+        return _CP()
+    monkeypatch.setattr(wizard.subprocess, "run", fake)
+    wizard._run(["x"], timeout=12.5)
+    assert seen.get("timeout") == 12.5


### PR DESCRIPTION
## Description

**The Windows E2E lane does not fail — it hangs.** That reframes the whole investigation.

Caught mid-run: the job sat `in_progress` for **25+ minutes** on *"Step 5/5: verifying the install"*, with every post-mortem step behind it stuck in `pending` — on a job whose ubuntu and macOS twins finish **entirely** in under 10 minutes.

The log's `exit 1` with no output is the harness eventually killing a **blocked** step, not a child dying silently. Every hypothesis eliminated so far was aimed at the wrong failure mode.

**Why diagnosis was so slow:** the job had no `timeout-minutes`, so GitHub's **6-hour** default applied. Each failing Windows run burned a runner *and* deferred the diagnostic steps that would have explained it.

## Three fixes

**1. Bound the verification.** `_run` grows an optional `timeout=`; `_step_doctor` passes it. The doctor probes live endpoints (embedder, LLM, warehouse) — a probe that *blocks* rather than fails stalls setup forever. A timeout is now a named outcome — *"VERIFICATION TIMED OUT … a probe is hanging, not failing"* — returning exit 3 (installed-but-unverified). §3: a step that can wait forever is indistinguishable from a hung machine.

**2. `timeout-minutes: 25` on the job.** A hang must not cost six hours, and the `if: always()` post-mortem steps must actually run.

**3. `_trace()` breadcrumbs** across the orchestrator boundaries and inside `_step_doctor` — unbuffered to stderr **and** `fsync`'d to a file per call. Since the process dies without flushing, the file is the only trustworthy record; the workflow sets `M3_TRACE_FILE` and dumps it unconditionally.

## Timeout sizing — corrected after review

The first draft used **300s**, chosen as "generous" without measuring. That contradicted a budget this same installer already sets: `--quiesce-timeout` defaults to **30s**, i.e. 30s is long enough to declare a DB-writer *stuck and start killing it*. A verification reading the same machine has no business waiting ten times longer.

Measured instead of guessed:

| Scenario | Time |
|---|---|
| warm doctor (live install) | ~5.9s |
| **cold doctor** (fresh roots, migrations, no embedder — *the E2E case*) | **~5.4s** |

So 300s was ~50× the real cost. **60s is 10×** — an order of magnitude of headroom, the same *order* as the existing quiesce budget, and small enough that a hang surfaces in a minute.

Also folded the captured-telemetry re-run (a separate hardcoded 180s) into the same constant, so there is **one** budget for "how long may a doctor take" rather than three numbers drifting apart.

## Verification

A doctor stubbed to sleep 30s now returns `False` in **2.0s** with the timeout message instead of blocking. 16 tests in the verification file, **100 across the setup suites**, ruff clean.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — 100 setup tests; 2 new (timeout bounded and named, `_run` forwards it)
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale in the constant's comment
- [x] No new warnings introduced

## Related issues
Closes #