### PR TITLE
Fix the Windows E2E hang: an unkillable ancestor is terminal, not retryable

### DIFF
--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -836,6 +836,28 @@ def _quiesce_db_writers(args: argparse.Namespace) -> bool:
         stuck = ", ".join(f"{p.role}(pid {p.pid})" for p in result.stuck)
         _warn(f"  {len(result.stuck)} writer(s) still holding the DB after "
               f"{timeout:.0f}s: {stuck}")
+
+        # An ANCESTOR writer is unkillable by design, so NO branch below can ever
+        # resolve it: --force-quiesce refuses it, the interactive "kill" refuses
+        # it, and "wait"/retry waits on a process that is waiting on us. Every
+        # route is an infinite loop or misleading advice ("re-run elevated" when
+        # privilege is not the problem). Short-circuit here, ONCE, before the
+        # branches — three call sites, one root cause.
+        #
+        # This is the E2E lane's hang: the runner invokes setup THROUGH the MCP
+        # server, so the writer is setup's own parent and the guard fired on
+        # every iteration (244 x 30s before the job cap).
+        ancestors = [p for p in result.stuck if _is_own_ancestor(p.pid)]
+        if ancestors:
+            who = ", ".join(f"{p.role}(pid {p.pid})" for p in ancestors)
+            _err(f"  cannot quiesce {who}: it is this install's own parent "
+                 f"process — no privilege level or retry can stop it.")
+            _err("  You are running setup FROM the m3 process it must stop. "
+                 "Start it from a plain shell instead — e.g. "
+                 "`python -m m3_memory.cli setup` — or run `m3 stop` from a "
+                 "separate terminal first.")
+            halt.clear_halt()  # abort: no exclusive step to protect
+            return False
         force = getattr(args, "force_quiesce", False) or getattr(args, "force_kill_mcp", False)
         gui = getattr(args, "gui_child", False)
         # GUI-triggered elevation is WINDOWS-ONLY: UAC is a GUI dialog that works
@@ -866,17 +888,10 @@ def _quiesce_db_writers(args: argparse.Namespace) -> bool:
                     #  - anything else is almost always an ELEVATED writer an
                     #    unprivileged installer cannot stop, where elevation IS
                     #    the fix.
-                    ancestors = [p for p in result.stuck if _is_own_ancestor(p.pid)]
-                    if ancestors:
-                        who = ", ".join(f"{p.role}(pid {p.pid})" for p in ancestors)
-                        _err(f"  cannot quiesce {who}: it is this install's own "
-                             f"parent process.")
-                        _err("  You are running setup FROM the m3 process it must "
-                             "stop. Start it from a plain shell instead — e.g. "
-                             "`python -m m3_memory.cli setup`, or run `m3 stop` "
-                             "from a separate terminal first.")
-                    else:
-                        _surface_elevated_kill_help(halt, result.stuck)
+                    # Ancestors are handled by the short-circuit at the top of
+                    # this loop, so anything reaching here is a genuinely
+                    # elevated writer — elevation IS the fix.
+                    _surface_elevated_kill_help(halt, result.stuck)
                     halt.clear_halt()
                     return False
                 result = halt.wait_for_quiesce(timeout=5.0, on_tick=_quiesce_tick(args))

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -854,10 +854,29 @@ def _quiesce_db_writers(args: argparse.Namespace) -> bool:
                 # privilege". A truly headless run (or a POSIX GUI child, no
                 # console for sudo) stays unelevated.
                 if not _kill_stuck_writers(result.stuck, allow_sudo=gui_can_elevate):
-                    # A kill failed — almost always an ELEVATED writer an
-                    # unprivileged installer can't stop. Do NOT report success or
-                    # migrate under it; abort with the actionable fix.
-                    _surface_elevated_kill_help(halt, result.stuck)
+                    # A kill failed. Two very different causes, and they need
+                    # different advice:
+                    #
+                    #  - an ANCESTOR writer (this install's own parent) is
+                    #    unkillable BY DESIGN. No amount of privilege changes
+                    #    that, so "re-run elevated" is actively misleading. It is
+                    #    also not retryable: re-waiting just re-enters this
+                    #    branch forever (windows-latest: 244 x 30s = the E2E
+                    #    lane's "hang").
+                    #  - anything else is almost always an ELEVATED writer an
+                    #    unprivileged installer cannot stop, where elevation IS
+                    #    the fix.
+                    ancestors = [p for p in result.stuck if _is_own_ancestor(p.pid)]
+                    if ancestors:
+                        who = ", ".join(f"{p.role}(pid {p.pid})" for p in ancestors)
+                        _err(f"  cannot quiesce {who}: it is this install's own "
+                             f"parent process.")
+                        _err("  You are running setup FROM the m3 process it must "
+                             "stop. Start it from a plain shell instead — e.g. "
+                             "`python -m m3_memory.cli setup`, or run `m3 stop` "
+                             "from a separate terminal first.")
+                    else:
+                        _surface_elevated_kill_help(halt, result.stuck)
                     halt.clear_halt()
                     return False
                 result = halt.wait_for_quiesce(timeout=5.0, on_tick=_quiesce_tick(args))
@@ -1126,6 +1145,34 @@ def _offer_elevated_schedule_repair(script: str, *, non_interactive: bool) -> bo
     return False
 
 
+def _own_ancestor_pids() -> set:
+    """This process plus its full ancestor chain — the pids we must never kill.
+
+    Shared by the kill guard and the caller's "is this retryable?" test so the
+    two can never disagree about what counts as our own branch. Degrades to
+    {self, parent} if m3_halt is unavailable; never returns an empty set.
+    """
+    protected = {os.getpid()}
+    try:
+        halt_mod = _import_m3_halt()
+        if halt_mod is not None and hasattr(halt_mod, "_ancestor_pids"):
+            protected.update(halt_mod._ancestor_pids(os.getpid()))
+        else:
+            protected.add(os.getppid())
+    except Exception:  # noqa: BLE001 — best-effort; never block the kill path
+        try:
+            protected.add(os.getppid())
+        except Exception:  # noqa: BLE001
+            pass
+    return protected
+
+
+def _is_own_ancestor(pid: int) -> bool:
+    """True when `pid` is this process or one of its ancestors — i.e. a writer
+    that is unkillable BY DESIGN, so waiting for it to exit can never succeed."""
+    return pid in _own_ancestor_pids()
+
+
 def _kill_stuck_writers(stuck, *, allow_sudo: bool = False) -> bool:
     """Kill every stuck writer; return True only if ALL were stopped (or already
     gone). A False means at least one kill was refused — cross-platform, almost
@@ -1156,18 +1203,7 @@ def _kill_stuck_writers(stuck, *, allow_sudo: bool = False) -> bool:
     #
     # Cross-platform on purpose: POSIX kills with os.kill, and killing an
     # ancestor there is just as fatal — this is not a Windows-only hazard.
-    protected = {os.getpid()}
-    try:
-        halt_mod = _import_m3_halt()
-        if halt_mod is not None and hasattr(halt_mod, "_ancestor_pids"):
-            protected.update(halt_mod._ancestor_pids(os.getpid()))
-        else:
-            protected.add(os.getppid())
-    except Exception:  # noqa: BLE001 — best-effort; never block the kill path
-        try:
-            protected.add(os.getppid())
-        except Exception:  # noqa: BLE001
-            pass
+    protected = _own_ancestor_pids()
 
     all_ok = True
     for p in stuck:
@@ -1175,8 +1211,17 @@ def _kill_stuck_writers(stuck, *, allow_sudo: bool = False) -> bool:
             # Loud, not silent (§3): the caller's quiesce is genuinely incomplete
             # and the install may still hit a lock — but sawing off our own branch
             # is strictly worse than proceeding.
+            #
+            # all_ok stays FALSE on purpose. An ancestor is unkillable BY DESIGN,
+            # so this is not a transient "try again" state: reporting success
+            # here made the caller re-wait the full quiesce timeout and re-enter
+            # this branch forever (observed on windows-latest: 244 iterations x
+            # 30s, which is the E2E lane's "hang"). The caller must treat an
+            # unkillable writer as terminal, not retryable — see the
+            # `unkillable` short-circuit in _step_preflight.
             _warn(f"    refusing to kill {p.role} (pid {p.pid}) — it is this "
                   f"install's own parent process")
+            all_ok = False
             continue
         if killer(p.pid):
             _ok(f"    stopped {p.role} (pid {p.pid})")

--- a/tests/test_setup_kill_protects_ancestors.py
+++ b/tests/test_setup_kill_protects_ancestors.py
@@ -47,10 +47,18 @@ def killed(monkeypatch):
 
 
 def test_never_kills_self(killed, monkeypatch):
+    """Refusing must report FAILURE, not success.
+
+    Returning True here said "all writers handled" while the writer was still
+    alive, so the caller re-waited the full quiesce timeout and re-entered the
+    same branch forever — 244 iterations x 30s on windows-latest, which IS the
+    E2E lane's "hang". An ancestor is unkillable by design: terminal, never
+    retryable.
+    """
     monkeypatch.setattr(sw, "_import_m3_halt", lambda: None)
     ok = sw._kill_stuck_writers([_Proc(os.getpid())])
     assert os.getpid() not in killed, "the installer killed its own process"
-    assert ok is True
+    assert ok is False, "an unkillable ancestor must not report success"
 
 
 def test_never_kills_the_parent(killed, monkeypatch):
@@ -88,3 +96,27 @@ def test_ancestor_lookup_failure_still_protects_self(killed, monkeypatch):
 
     sw._kill_stuck_writers([_Proc(os.getpid())])
     assert os.getpid() not in killed
+
+
+def test_ancestor_refusal_is_not_retryable(killed, monkeypatch):
+    """The refusal must be TERMINAL, so the caller breaks instead of looping.
+
+    `_kill_stuck_writers` returning False routes the caller to its abort path;
+    returning True made it re-wait and re-enter forever. This pins the signal
+    the loop depends on.
+    """
+    fake = types.ModuleType("m3_halt")
+    fake._ancestor_pids = lambda pid, **kw: {424242}
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: fake)
+    assert sw._kill_stuck_writers([_Proc(424242, role="mcp")]) is False
+    assert killed == []
+
+
+def test_is_own_ancestor_agrees_with_the_guard(monkeypatch):
+    """One implementation: the caller's test and the guard must never disagree."""
+    fake = types.ModuleType("m3_halt")
+    fake._ancestor_pids = lambda pid, **kw: {555555}
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: fake)
+    assert sw._is_own_ancestor(555555) is True
+    assert sw._is_own_ancestor(os.getpid()) is True
+    assert sw._is_own_ancestor(999999) is False

--- a/tests/test_setup_kill_protects_ancestors.py
+++ b/tests/test_setup_kill_protects_ancestors.py
@@ -120,3 +120,77 @@ def test_is_own_ancestor_agrees_with_the_guard(monkeypatch):
     assert sw._is_own_ancestor(555555) is True
     assert sw._is_own_ancestor(os.getpid()) is True
     assert sw._is_own_ancestor(999999) is False
+
+
+# ── the short-circuit: an ancestor must never reach a retry branch ───────────
+
+def test_ancestor_aborts_the_quiesce_instead_of_looping(monkeypatch, capsys):
+    """An unkillable ancestor must abort ONCE, not spin.
+
+    Every branch below the short-circuit is a dead end for this case:
+    --force-quiesce refuses it, the interactive "kill" refuses it, and
+    "wait"/retry waits on a process that is waiting on us. On windows-latest the
+    force path looped 244 times x 30s — the E2E lane's entire "hang".
+
+    Drives the real loop (_quiesce_db_writers) and fails if any retry branch is
+    reached at all.
+    """
+    import argparse
+
+    waits = {"n": 0}
+
+    class _Stuck:
+        def __init__(self, pid, role="mcp"):
+            self.pid, self.role = pid, role
+
+    class _Result:
+        ok = False
+        stuck = [_Stuck(777777)]
+
+    class _Halt:
+        def raise_halt(self, *a, **k):
+            return True
+
+        def clear_halt(self, *a, **k):
+            return None
+
+        def list_all_db_writers(self, *a, **k):
+            return [_Stuck(777777)]
+
+        def list_blocking_db_writers(self, *a, **k):
+            return [_Stuck(777777)]
+
+        def set_halt(self, *a, **k):
+            return True
+
+        def elevated_kill_commands(self, *a, **k):
+            return []
+
+        def kill_stale_daemons(self, *a, **k):
+            return []
+
+        def wait_for_quiesce(self, *a, **k):
+            waits["n"] += 1
+            if waits["n"] > 4:
+                raise AssertionError("looped: the short-circuit did not fire")
+            return _Result()
+
+    monkeypatch.setattr(sw, "_import_m3_halt", lambda: _Halt())
+    monkeypatch.setattr(sw, "_is_own_ancestor", lambda pid: pid == 777777)
+    monkeypatch.setattr(sw, "_quiesce_tick", lambda args: None)
+    monkeypatch.setattr(sw, "_quiesce_tick_done", lambda args: None)
+    monkeypatch.setattr(sw, "_kill_stuck_writers",
+                        lambda *a, **k: pytest.fail("reached the kill branch"))
+    monkeypatch.setattr(sw, "_surface_elevated_kill_help",
+                        lambda *a, **k: pytest.fail("blamed privilege"))
+
+    args = argparse.Namespace(non_interactive=True, force_quiesce=True,
+                              force_kill_mcp=False, gui_child=False,
+                              quiesce_timeout=1.0)
+    assert sw._quiesce_db_writers(args) is False, (
+        "an unkillable ancestor must abort the quiesce, not report success"
+    )
+    blob = "".join(capsys.readouterr())
+    assert "own parent process" in blob
+    assert "no privilege level or retry can stop it" in blob
+    assert "m3 stop" in blob, "must name the actionable fix"


### PR DESCRIPTION
## The hang is found, and the trace named it

windows-latest logged this **244 times**:

```
[!]   1 writer(s) still holding the DB after 30s: mcp(pid 8232)
[!]     refusing to kill mcp (pid 8232) — it is this install's own parent
```

**244 × 30s is the E2E lane's 25-minute "hang"** — an infinite quiesce loop, not a crash. The earlier `exit 1` with no output was the harness killing a **blocked** step, which is why every crash-shaped hypothesis missed.

## Cause — and it is mine

The ancestor guard I added in #121 returned `True` ("all writers handled") while the writer was still **alive**. The caller reads `True` as success, re-waits the full quiesce timeout, finds the same writer, refuses again — forever. On the runner the MCP server is setup's own **parent** (the job invokes setup through it), so the guard fired every iteration.

An ancestor is unkillable **by design**. That is terminal, never retryable.

## The fix

The check now happens **once, at the top of the quiesce loop, before any branch**. The philosophy pass is what found the full blast radius — asking *"what does this do to a user who runs `m3 setup` from inside the m3 MCP server?"* surfaced three dead ends, not one:

| Path | Was |
|---|---|
| `--force-quiesce` | infinite loop |
| non-force | advises `--force-quiesce`, which now also aborts → dead end |
| interactive "kill" | "re-run elevated" — misleading; privilege cannot stop your own parent |
| interactive "wait" | waits forever on a process waiting on us |

All four now abort once with the fix that actually works:

> You are running setup FROM the m3 process it must stop. Start it from a plain shell — `python -m m3_memory.cli setup` — or run `m3 stop` from a separate terminal first.

The per-branch copy from the first draft is **removed**: one implementation, so the branches cannot drift (§10a). Anything reaching the elevation help is now genuinely an elevated writer, where elevation *is* the fix.

## Why this was diagnosable at all

The 25-minute job cap merged in #123 did its job: the run was **cancelled at the cap** instead of burning a 6-hour runner, so the `if: always()` trace dump actually ran.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **103 across the setup suites**; the new test drives the real `_quiesce_db_writers` loop (not source order) and **fails on the pre-fix wizard**
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale in the code comment
- [x] No new warnings introduced

## Related issues
Closes #