### PR TITLE
Fix a health check that could not report ill; restart what setup stopped

### DIFF
--- a/bin/doctor/cognitive_loop_probe.py
+++ b/bin/doctor/cognitive_loop_probe.py
@@ -79,18 +79,41 @@ def _process_running() -> Optional[bool]:
     None when we can't tell (no pgrep/tasklist). Complements the service-state
     check — a Windows ONSTART task in particular is "installed" long before we
     can confirm the daemon is actually up."""
+    # psutil FIRST on every platform: it is already a hard dependency, reads the
+    # cmdline directly, and is the same mechanism m3_halt's writer scan uses — so
+    # "running" means one thing across the codebase.
+    #
+    # This replaces a `wmic` call that could no longer work: wmic is DEPRECATED
+    # and REMOVED in Windows 11 24H2+, so the subprocess returned non-zero and
+    # this function answered None ("unknown") forever. The probe only NAGs on a
+    # POSITIVE "not running", so an unknown meant it printed
+    # "cognitive loop: OK" while the loop was dead — observed 2026-08-10 on a
+    # box where no m3_cognitive_loop process existed at all. A health check that
+    # cannot report ill is worse than none (§3/§5).
+    #
+    # Match on python processes only: the marker string appears in any shell that
+    # merely GREPS for it, and matching those reports the loop as up because
+    # something asked about it.
+    try:
+        import psutil
+        for p in psutil.process_iter(["name", "cmdline"]):
+            try:
+                name = (p.info.get("name") or "").lower()
+                if not any(i in name for i in ("python", "pythonw")):
+                    continue
+                if "m3_cognitive_loop" in " ".join(p.info.get("cmdline") or []):
+                    return True
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return False
+    except ImportError:
+        pass  # fall through to the platform CLIs below
+
     try:
         if sys.platform == "win32":
-            # tasklist can't match on the script arg; WMIC can read the command
-            # line. Best-effort — absence of WMIC just yields None (unknown).
-            proc = subprocess.run(
-                ["wmic", "process", "where",
-                 "name like '%python%'", "get", "commandline"],
-                capture_output=True, text=True,
-            )
-            if proc.returncode != 0:
-                return None
-            return "m3_cognitive_loop" in (proc.stdout or "")
+            # No psutil: tasklist cannot match on the script arg, so we cannot
+            # tell. Unknown, never a false "down".
+            return None
         proc = subprocess.run(
             ["pgrep", "-f", "m3_cognitive_loop"], capture_output=True, text=True
         )

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -2695,6 +2695,45 @@ def _doctor_failure_telemetry(argv: list, rc: "int | None") -> None:
               "its output in transit.")
 
 
+_ROLE_TO_TASK = {
+    "cognitive-loop": "AgentOS_CognitiveLoop",
+    "dashboard": "AgentOS_Dashboard",
+}
+
+
+def _start_service_for_role(role: str) -> bool:
+    """Start the keep-alive task backing `role`. True if the start was issued.
+
+    Reuses install_schedules._start_longlived_tasks rather than re-implementing
+    three platform launches (schtasks /Run, launchctl, systemctl --user) — that
+    module already owns the per-OS mechanism and the _SELF_HEAL_TASKS gate, and a
+    second copy here would drift from it (§10a).
+
+    Why setup must do this at all: install_schedules only restarts the tasks THIS
+    run registered. An upgrade that re-registers nothing therefore restarts
+    nothing, while preflight has already stopped every writer — so the keep-alive
+    cadence (PT30M for the cognitive loop) is the only thing bringing it back,
+    leaving the loop down for up to half an hour after a "successful" setup.
+
+    Best-effort: a missing payload or a failed start returns False and the caller
+    reports the service as down, which is the honest outcome (§3).
+    """
+    task = _ROLE_TO_TASK.get(role)
+    if not task:
+        return False
+    try:
+        from m3_memory.installer import bin_dir
+        bd = bin_dir()
+        if bd and str(bd) not in sys.path:
+            sys.path.insert(0, str(bd))
+        import install_schedules  # type: ignore
+        install_schedules._start_longlived_tasks([{"name": task}])
+        return True
+    except Exception as e:  # noqa: BLE001 — never fail setup on a restart attempt
+        _warn(f"    could not start {task}: {type(e).__name__}: {e}")
+        return False
+
+
 def _step_verify_daemons(plan=None) -> bool:
     """Confirm the background services this install ENABLED are actually running.
 
@@ -2756,6 +2795,26 @@ def _step_verify_daemons(plan=None) -> bool:
         return True
 
     missing = [r for r in expected if r not in live_roles]
+
+    # An install STOPPED these; restarting them is this step's job, not the
+    # user's. Their keep-alive tasks self-heal on a PT30M/PT5M cadence, so
+    # without an explicit kick the cognitive loop can sit DOWN for up to half an
+    # hour after a successful setup — reported accurately, and useless to a user
+    # who just wants a working install. install_schedules only restarts tasks
+    # THIS run registered, so an upgrade that re-registers nothing restarts
+    # nothing.
+    if missing:
+        _say("  restarting stopped services...")
+        for role in list(missing):
+            if _start_service_for_role(role):
+                _ok(f"  {role}: restarted")
+        try:
+            live_roles = {(p.role or "").split("(", 1)[0].strip()
+                          for p in halt.list_live_processes()}
+            missing = [r for r in expected if r not in live_roles]
+        except Exception:  # noqa: BLE001 — keep the pre-restart verdict
+            pass
+
     for role in expected:
         if role in live_roles:
             _ok(f"  {role}: running")

--- a/tests/test_setup_post_install_verify.py
+++ b/tests/test_setup_post_install_verify.py
@@ -334,3 +334,55 @@ def test_embed_server_is_not_registry_checked(wizard, monkeypatch, capsys):
     plan.use_shared_embedder = True
     assert wizard._step_verify_daemons(plan) is True
     assert "embed-server" not in "".join(capsys.readouterr())
+
+
+def test_a_stopped_daemon_is_restarted_not_just_reported(wizard, monkeypatch, capsys):
+    """Setup STOPPED these; restarting them is its job, not the user's.
+
+    install_schedules only restarts tasks THIS run registered, so an upgrade
+    that re-registers nothing restarts nothing — while preflight has already
+    stopped every writer. The keep-alive cadence (PT30M for the cognitive loop)
+    would then be the only thing bringing it back, leaving the loop down for up
+    to half an hour after a "successful" setup. Observed 2026-08-10.
+    """
+    started = []
+    monkeypatch.setattr(wizard, "_start_service_for_role",
+                        lambda role: (started.append(role), True)[1])
+
+    calls = {"n": 0}
+
+    def _halt_mod():
+        import types
+        m = types.ModuleType("m3_halt")
+
+        def live(*a, **k):
+            calls["n"] += 1
+            # down on the first read, up after the restart
+            roles = ["dashboard"] if calls["n"] == 1 else ["dashboard", "cognitive-loop"]
+            return [types.SimpleNamespace(role=r, pid=i) for i, r in enumerate(roles, 1)]
+
+        m.list_live_processes = live
+        return m
+
+    monkeypatch.setattr(wizard, "_import_m3_halt", _halt_mod)
+
+    assert wizard._step_verify_daemons(_P(loop=True, dash=True)) is True, (
+        "a service that comes back after the restart must not fail verification"
+    )
+    assert started == ["cognitive-loop"], f"did not restart the down service: {started}"
+    assert "restarted" in "".join(capsys.readouterr()).lower()
+
+
+def test_a_daemon_that_stays_down_still_fails(wizard, monkeypatch, capsys):
+    """The restart is best-effort — it must not turn a real failure green."""
+    monkeypatch.setattr(wizard, "_start_service_for_role", lambda role: False)
+
+    import types
+    m = types.ModuleType("m3_halt")
+    m.list_live_processes = lambda *a, **k: [
+        types.SimpleNamespace(role="dashboard", pid=1)
+    ]
+    monkeypatch.setattr(wizard, "_import_m3_halt", lambda: m)
+
+    assert wizard._step_verify_daemons(_P(loop=True, dash=True)) is False
+    assert "cognitive-loop: NOT running" in "".join(capsys.readouterr())


### PR DESCRIPTION
Two real defects, both from your live upgrade on Windows 11.

## 1. `m3 doctor` printed "cognitive loop: OK" while the loop was **dead**

`_process_running()` shells out to **`wmic`** on Windows. wmic is **deprecated and removed in Windows 11 24H2+**, so the subprocess returns non-zero and the function answers `None` ("unknown") *forever*.

The probe only NAGs on a **positive** "not running" (`installed AND inactive AND no process`), so an unknown could never reach that branch — it printed `✅ OK` unconditionally.

A health check that cannot report ill is worse than no check (§3/§5). It also **disagreed, in the same run**, with the new post-install verification that correctly reported the loop down — which is how it surfaced.

Now **psutil-first on every platform**: already a hard dependency (`>=7.2.2`), reads the cmdline directly, and is the same mechanism `m3_halt`'s writer scan uses — so "running" means one thing across the codebase. The `pgrep` fallback stays for a psutil-less environment; Windows-without-psutil returns `None` rather than a false "down".

**Matching is restricted to python/pythonw processes.** The marker string appears in any shell that merely *greps* for it, so an unfiltered scan reports the loop as UP because something asked about it. I hit exactly that while diagnosing this — my own tool call matched — and nearly drew the opposite conclusion.

## 2. A successful setup could leave the cognitive loop down for **30 minutes**

Preflight **stops** every DB-writer (required — nothing may hold the DB through a migration), but `install_schedules` only restarts the tasks *this run registered*. An upgrade that re-registers nothing therefore restarts nothing, and the keep-alive cadence — **PT30M** for `AgentOS_CognitiveLoop` — becomes the only thing bringing it back.

Your log shows exactly this: `Restarted AgentOS_Dashboard`, `Restarted AgentOS_EmbedServer`, and the cognitive loop silently left down.

`_step_verify_daemons` now **starts what it finds stopped, then re-checks**, so a service that comes back is not reported as a failure. It delegates to `install_schedules._start_longlived_tasks` rather than re-implementing three platform launches (`schtasks /Run`, `launchctl`, `systemctl --user`) — that module owns the per-OS mechanism and the `_SELF_HEAL_TASKS` gate; a second copy would drift (§10a).

Best-effort by design: a service that **stays** down still fails verification.

## Note on `m3 stop`

Not a bug — your `m3 stop` ran on **2026.8.19.10**, before the upgrade in the same session. It works on `.13` (verified via both the module and the `m3` launcher).

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **391** across setup/halt/doctor; 2 new (restarted-then-passes, stays-down-still-fails)
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale at both sites
- [x] No new warnings introduced

No SQL in this diff, so the backend seam is not involved (verified, not assumed). psutil-first is safe on all three OSes — it is a hard dependency, with the POSIX fallback retained.

## Related issues
Closes #