### PR TITLE
doctor --fix can now offer inline UAC; stop suppressing the offer on upgrades

### DIFF
--- a/bin/doctor/shared_embedder_probe.py
+++ b/bin/doctor/shared_embedder_probe.py
@@ -394,11 +394,48 @@ def _fix_register_task() -> bool:
     rc = subprocess.run(  # noqa: S603 — fixed argv
         [sys.executable, script, "--add", "embed-server"], check=False,
     ).returncode
-    if rc != 0:
-        # install_schedules already printed the elevation hint on Windows.
-        print("  [fix] task not registered — on Windows this needs an ADMIN shell:")
-        print("            python bin/install_schedules.py --repair   # from an elevated terminal")
-    return rc == 0
+    if rc == 0:
+        return True
+
+    # Registering a scheduled task needs admin on Windows. `m3 setup` OFFERS an
+    # inline UAC prompt here; `m3 doctor --fix` only printed a command to
+    # copy-paste — so the one command whose whole job is "repair what
+    # self-repairs" could not repair the single most common breakage. The
+    # elevation machinery already exists and is used by installer.py; this wires
+    # --fix to the same helper instead of keeping a second, weaker path (§10a).
+    #
+    # Consent-gated by construction: _offer_elevated_schedule_repair shows a UAC
+    # dialog the user approves. We never silently elevate, and we never leave a
+    # long-lived privileged process behind — the elevated child registers the
+    # task and exits.
+    if _offer_elevated_repair(script):
+        return True
+
+    print("  [fix] task not registered — on Windows this needs an ADMIN shell:")
+    print("            python bin/install_schedules.py --repair   # from an elevated terminal")
+    return False
+
+
+def _offer_elevated_repair(script: str) -> bool:
+    """Offer a UAC-elevated retry of the schedule registration. False off
+    Windows, on a headless run, or if the user declines.
+
+    Imports the wizard's helper lazily: bin/ probes must not hard-depend on the
+    m3_memory package being importable (a payload-only checkout has bin/ without
+    it), so an ImportError degrades to the printed banner rather than crashing
+    the doctor (§3)."""
+    if sys.platform != "win32":
+        return False
+    try:
+        from m3_memory.setup_wizard import _offer_elevated_schedule_repair
+    except Exception:  # noqa: BLE001 — payload-only install: fall back to the banner
+        return False
+    try:
+        return bool(_offer_elevated_schedule_repair(script, non_interactive=False))
+    except Exception as e:  # noqa: BLE001 — a repair attempt must not crash --fix
+        print(f"  [fix] elevated retry unavailable ({type(e).__name__}); "
+              f"falling back to the manual command.")
+        return False
 
 
 def _norm_model_tag(tag: str) -> str:

--- a/m3_memory/setup_wizard.py
+++ b/m3_memory/setup_wizard.py
@@ -1140,13 +1140,43 @@ def _retry_elevated(action, *, what: str, max_attempts: int = 5) -> bool:
     return False
 
 
+def _stdin_is_interactive() -> bool:
+    """Is a human able to answer a prompt on this stdin?
+
+    The honest test for "can we ask a question", as distinct from a caller's
+    `non_interactive` flag, which usually means "my choices are already
+    gathered" — a very different thing. Conflating the two is what suppressed
+    the inline-UAC offer on upgrades (see _offer_elevated_schedule_repair).
+
+    False on a closed/detached stdin (services, CI, piped installers) so those
+    paths keep the copy-paste banner instead of blocking on input nobody sends.
+    """
+    try:
+        return bool(sys.stdin is not None and sys.stdin.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
 def _offer_elevated_schedule_repair(script: str, *, non_interactive: bool) -> bool:
     """On interactive Windows, OFFER to UAC-elevate the boot-task registration a
     prior unelevated attempt was denied. Applies to first install AND upgrade —
     every `m3 setup` re-runs schedule registration. Returns True if the elevated
     repair succeeded (boot tasks now registered), False otherwise (caller keeps
     the printed banner as the fallback). No-op off interactive Windows."""
-    if sys.platform != "win32" or non_interactive:
+    if sys.platform != "win32":
+        return False
+    # `non_interactive` here means "the caller already gathered its choices", NOT
+    # "there is no human". `m3 setup` runs its install step non-interactively by
+    # design — every question was answered up front — so gating the UAC offer on
+    # that flag suppressed it for the ONE path that most needs it: an upgrade,
+    # where the dashboard deps are already present and only the boot-task
+    # REGISTRATION is denied. The user then got the copy-paste banner instead of
+    # the inline prompt they explicitly prefer.
+    #
+    # What actually decides whether we can prompt is whether a console is
+    # attached. A truly headless run (CI, a service, a piped installer) has no
+    # tty and still falls through to the banner.
+    if not _stdin_is_interactive():
         return False
     if not _ask_yes_no(
         "  Register the boot-start services now? (opens a Windows admin prompt)",

--- a/tests/test_install_elevation_offers.py
+++ b/tests/test_install_elevation_offers.py
@@ -18,6 +18,7 @@ These tests pin the CONTRACT, not the wiring:
 """
 from __future__ import annotations
 
+import pathlib
 import subprocess
 import sys
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from m3_memory import installer, setup_wizard
+
+_BIN = pathlib.Path(__file__).resolve().parents[1] / "bin"
 
 DENIED = "[FAIL] Failed to create task AgentOS_Dashboard: ERROR: Access is denied."
 
@@ -173,3 +176,66 @@ def test_stuck_writer_elevation_retries():
          patch.object(setup_wizard, "_prompt", return_value="retry"):
         assert setup_wizard._kill_stuck_writers([writer], allow_sudo=True) is True
     assert attempts["n"] == 2, "a missed UAC dialog was not re-offered"
+
+
+# --- the offer must not be gated on the CALLER's non_interactive flag --------
+
+def test_offer_survives_a_non_interactive_caller_when_a_console_exists():
+    """`non_interactive` means "choices already gathered", NOT "no human".
+
+    `m3 setup` runs its install step non-interactively by design — every question
+    was answered up front. Gating the UAC offer on that flag suppressed it for
+    the ONE path that most needs it: an UPGRADE, where the dashboard deps are
+    already present and only the boot-task REGISTRATION is denied. The user then
+    got the copy-paste banner instead of the inline prompt they prefer
+    (observed 2026-08-10 on a real upgrade).
+
+    What decides "can we ask" is whether a console is attached.
+    """
+    with patch.object(setup_wizard.sys, "platform", "win32"), \
+         patch.object(setup_wizard, "_stdin_is_interactive", return_value=True), \
+         patch.object(setup_wizard, "_ask_yes_no", return_value=True) as ask, \
+         patch.object(setup_wizard, "_retry_elevated", return_value=True):
+        assert setup_wizard._offer_elevated_schedule_repair(
+            "sched.py", non_interactive=True) is True
+    assert ask.called, "a non-interactive CALLER suppressed a prompt a human could answer"
+
+
+def test_no_console_still_falls_back_to_the_banner():
+    """A truly headless run must never block on a dialog nobody can approve."""
+    with patch.object(setup_wizard.sys, "platform", "win32"), \
+         patch.object(setup_wizard, "_stdin_is_interactive", return_value=False), \
+         patch.object(setup_wizard, "_ask_yes_no") as ask:
+        assert setup_wizard._offer_elevated_schedule_repair(
+            "sched.py", non_interactive=False) is False
+    assert not ask.called
+
+
+# --- `m3 doctor --fix` must offer elevation too ------------------------------
+
+def test_doctor_fix_offers_elevation_on_a_denied_registration():
+    """`--fix` exists to repair what self-repairs; a denied task registration is
+    the most common breakage it meets, and it could only print a command to
+    copy-paste. It now reuses the SAME helper installer.py does, rather than
+    keeping a second, weaker path (§10a)."""
+    sys.path.insert(0, str(_BIN))
+    from doctor import shared_embedder_probe as probe
+
+    with patch.object(probe.sys, "platform", "win32"), \
+         patch.object(setup_wizard, "_offer_elevated_schedule_repair",
+                      return_value=True) as offer:
+        assert probe._offer_elevated_repair("sched.py") is True
+    assert offer.called, "doctor --fix did not offer elevation"
+    # It must ask as a real prompt, not inherit a caller's "already decided".
+    assert offer.call_args.kwargs.get("non_interactive") is False
+
+
+def test_doctor_fix_degrades_when_the_wizard_is_unimportable():
+    """bin/ probes must not hard-depend on the m3_memory package: a payload-only
+    checkout has bin/ without it, and the doctor must still run (§3)."""
+    sys.path.insert(0, str(_BIN))
+    from doctor import shared_embedder_probe as probe
+
+    with patch.object(probe.sys, "platform", "win32"), \
+         patch.dict(sys.modules, {"m3_memory.setup_wizard": None}):
+        assert probe._offer_elevated_repair("sched.py") is False

--- a/tests/test_setup_wizard_preflight.py
+++ b/tests/test_setup_wizard_preflight.py
@@ -1135,6 +1135,9 @@ def test_offer_elevated_repair_noop_non_interactive(monkeypatch):
 def test_offer_elevated_repair_runs_on_yes(monkeypatch):
     """Interactive Windows, user says yes -> UAC repair runs; success -> True."""
     monkeypatch.setattr(setup_wizard.sys, "platform", "win32")
+    # "Interactive" now means a real console, not the caller's non_interactive
+    # flag — pytest's stdin is not a tty, so state the premise explicitly.
+    monkeypatch.setattr(setup_wizard, "_stdin_is_interactive", lambda: True)
     monkeypatch.setattr(setup_wizard, "_ask_yes_no", lambda *a, **k: True)
     ran = []
     monkeypatch.setattr(setup_wizard, "_runas_schedule_repair_windows",


### PR DESCRIPTION
Two halves of one gap: m3 **knows** how to elevate, but the command whose whole job is *"repair what self-repairs"* could not use it — and the offer was suppressed on exactly the path that needed it most.

## Design answer first: no privileged manager

The governor is a **pacing library**, not a process manager — `bin/m3_core/governor.py` contains zero `subprocess`/`kill`/`schtasks` calls; `get_governor_pacing()` returns sleep delays. Nothing in m3 needs a resident privileged process.

What needs admin is **one-shot registration** (scheduled tasks, the Windows service). So the right model — and what this PR completes — is: unprivileged daemons, plus a **consent-gated UAC prompt per repair batch**, never a long-lived elevated process.

## 1. `m3 doctor --fix` never offered elevation

`m3 setup` offers an inline UAC prompt for a denied task registration. `--fix` only printed a command to copy-paste — so the most common breakage it meets was the one thing it could not fix.

It now reuses `installer.py`'s `_offer_elevated_schedule_repair` rather than keeping a second, weaker path (§10a). The elevated child registers the task and **exits** — the daemons stay unprivileged.

The import is lazy and failure-tolerant: `bin/` probes must not hard-depend on the `m3_memory` package (a payload-only checkout has `bin/` without it), so an `ImportError` degrades to the banner instead of crashing the doctor (§3).

## 2. The offer was gated on the caller's `non_interactive` flag

That flag does not mean *"no human"* — it means *"my choices are already gathered"*. `m3 setup` runs its install step non-interactively **by design**, so on an **upgrade** (deps already present, only the boot-task registration denied) the user got the banner instead of the prompt they prefer.

Observed on a real upgrade 2026-08-10:

```
[FAIL] Failed to create task AgentOS_Dashboard: ERROR: Access is denied.
==========================================================================
  ACTION REQUIRED — boot-start services NOT installed (needs admin)
```

…and never a dialog.

Now gated on **whether a console is attached** (`_stdin_is_interactive`) — the honest test for "can we ask a question". A truly headless run (CI, a service, a piped installer) still falls through to the banner and never blocks on a dialog nobody can approve.

`_stdin_is_interactive` is a **shared helper**: the file had two ad-hoc `isatty()` calls with different semantics, and precisely this distinction is what went wrong.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — **571** across elevation/setup/doctor/schedule; **4 new tests, all failing on the pre-fix code**
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale at both sites
- [x] No new warnings introduced

One existing test stubbed "interactive Windows" without stubbing the tty; its premise is now explicit rather than incidentally true.

No SQL in this diff, so the backend seam is not involved.

## Related issues
Closes #