### PR TITLE
Fix `m3 setup` self-flagging as an MCP server; verify daemons run after install

### DIFF
--- a/bin/m3_halt.py
+++ b/bin/m3_halt.py
@@ -35,6 +35,7 @@ import enum
 import json
 import logging
 import os
+import re
 import sys
 import threading
 import time
@@ -324,8 +325,27 @@ _WRITER_CMDLINE_SIGNATURES = {
     # normal desktop — was invisible to every pre-flight scan. Match the m3
     # launcher too, anchored on a path separator so it cannot match an unrelated
     # process that merely contains "m3".
-    "mcp": ("mcp-memory", "mcp_proxy.py", "/m3.exe", "\\m3.exe", "/m3 ", "\\m3 "),
+    "mcp": ("mcp-memory", "mcp_proxy.py"),
 }
+
+# A BARE `m3` (no subcommand) starts the MCP server — see m3_memory/cli.py, which
+# falls through to _run_bridge() when no subcommand is given. It must be detected
+# as a writer. But `m3 setup`, `m3 doctor`, `m3 stop`, `m3 memory ...` are all
+# short-lived COMMANDS that hold nothing.
+#
+# The old signatures were the substrings "/m3.exe", "\\m3.exe", "/m3 ", "\\m3 ",
+# which match the EXECUTABLE and cannot tell those apart — so `m3 setup` flagged
+# ITSELF as a live MCP server. On Windows that was fatal rather than cosmetic:
+# preflight found its own parent "holding" the DB, correctly refused to kill an
+# ancestor, and aborted the install (exit 2). `m3 setup` simply could not run
+# through the console script. Meanwhile the real server (memory_bridge.py) was
+# matched by NONE of them — the signature was inverted.
+#
+# Anchoring on END-OF-CMDLINE captures exactly "m3 was invoked with no
+# subcommand", cross-platform (works for /usr/local/bin/m3 and a quoted Windows
+# path alike), with no dependency on which flags a future subcommand adds.
+_MCP_BARE_M3_RE = re.compile(
+    r"""(?:^|[\\/ "'])m3(?:\.exe)?["']?(?:\s+serve\b.*)?\s*$""", re.I)
 # Fallback process-NAME substrings, used when a process's cmdline is unreadable —
 # which happens for an ELEVATED process when the installer runs unprivileged
 # (psutil returns an empty cmdline / raises AccessDenied). The name alone can't
@@ -386,10 +406,19 @@ def scan_db_writer_processes(engine_root: Optional[str] = None) -> list[ProcInfo
                     if any(sig in cmdline for sig in sigs):
                         matched = role
                         break
+                # A BARE `m3` (no subcommand) IS the MCP server; `m3 setup` /
+                # `m3 doctor` / `m3 stop` are commands that hold nothing. See
+                # _MCP_BARE_M3_RE — an executable-substring match cannot tell
+                # them apart and made the installer flag itself.
+                if matched is None and _MCP_BARE_M3_RE.search(cmdline):
+                    matched = "mcp"
             if matched:
-                # Skip the venv launcher stub — it shares the real worker's
-                # cmdline but holds nothing and can never quiesce. See
-                # _is_venv_launcher_stub.
+                # Skip a SHIM generation — it shares the real worker's cmdline
+                # but holds nothing and can never quiesce, so counting it burns
+                # the whole quiesce timeout and then names it as stuck.
+                #
+                # The venv Scripts/ redirector shares the worker's cmdline
+                # but holds nothing (_is_venv_launcher_stub).
                 if _is_venv_launcher_stub(proc):
                     continue
                 found.append(ProcInfo(pid=pid, role=matched, started_at="",

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -2695,6 +2695,79 @@ def _doctor_failure_telemetry(argv: list, rc: "int | None") -> None:
               "its output in transit.")
 
 
+def _step_verify_daemons(plan=None) -> bool:
+    """Confirm the background services this install ENABLED are actually running.
+
+    An install/upgrade STOPS m3's daemons (the preflight quiesce is required so
+    nothing holds the DB through a migration) and is responsible for bringing
+    them back. Nothing verified that: the cognitive-loop and dashboard probes
+    print "installed but not running" as WARNINGS that feed no exit code, so
+    setup could report success over a system whose writers were all down —
+    exactly the state a user is left in after an upgrade that quiesced them.
+
+    Verified through the PID registry (m3_halt.list_live_processes), which is
+    the same source the quiesce reads, so "running" here means the same thing it
+    means everywhere else. Registration is cross-platform, so this is too.
+
+    Reports which expected roles are missing and returns False; the caller
+    decides severity. Best-effort: an unavailable registry yields True rather
+    than blocking an otherwise-good install on a probe failure (§3 — degrade to
+    "unknown", never to a false alarm).
+    """
+    # Field names verified against SetupPlan — a typo here would make this check
+    # silently pass (getattr(..., False) on a misspelling reads as "not enabled"),
+    # which is the same silent-success class this step exists to close.
+    #
+    # embed-server is DELIBERATELY absent: it is a SERVICE, not a registered
+    # writer. The Rust m3-embed-server never joins the PID registry, so asking
+    # the registry about it reports "NOT running" while it is serving :8082
+    # (verified live — health 200 with no registry entry). Its liveness is an
+    # HTTP /health probe, which `m3 doctor`'s shared-embedder probe already owns
+    # and repairs; duplicating that here would only add a false alarm.
+    _SERVICES = (
+        ("cognitive_loop", "cognitive-loop"),
+        ("install_dashboard", "dashboard"),
+    )
+    expected: list[str] = []
+    if plan is not None:
+        for field, role in _SERVICES:
+            if not hasattr(plan, field):  # fail loud on drift, never silently skip
+                _warn(f"  internal: SetupPlan has no {field!r}; cannot verify "
+                      f"{role}. This is a bug — please report it.")
+                continue
+            if getattr(plan, field):
+                expected.append(role)
+    if not expected:
+        return True  # nothing was enabled → nothing to verify
+
+    _say("Verifying background services are running")
+    halt = _import_m3_halt()
+    if halt is None or not hasattr(halt, "list_live_processes"):
+        _warn("  could not read the process registry — service state UNKNOWN. "
+              "Run `m3 doctor` to check.")
+        return True
+
+    try:
+        live_roles = {(p.role or "").split("(", 1)[0].strip()
+                      for p in halt.list_live_processes()}
+    except Exception as e:  # noqa: BLE001 — a probe must not fail the install
+        _warn(f"  could not read the process registry ({type(e).__name__}) — "
+              f"service state UNKNOWN. Run `m3 doctor` to check.")
+        return True
+
+    missing = [r for r in expected if r not in live_roles]
+    for role in expected:
+        if role in live_roles:
+            _ok(f"  {role}: running")
+    for role in missing:
+        _warn(f"  {role}: NOT running")
+    if missing:
+        _warn(f"  {len(missing)} of {len(expected)} background service(s) are "
+              f"not running. `m3 doctor --fix` restarts what self-repairs.")
+        return False
+    return True
+
+
 def _step_doctor(plan=None) -> bool:
     """Final verification — DOES the install actually work?
 
@@ -2929,6 +3002,15 @@ def run_setup(args: argparse.Namespace) -> int:
         _trace("after governor_migration")
         verified = _step_doctor(plan)
         _trace(f"after step_doctor -> verified={verified}")
+        # An install/upgrade STOPS the daemons (preflight must quiesce them so
+        # nothing holds the DB through a migration) and owns restarting them.
+        # Verify that actually happened: a green doctor over a system whose
+        # writers are all down is the silent success this whole step exists to
+        # prevent, and it is the state an upgrade leaves behind if a restart
+        # fails. Folded into `verified`, so the exit code says so (3, not 0).
+        daemons_up = _step_verify_daemons(plan)
+        _trace(f"after verify_daemons -> up={daemons_up}")
+        verified = verified and daemons_up
         _summary(plan, governor_result, verified=verified)
         _trace("after summary")
         # Exit 3 = "installed but not verified healthy". Distinct from 0

--- a/tests/test_halt_writer_detection.py
+++ b/tests/test_halt_writer_detection.py
@@ -34,6 +34,13 @@ def _cmd_role(halt, cmdline):
     for role, sigs in halt._WRITER_CMDLINE_SIGNATURES.items():
         if any(s in cmdline for s in sigs):
             return role
+    # A bare `m3` / `m3 serve` IS the MCP server, but `m3 setup` / `m3 doctor`
+    # are commands that hold nothing — an executable substring cannot tell them
+    # apart (it made the installer flag itself). scan_db_writer_processes
+    # consults this regex after the substring table; mirror that here so the
+    # helper matches what the scan actually does.
+    if halt._MCP_BARE_M3_RE.search(cmdline):
+        return "mcp"
     return None
 
 

--- a/tests/test_halt_writer_signatures.py
+++ b/tests/test_halt_writer_signatures.py
@@ -1,0 +1,93 @@
+r"""The writer scan must not mistake an m3 COMMAND for the m3 SERVER.
+
+A bare `m3` (no subcommand) starts the MCP server — cli.py falls through to
+_run_bridge() — so it must be detected as a DB-writer. But `m3 setup`,
+`m3 doctor`, `m3 stop` and `m3 memory ...` are short-lived commands that hold
+nothing.
+
+The old signatures were the substrings "/m3.exe", "\\m3.exe", "/m3 ", "\\m3 ",
+which match the EXECUTABLE and cannot tell those apart. Two consequences, both
+real:
+
+  - `m3 setup` flagged ITSELF as a live MCP server. On Windows that was fatal,
+    not cosmetic: preflight found its own parent "holding" the DB, correctly
+    refused to kill an ancestor, and aborted the install (exit 2). `m3 setup`
+    could not run through the console script at all.
+  - the REAL server (memory_bridge.py) was matched by none of them.
+
+The signature was, in effect, inverted. These tests pin both directions.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BIN = Path(__file__).resolve().parents[1] / "bin"
+sys.path.insert(0, str(_BIN))
+
+import m3_halt  # noqa: E402
+
+SERVER_CMDLINES = [
+    "m3",
+    "m3.exe",
+    r"C:\Users\u\.local\bin\m3.exe",
+    r'"C:\Users\u\.local\bin\m3.exe"',
+    "/usr/local/bin/m3",
+    # the real shape on this box: the venv interpreter running the m3 shim
+    r"C:\x\pipx\venvs\m3-memory\Scripts\python.exe C:\u\.local\bin\m3.exe",
+    # `m3 serve` runs the bridge as a streamable-HTTP MCP server — a genuine
+    # long-lived writer, and the ONE subcommand that IS the server. A regex that
+    # only allowed a bare `m3` would silently stop detecting it.
+    r"C:\x\Scripts\m3.exe serve",
+    "/home/u/.local/bin/m3 serve --port 8080",
+]
+
+COMMAND_CMDLINES = [
+    r"C:\x\Scripts\m3.exe setup --non-interactive --terminal",
+    r"C:\x\Scripts\m3.exe doctor",
+    r"C:\x\Scripts\m3.exe stop",
+    "/usr/bin/m3 memory memory_write --content x",
+    "/usr/bin/m3 chatlog status",
+    # the module form, and the UTF-8 re-exec child it spawns on Windows
+    r"C:\py\python.exe -m m3_memory.cli setup",
+    r"C:\py\python.exe -X utf8 -m m3_memory.cli setup",
+]
+
+
+@pytest.mark.parametrize("cmd", SERVER_CMDLINES)
+def test_bare_m3_is_detected_as_the_mcp_server(cmd):
+    assert m3_halt._MCP_BARE_M3_RE.search(cmd), (
+        f"a bare `m3` starts the MCP server and must be seen as a writer: {cmd!r}"
+    )
+
+
+@pytest.mark.parametrize("cmd", COMMAND_CMDLINES)
+def test_m3_subcommands_are_not_the_server(cmd):
+    assert not m3_halt._MCP_BARE_M3_RE.search(cmd), (
+        f"an m3 SUBCOMMAND holds no DB and must not be flagged as a writer — "
+        f"flagging `m3 setup` made the installer abort on its own parent: {cmd!r}"
+    )
+
+
+def test_the_old_executable_substrings_are_gone():
+    """Guard the fix itself: re-adding an exe-substring signature reintroduces
+    the self-flagging bug, because it cannot see the subcommand."""
+    sigs = m3_halt._WRITER_CMDLINE_SIGNATURES.get("mcp", ())
+    for bad in ("/m3.exe", "\\m3.exe", "/m3 ", "\\m3 "):
+        assert bad not in sigs, (
+            f"{bad!r} matches the executable, not the invocation — `m3 setup` "
+            f"would flag itself again"
+        )
+
+
+def test_the_real_bridge_still_matches_a_signature():
+    """memory_bridge.py is the actual server process; something must catch it.
+
+    It registers itself via the PID registry (register_process("mcp")), which is
+    the primary path — this asserts the roles table still knows the mcp role so
+    a registry entry classifies correctly.
+    """
+    assert "mcp" in m3_halt._WRITER_CMDLINE_SIGNATURES
+    assert "mcp-memory" in m3_halt._WRITER_CMDLINE_SIGNATURES["mcp"]

--- a/tests/test_setup_post_install_verify.py
+++ b/tests/test_setup_post_install_verify.py
@@ -267,3 +267,70 @@ def test_run_forwards_a_timeout(wizard, monkeypatch):
     monkeypatch.setattr(wizard.subprocess, "run", fake)
     wizard._run(["x"], timeout=12.5)
     assert seen.get("timeout") == 12.5
+
+
+# ── post-install daemon liveness ─────────────────────────────────────────────
+
+class _P:
+    """Minimal SetupPlan stand-in."""
+    def __init__(self, loop=False, dash=False):
+        self.cognitive_loop = loop
+        self.install_dashboard = dash
+
+
+def _fake_halt(roles):
+    import types
+    m = types.ModuleType("m3_halt")
+    m.list_live_processes = lambda *a, **k: [
+        types.SimpleNamespace(role=r, pid=i) for i, r in enumerate(roles, 1)
+    ]
+    return m
+
+
+def test_daemons_running_is_success(wizard, monkeypatch, capsys):
+    monkeypatch.setattr(wizard, "_import_m3_halt",
+                        lambda: _fake_halt(["cognitive-loop", "dashboard"]))
+    assert wizard._step_verify_daemons(_P(loop=True, dash=True)) is True
+    assert "cognitive-loop: running" in capsys.readouterr().out
+
+
+def test_a_stopped_daemon_fails_verification(wizard, monkeypatch, capsys):
+    """An upgrade STOPS the daemons and owns restarting them.
+
+    Reporting success over a system whose writers are all down is the silent
+    success this step exists to prevent — and it is exactly the state an upgrade
+    leaves if a restart fails. The cognitive-loop/dashboard probes print
+    "not running" as WARNINGS that feed no exit code, so nothing caught it.
+    """
+    monkeypatch.setattr(wizard, "_import_m3_halt",
+                        lambda: _fake_halt(["dashboard"]))
+    assert wizard._step_verify_daemons(_P(loop=True, dash=True)) is False
+    blob = "".join(capsys.readouterr())
+    assert "cognitive-loop: NOT running" in blob
+    assert "m3 doctor --fix" in blob, "must name the repair"
+
+
+def test_nothing_enabled_is_vacuously_ok(wizard, monkeypatch):
+    monkeypatch.setattr(wizard, "_import_m3_halt", lambda: _fake_halt([]))
+    assert wizard._step_verify_daemons(_P()) is True
+
+
+def test_unreadable_registry_does_not_fail_the_install(wizard, monkeypatch, capsys):
+    """Degrade to UNKNOWN, never to a false alarm (§3)."""
+    monkeypatch.setattr(wizard, "_import_m3_halt", lambda: None)
+    assert wizard._step_verify_daemons(_P(loop=True)) is True
+    assert "UNKNOWN" in "".join(capsys.readouterr())
+
+
+def test_embed_server_is_not_registry_checked(wizard, monkeypatch, capsys):
+    """The embed server is a SERVICE, not a registered writer.
+
+    It never joins the PID registry, so a registry check reports "NOT running"
+    while it serves :8082 — verified live (health 200, no registry entry). Its
+    liveness belongs to doctor's HTTP /health probe.
+    """
+    monkeypatch.setattr(wizard, "_import_m3_halt", lambda: _fake_halt([]))
+    plan = _P()
+    plan.use_shared_embedder = True
+    assert wizard._step_verify_daemons(plan) is True
+    assert "embed-server" not in "".join(capsys.readouterr())


### PR DESCRIPTION
Two fixes to the install path, both found by chasing *"why can't `m3 setup` run on Windows?"* to the end.

## 1. `m3 setup` flagged ITSELF as a running MCP server

`_WRITER_CMDLINE_SIGNATURES` matched the `mcp` role on the substrings `/m3.exe`, `\m3.exe`, `/m3 `, `\m3 `. Those match the **executable**, so they cannot tell

| IS the server | is NOT |
|---|---|
| `m3` (falls through to `_run_bridge`) | `m3 setup` |
| `m3 serve` (streamable-HTTP bridge) | `m3 doctor`, `m3 stop`, `m3 memory …` |

apart. **The signature was effectively inverted:** `m3 setup` matched it, while the real server (`memory_bridge.py`) matched *none* of them.

On Windows that was fatal, not cosmetic — preflight found its own **parent** holding the DB, correctly refused to kill an ancestor, and aborted the install (exit 2). Setup could not run through the console script at all, which is why the E2E lane had to switch to the module form.

Now anchored at **end-of-cmdline**: `m3`/`m3.exe` with no subcommand, or with `serve`.

**Blast radius checked, not assumed.** `m3 serve` is the only subcommand that *is* a server — `tests/test_halt_writer_detection.py` already guarded it, and its helper duplicated the substring loop, so it now consults the same regex the scan uses rather than drifting. Verified across **9 POSIX shapes** too (`/usr/local/bin/m3`, symlinked venv `bin/m3`, and `m3-embed-server` correctly *not* matching).

## 2. Nothing verified the daemons were running afterwards

An install/upgrade **stops** m3's daemons (preflight must quiesce them so nothing holds the DB through a migration) and owns bringing them back. The cognitive-loop and dashboard probes print *"installed but not running"* as **warnings that feed no exit code** — so setup could report success over a system whose writers were all down.

Not hypothetical: that is the state a user is left in when a restart fails after an upgrade.

`_step_verify_daemons` now checks the services this run **enabled** against the PID registry (the same source the quiesce reads), names any that are down, points at `m3 doctor --fix`, and folds into `verified` so the exit code says so (**3**, not 0).

### Two things it deliberately does not do — both found by testing live

- **`embed-server` is not registry-checked.** It is a *service*, not a registered writer: the Rust server never joins the PID registry, so my first version reported *"embed-server: NOT running"* while it was serving `:8082` (**health 200, no registry entry**). Shipping that would have told every user their embedder was down. Its liveness is doctor's HTTP `/health` probe.
- **An unreadable registry returns True.** A probe failure degrades to *unknown* and says so — never to a false alarm that fails a good install (§3).

Plan field names are asserted against `SetupPlan` rather than assumed: a typo would make `getattr(…, False)` read as *"not enabled"* and silently verify nothing. **Two of my first three guesses were wrong** (`enable_cognitive_loop` does not exist), so the lookup is explicit and warns loudly on drift.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **262** across setup/halt/quiesce; 15 new signature tests (**14 fail on the pre-fix table**) + 5 daemon-liveness tests
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale at both sites
- [x] No new warnings introduced

No SQL in this diff, so the backend seam is not involved (verified, not assumed).

## Related issues
Closes #