### PR TITLE
Fix `claude mcp add` failing whenever root pins are passed

### DIFF
--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -2057,7 +2057,18 @@ def _wire_claude(capture_mode: str) -> bool:
     add_cmd = ["claude", "mcp", "add", "--scope", "user"]
     for k, v in env.items():
         add_cmd += ["--env", f"{k}={v}"]
-    add_cmd += ["m3_memory", "m3"]
+    # `--` TERMINATES the option list. `claude mcp add`'s --env is VARIADIC
+    # (`-e, --env <env...>`), so it greedily swallows everything after it —
+    # including the two positionals — and the CLI then fails with
+    #     error: missing required argument 'name'
+    # leaving m3 unwired in Claude Code. Reproduced against the shipped CLI:
+    # without `--` it fails 100% of the time when any --env is present; with it,
+    # the server registers and the env lands intact (verified by reading back
+    # ~/.claude.json).
+    #
+    # This only bites when env vars are passed, which is why it survived: a
+    # roots-less install has an empty env dict and registers fine.
+    add_cmd += ["--", "m3_memory", "m3"]
 
     _say("  · registering m3 memory server in Claude Code (mcp__m3_memory__, user scope)")
     # Drop the legacy roots-less `memory` entry a prior setup created (migration),
@@ -2120,8 +2131,14 @@ def _claude_mcp_add(add_cmd: list[str]) -> bool:
         return True
     if blob:
         print(blob)
+    # Echo the EXACT argv we ran, not a simplified version. The simplified form
+    # ("claude mcp add --scope user m3_memory m3") drops the --env root pins, and
+    # a user who follows it gets a server reading the DEFAULT roots while their
+    # chatlog hook writes to the pinned ones — the split-brain hazard in
+    # CLAUDE.md, arrived at by following our own advice.
+    import shlex
     _warn(f"`claude mcp add m3_memory` failed (exit {proc.returncode}); "
-          "manual: `claude mcp add --scope user m3_memory m3`")
+          f"manual: {shlex.join(add_cmd)}")
     return False
 
 

--- a/tests/test_claude_m3_memory_registration.py
+++ b/tests/test_claude_m3_memory_registration.py
@@ -143,3 +143,46 @@ def test_wire_claude_prints_loud_plugin_default_notice(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "mcp__m3_memory__" in out
     assert "plugin:m3:memory" in out and "disabledMcpServers" in out
+
+
+def test_add_terminates_options_before_the_positionals(monkeypatch):
+    r"""`claude mcp add` needs `--` before the name when --env is present.
+
+    Its --env is VARIADIC (`-e, --env <env...>`), so it greedily swallows
+    everything after it — including the two positionals — and the CLI fails with
+
+        error: missing required argument 'name'
+
+    leaving m3 unwired in Claude Code. Reproduced against the shipped CLI: 100%
+    failure with any --env and no `--`; with `--` the server registers and the
+    env lands intact (verified by reading back ~/.claude.json).
+
+    It survived because a roots-less install passes an empty env dict and so
+    never hits the variadic case.
+    """
+    from types import SimpleNamespace
+
+    from m3_memory import setup_wizard as sw
+
+    monkeypatch.setattr(sw.shutil, "which", lambda name: "/usr/bin/claude")
+    monkeypatch.setattr(sw, "_wire_claude_hooks", lambda mode: True)
+    import m3_memory.installer as inst
+    monkeypatch.setattr(inst, "_canonical_memory_env",
+                        lambda: {"M3_ENGINE_ROOT": "/data/e", "M3_CONFIG_ROOT": "/data/c"})
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(sw.subprocess, "run",
+                        lambda cmd, *a, **k: (calls.append(list(cmd)),
+                                              SimpleNamespace(returncode=0,
+                                                              stdout="ok", stderr=""))[1])
+    assert sw._wire_claude("both") is True
+
+    add = [c for c in calls if "add" in c][0]
+    assert "--" in add, "missing the option terminator — --env will eat the name"
+    # The separator must come AFTER every --env and immediately BEFORE the name.
+    assert add.index("--") == len(add) - 3, f"`--` is misplaced: {add}"
+    assert add[-2:] == ["m3_memory", "m3"]
+    # And every env var must still precede it.
+    for i, tok in enumerate(add):
+        if tok == "--env":
+            assert i < add.index("--"), "an --env landed after the terminator"


### PR DESCRIPTION
## Description

Your install printed:

```
==>   · registering m3 memory server in Claude Code (mcp__m3_memory__, user scope)
error: missing required argument 'name'
[!] `claude mcp add m3_memory` failed (exit 1)
```

…so **m3 was left unwired in Claude Code**, and `m3 doctor --fix` had to recover it.

### Cause

`claude mcp add`'s `--env` is **variadic** — the CLI declares it as `-e, --env <env...>`. Without an option terminator it greedily consumes everything that follows, **including the two positionals** (`m3_memory m3`), so the parser then has no `name`.

Reproduced against the shipped CLI: **100% failure** with any `--env` and no `--`; with `--` the server registers and the env lands intact (verified by reading the entry back out of `~/.claude.json`).

It survived this long because the bug only appears **when env vars are passed** — a roots-less install has an empty env dict and registers fine. Decoupled roots are now the default, so every fresh install hits it.

### Also fixed: the failure message was itself a trap

It printed a *simplified* manual command — `claude mcp add --scope user m3_memory m3` — which **drops the `--env` root pins**. A user following our own advice would get a server reading the **default** roots while their chatlog hook writes to the **pinned** ones: the split-brain hazard `CLAUDE.md` warns about, arrived at by doing what we told them.

It now echoes the exact argv that was run.

### Scope

Checked the whole class, not the one instance: this is the **only** place the codebase builds a `claude mcp add` argv, and the only `--env` construction.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **217** across claude/wire/setup/mcp; new test asserts the terminator is present, sits immediately before the positionals, and that no `--env` escapes past it. **It fails on the pre-fix wizard.**
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale at the call site
- [x] No new warnings introduced

Verified end-to-end against the live `claude` CLI: rc=0, server registered, **both root pins intact**.

No SQL in this diff, so the backend seam is not involved.

## Related issues
Closes #