### PR TITLE
E2E: invoke setup as a module, not via the `m3` console script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,15 @@ jobs:
         # --no-shared-embedder / --no-dashboard / --no-governor-migration:
         #   long-lived services and OS scheduler entries are not the subject
         #   of this test and would leak state on a shared runner.
-        m3 setup \
+        # Invoke the MODULE, not the `m3` console script. On Windows the script's
+        # UTF-8 re-exec SPAWNS a child rather than replacing the image, so the
+        # launcher generation stays alive as a registered m3 process for the whole
+        # run. Setup's preflight then finds its own PARENT holding the DB and
+        # correctly refuses to kill it — exit 2, "cannot quiesce mcp(pid N): it is
+        # this install's own parent process". `python -m m3_memory.cli` has no
+        # launcher generation. This is exactly the advice setup itself prints for
+        # this case, so CI should follow it.
+        python -m m3_memory.cli setup \
           --non-interactive --terminal \
           --agents "" --capture-mode none \
           --no-native-wheel --no-shared-embedder \
@@ -347,7 +355,15 @@ jobs:
         export M3_ENGINE_ROOT="$M3_E2E_ROOT/engine"
         echo "engine root before upgrade:"
         ls -la "$M3_E2E_ROOT/engine"
-        m3 setup \
+        # Invoke the MODULE, not the `m3` console script. On Windows the script's
+        # UTF-8 re-exec SPAWNS a child rather than replacing the image, so the
+        # launcher generation stays alive as a registered m3 process for the whole
+        # run. Setup's preflight then finds its own PARENT holding the DB and
+        # correctly refuses to kill it — exit 2, "cannot quiesce mcp(pid N): it is
+        # this install's own parent process". `python -m m3_memory.cli` has no
+        # launcher generation. This is exactly the advice setup itself prints for
+        # this case, so CI should follow it.
+        python -m m3_memory.cli setup \
           --non-interactive --terminal \
           --agents "" --capture-mode none \
           --no-native-wheel --no-shared-embedder \


### PR DESCRIPTION
## Description

With the infinite-loop fix (#124) in, the Windows lane now **fails fast — 2m15s, down from 25 minutes** — and names its own cause:

```
[X] cannot quiesce mcp(pid 8792): it is this install's own parent process
[X] setup aborted by preflight
```

**The abort is correct.** Setup genuinely *is* a descendant of a process the writer scan identifies as m3.

On Windows the `m3` console script's UTF-8 re-exec **spawns a child** (`subprocess.run`, which blocks) rather than replacing the process image, so a launcher generation stays alive for the whole run — and `scan_db_writer_processes`, a cmdline scan independent of the PID registry, matches it as an m3 DB-writer.

`python -m m3_memory.cli setup` has no launcher generation. **That is exactly the advice setup itself prints for this case**, so CI follows it.

## ⚠️ This unblocks the lane; it does not fully absolve the product

A real user running `m3 setup` on Windows can hit the same refusal. The underlying question — *should a blocked re-exec shim be reported as a quiescable DB-writer at all?* — belongs in `scan_db_writer_processes`, not in a workflow.

Filing that separately rather than bundling a writer-discovery change into a CI fix. The refusal is still strictly better than the old behaviour: it aborts in seconds with actionable advice instead of hanging for 25 minutes.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — workflow-only change; CI on this PR is the test
- [x] Lint clean — no Python touched
- [x] Type check passes — no Python touched
- [x] Documentation updated if needed — rationale in the workflow comment
- [x] No new warnings introduced

YAML re-validated; both setup invocations confirmed converted.

## Related issues
Closes #