### PR TITLE
Release 2026.8.19.13 — `m3 setup` no longer mistakes itself for a running server

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.12",
+  "version": "2026.8.19.13",
   "description": "Give Antigravity a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.12",
+  "version": "2026.8.19.13",
   "description": "Give Claude Code a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,42 @@ the policy is forward-going only.
 
 ### None pending
 
+## [2026.8.19.13] — 2026-08-10 — `m3 setup` no longer mistakes itself for a running server
+
+> The previous release fixed the Windows E2E *hang*. This one fixes what the
+> hang was protecting against: `m3 setup` could not run through the `m3` console
+> script on Windows at all, because it flagged ITSELF as a live MCP server.
+
+### Fixed
+
+- **`m3 setup` reported itself as a running MCP server, and aborted.** The
+  writer scan matched the `mcp` role on the substrings `/m3.exe`, `\m3.exe`,
+  `/m3 `, `\m3 ` — the EXECUTABLE, not the invocation. So it could not tell
+  `m3` (which starts the server) from `m3 setup` / `m3 doctor` / `m3 stop`
+  (commands that hold nothing). The signature was effectively inverted:
+  `m3 setup` matched it while the real server process (`memory_bridge.py`)
+  matched none of it.
+
+  On Windows that was fatal rather than cosmetic — preflight found its own
+  PARENT holding the DB, correctly refused to kill an ancestor, and aborted the
+  install with exit 2. Detection is now anchored at end-of-cmdline: a bare `m3`
+  or `m3 serve` (the two invocations that ARE the server) and nothing else,
+  verified across Windows and POSIX process shapes.
+
+- **Nothing verified m3's background services were running after an
+  install/upgrade.** An install STOPS the daemons — preflight must quiesce them
+  so nothing holds the DB through a migration — and owns restarting them. The
+  cognitive-loop and dashboard probes printed "installed but not running" as
+  warnings that fed no exit code, so setup could report success over a system
+  whose writers were all down. That is the state a user is left in whenever a
+  restart fails. Setup now verifies the services it enabled are live, names any
+  that are not, points at `m3 doctor --fix`, and returns exit 3 rather than 0.
+
+  The embed server is deliberately excluded from that check: it is a service,
+  not a registered writer, and never joins the PID registry — checking it there
+  reported "NOT running" while it was serving :8082. Its liveness stays with
+  doctor's HTTP health probe.
+
 ## [2026.8.19.12] — 2026-08-10 — the Windows install path, and a CI lane that had never been green
 
 > The Windows E2E lane had failed on every run in its recorded history. It was

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.8.19.12",
+  "version": "2026.8.19.13",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.8.19.12"
+version = "2026.8.19.13"
 description = "Give your AI agent a memory — local-first, private, easy to install. Guided setup wizard; works out of the box on your own machine, no cloud. For everyday agent users, homelabs, and developers alike · 99.2% LongMemEval-S retrieval @ k=10 · Works with Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · any MCP agent (native + one-command plugins) · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first memory — 100+ tools, 99.2% LongMemEval-S retrieval@10, hybrid search, GDPR, no cloud.",
-  "version": "2026.8.19.12",
+  "version": "2026.8.19.13",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.8.19.12",
+      "version": "2026.8.19.13",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Description

Cuts **2026.8.19.13**. Version bumped in `pyproject.toml` (single source of truth) and synced to all four derived manifests; `--check`, `test_tool_count_drift.py` and the catalog drift gate all pass.

The previous release fixed the Windows E2E **hang**. This one fixes what the hang was protecting against: **`m3 setup` could not run through the `m3` console script on Windows at all**, because it flagged *itself* as a live MCP server.

### Fixed

**`m3 setup` reported itself as a running MCP server, and aborted.** The writer scan matched the `mcp` role on the substrings `/m3.exe`, `\m3.exe`, `/m3 `, `\m3 ` — the **executable**, not the invocation:

| IS the server | is NOT |
|---|---|
| `m3` (falls through to the bridge) | `m3 setup` |
| `m3 serve` | `m3 doctor`, `m3 stop`, `m3 memory …` |

The signature was effectively **inverted** — `m3 setup` matched it while the real server (`memory_bridge.py`) matched none of it. On Windows that was fatal: preflight found its own **parent** holding the DB, correctly refused to kill an ancestor, and aborted with exit 2.

Now anchored at end-of-cmdline — a bare `m3` or `m3 serve` and nothing else — verified across both Windows and POSIX process shapes.

**Nothing verified m3's background services were running after an install/upgrade.** An install **stops** the daemons (preflight must quiesce them so nothing holds the DB through a migration) and owns restarting them. The cognitive-loop and dashboard probes printed *"installed but not running"* as warnings that fed **no exit code**, so setup could report success over a system whose writers were all down — the state a user is left in whenever a restart fails.

Setup now verifies the services it enabled are live, names any that are not, points at `m3 doctor --fix`, and returns **exit 3** rather than 0.

The embed server is deliberately excluded from that check: it is a *service*, not a registered writer, and never joins the PID registry — checking it there reported *"NOT running"* while it was serving `:8082` (health 200). Its liveness stays with doctor's HTTP probe.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — version-sync gate (9), catalog drift (11), `--check` in sync; 262 across setup/halt/quiesce on the released commit
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — CHANGELOG entry
- [x] No new warnings introduced

**`main` is fully green across all three OSes** at the commit this releases (OVERALL: success). Diff audited for PII / local paths / secrets / bench data before push: clean.

## Related issues
Closes #