### PR TITLE
Release 2026.8.19.15 — self-heal can finally reach the privileged repairs

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "description": "Give Antigravity a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "description": "Give Claude Code a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,36 @@ the policy is forward-going only.
 
 ### None pending
 
+## [2026.8.19.15] — 2026-08-10 — self-heal can finally reach the privileged repairs
+
+> m3 already knew how to elevate. The command whose whole job is "repair what
+> self-repairs" could not use it, and the offer was suppressed on exactly the
+> path that needed it most — an upgrade.
+
+### Fixed
+
+- **`m3 doctor --fix` could not repair anything that needs admin.** Registering
+  a scheduled task requires elevation on Windows. `m3 setup` offers an inline
+  UAC prompt for this; `--fix` only printed a command to copy-paste, so the most
+  common breakage it meets was the one thing it could not fix. It now reuses the
+  installer's existing elevation helper rather than keeping a second, weaker
+  path.
+
+  Consent-gated by construction: a UAC dialog the user approves, an elevated
+  child that registers the task and exits. There is no long-lived privileged
+  process — the daemons stay unprivileged, and the governor remains a pacing
+  library rather than a process manager.
+
+- **The elevation offer was suppressed on upgrades.** It was gated on the
+  caller's `non_interactive` flag, which does not mean "no human" — it means
+  "my choices are already gathered". `m3 setup` runs its install step
+  non-interactively by design, so on an upgrade (dashboard deps already present,
+  only the boot-task registration denied) the user got an ACTION REQUIRED banner
+  instead of the inline prompt. It is now gated on whether a console is
+  attached, which is the honest test for "can we ask a question". Headless runs
+  — CI, services, piped installers — still fall through to the banner and never
+  block on a dialog nobody can approve.
+
 ## [2026.8.19.14] — 2026-08-10 — two failures a real upgrade surfaced
 
 > Both fixes came from one user's upgrade log on Windows 11: a health check that

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.8.19.14"
+version = "2026.8.19.15"
 description = "Give your AI agent a memory — local-first, private, easy to install. Guided setup wizard; works out of the box on your own machine, no cloud. For everyday agent users, homelabs, and developers alike · 99.2% LongMemEval-S retrieval @ k=10 · Works with Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · any MCP agent (native + one-command plugins) · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first memory — 100+ tools, 99.2% LongMemEval-S retrieval@10, hybrid search, GDPR, no cloud.",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.8.19.14",
+      "version": "2026.8.19.15",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Description

Cuts **2026.8.19.15**. Version bumped in `pyproject.toml` (single source of truth) and synced to all four derived manifests; `--check`, `test_tool_count_drift.py` and the catalog drift gate all pass.

m3 already knew how to elevate. The command whose whole job is *"repair what self-repairs"* could not use it — and the offer was suppressed on exactly the path that needed it most.

### Fixed

**`m3 doctor --fix` could not repair anything that needs admin.** Registering a scheduled task requires elevation on Windows. `m3 setup` offers an inline UAC prompt for this; `--fix` only printed a command to copy-paste, so **the most common breakage it meets was the one thing it could not fix.** It now reuses the installer's existing elevation helper rather than keeping a second, weaker path (§10a).

Consent-gated by construction: a UAC dialog the user approves, an elevated child that registers the task and **exits**. There is no long-lived privileged process — the daemons stay unprivileged, and the governor remains a *pacing library* (zero `subprocess`/`kill`/`schtasks` calls) rather than a process manager.

**The elevation offer was suppressed on upgrades.** It was gated on the caller's `non_interactive` flag, which does not mean *"no human"* — it means *"my choices are already gathered"*. `m3 setup` runs its install step non-interactively **by design**, so on an upgrade (dashboard deps already present, only the boot-task registration denied) the user got:

```
[FAIL] Failed to create task AgentOS_Dashboard: ERROR: Access is denied.
  ACTION REQUIRED — boot-start services NOT installed (needs admin)
```

…instead of the inline prompt. Now gated on **whether a console is attached**, the honest test for "can we ask a question". Headless runs — CI, services, piped installers — still fall through to the banner and never block on a dialog nobody can approve.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — version-sync gate (9), catalog drift (11), `--check` in sync; **571** across elevation/setup/doctor/schedule on the released commit
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — CHANGELOG entry
- [x] No new warnings introduced

The 4 new regression tests all fail on the pre-fix code. Diff audited for PII / local paths / secrets / bench data before push: clean.

## Related issues
Closes #