### PR TITLE
Release 2026.8.19.14 — two failures a real upgrade surfaced

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.13",
+  "version": "2026.8.19.14",
   "description": "Give Antigravity a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.13",
+  "version": "2026.8.19.14",
   "description": "Give Claude Code a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,42 @@ the policy is forward-going only.
 
 ### None pending
 
+## [2026.8.19.14] — 2026-08-10 — two failures a real upgrade surfaced
+
+> Both fixes came from one user's upgrade log on Windows 11: a health check that
+> could not report ill, and an agent-wiring call that failed whenever roots were
+> pinned.
+
+### Fixed
+
+- **`m3 doctor` reported "cognitive loop: OK" while the loop was dead.** The
+  Windows liveness check shelled out to `wmic`, which is DEPRECATED and REMOVED
+  in Windows 11 24H2+. The subprocess returned non-zero, the check answered
+  "unknown" forever, and because the probe only nags on a POSITIVE "not
+  running", it printed OK unconditionally. A health check that cannot report ill
+  is worse than none. Now psutil-first on every platform — already a hard
+  dependency, and the same mechanism the writer scan uses, so "running" means
+  one thing across the codebase. Matching is restricted to python processes: the
+  marker string appears in any shell that merely greps for it, which would
+  otherwise report the loop as up because something asked about it.
+
+- **A successful setup could leave the cognitive loop down for 30 minutes.**
+  Preflight stops every DB-writer (required — nothing may hold the DB through a
+  migration), but the installer only restarts tasks THAT run registered. An
+  upgrade that re-registers nothing restarted nothing, leaving the keep-alive
+  cadence (PT30M) as the only thing bringing the loop back. Setup now starts
+  what it finds stopped and re-checks, so a service that returns is not reported
+  as a failure — and one that stays down still fails verification.
+
+- **`claude mcp add` failed whenever root pins were passed**, leaving m3 unwired
+  in Claude Code. The CLI's `--env` is variadic (`-e, --env <env...>`), so
+  without an option terminator it swallowed the two positionals and the parser
+  reported `missing required argument 'name'`. The bug only appeared when env
+  vars were present, so a roots-less install never hit it — and decoupled roots
+  are now the default. The failure message also printed a simplified manual
+  command that DROPPED the root pins, which would have produced the split-brain
+  the pins exist to prevent; it now echoes the exact argv that ran.
+
 ## [2026.8.19.13] — 2026-08-10 — `m3 setup` no longer mistakes itself for a running server
 
 > The previous release fixed the Windows E2E *hang*. This one fixes what the

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.8.19.13",
+  "version": "2026.8.19.14",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.8.19.13"
+version = "2026.8.19.14"
 description = "Give your AI agent a memory — local-first, private, easy to install. Guided setup wizard; works out of the box on your own machine, no cloud. For everyday agent users, homelabs, and developers alike · 99.2% LongMemEval-S retrieval @ k=10 · Works with Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · any MCP agent (native + one-command plugins) · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first memory — 100+ tools, 99.2% LongMemEval-S retrieval@10, hybrid search, GDPR, no cloud.",
-  "version": "2026.8.19.13",
+  "version": "2026.8.19.14",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.8.19.13",
+      "version": "2026.8.19.14",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Description

Cuts **2026.8.19.14**. Version bumped in `pyproject.toml` (single source of truth) and synced to all four derived manifests; `--check`, `test_tool_count_drift.py` and the catalog drift gate all pass.

Both fixes came from **one user's upgrade log** on Windows 11 — neither was reachable from CI.

### Fixed

**`m3 doctor` reported "cognitive loop: OK" while the loop was dead.** The Windows liveness check shelled out to `wmic`, which is **removed in Windows 11 24H2+**. The subprocess returned non-zero → the check answered "unknown" forever → and because the probe only nags on a *positive* "not running", it printed `✅ OK` unconditionally.

A health check that cannot report ill is worse than none. Now **psutil-first** on every platform — already a hard dependency, and the same mechanism the writer scan uses, so "running" means one thing across the codebase. Matching is restricted to python processes: the marker string appears in any shell that merely *greps* for it, which would otherwise report the loop as up because something asked about it.

**A successful setup could leave the cognitive loop down for 30 minutes.** Preflight stops every DB-writer (required — nothing may hold the DB through a migration), but the installer only restarts tasks *that run registered*. An upgrade that re-registers nothing restarted nothing, leaving the **PT30M** keep-alive as the only recovery. Setup now starts what it finds stopped and re-checks, so a service that returns is not reported as a failure — and one that **stays** down still fails verification.

**`claude mcp add` failed whenever root pins were passed**, leaving m3 unwired in Claude Code. The CLI's `--env` is **variadic** (`-e, --env <env...>`), so without an option terminator it swallowed the two positionals and the parser reported `missing required argument 'name'`.

The bug only appeared **when env vars were present**, so a roots-less install never hit it — and decoupled roots are now the default. The failure message also printed a simplified manual command that **dropped the root pins**, which would have produced exactly the split-brain those pins prevent; it now echoes the exact argv that ran.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — version-sync gate (9), catalog drift (11), `--check` in sync; 217 + 391 across the claude/wire/setup/halt/doctor suites on the released commits
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — CHANGELOG entry
- [x] No new warnings introduced

Both fixes verified against live systems: the `claude mcp add` form registers with **both root pins intact** (read back from `~/.claude.json`), and the psutil probe correctly distinguishes a running loop from a dead one. Diff audited for PII / local paths / secrets / bench data before push: clean.

## Related issues
Closes #