### PR TITLE
Build tenancy predicates from the seam, not hardcoded '?'

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "description": "Give Antigravity a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "m3",
   "displayName": "m3 Memory",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "description": "Give Claude Code a private memory that lives on your own machine — it remembers across sessions, works fully offline, and never touches the cloud. 100+ MCP tools: fast hybrid search, automatic chat capture, contradiction tracking, and one-command GDPR export/delete.",
   "keywords": [
     "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,36 @@ the policy is forward-going only.
 
 ### None pending
 
+## [2026.8.19.15] — 2026-08-10 — self-heal can finally reach the privileged repairs
+
+> m3 already knew how to elevate. The command whose whole job is "repair what
+> self-repairs" could not use it, and the offer was suppressed on exactly the
+> path that needed it most — an upgrade.
+
+### Fixed
+
+- **`m3 doctor --fix` could not repair anything that needs admin.** Registering
+  a scheduled task requires elevation on Windows. `m3 setup` offers an inline
+  UAC prompt for this; `--fix` only printed a command to copy-paste, so the most
+  common breakage it meets was the one thing it could not fix. It now reuses the
+  installer's existing elevation helper rather than keeping a second, weaker
+  path.
+
+  Consent-gated by construction: a UAC dialog the user approves, an elevated
+  child that registers the task and exits. There is no long-lived privileged
+  process — the daemons stay unprivileged, and the governor remains a pacing
+  library rather than a process manager.
+
+- **The elevation offer was suppressed on upgrades.** It was gated on the
+  caller's `non_interactive` flag, which does not mean "no human" — it means
+  "my choices are already gathered". `m3 setup` runs its install step
+  non-interactively by design, so on an upgrade (dashboard deps already present,
+  only the boot-task registration denied) the user got an ACTION REQUIRED banner
+  instead of the inline prompt. It is now gated on whether a console is
+  attached, which is the honest test for "can we ask a question". Headless runs
+  — CI, services, piped installers — still fall through to the banner and never
+  block on a dialog nobody can approve.
+
 ## [2026.8.19.14] — 2026-08-10 — two failures a real upgrade surfaced
 
 > Both fixes came from one user's upgrade log on Windows 11: a health check that

--- a/bin/memory/search.py
+++ b/bin/memory/search.py
@@ -817,7 +817,8 @@ async def memory_search_scored_impl(
             names = [v for v in names if v != "__none__"]
             sub: list[str] = []
             if names:
-                placeholders = ",".join(["?"] * len(names))
+                from .backends import dialect as _dl_v
+                placeholders = _dl_v().placeholder(len(names))
                 sub.append(f"mi.variant IN ({placeholders})")
                 params.extend(names)
             if include_null:
@@ -858,10 +859,12 @@ async def memory_search_scored_impl(
     # different (incomparable) vector space — and a wrong-dim blob would break the
     # cosine pack. Restrict the embeddings join to the proper identity.
     from memory.embed import _compatible_model_names
+
+    from .backends import dialect as _dl_m
     _compat = sorted(_compatible_model_names())
     if _compat:
         where_clauses.append(
-            "me.embed_model IN (%s)" % ",".join("?" for _ in _compat))
+            "me.embed_model IN (%s)" % _dl_m().placeholder(len(_compat)))
         params.extend(_compat)
     where_clauses.append("me.dim = ?")
     params.append(config.EMBED_DIM)
@@ -1360,16 +1363,27 @@ async def _apply_two_stage_expansion(ranked, k, user_id: str = "", scope: str = 
                     existing_ids.add(tid)
     if source_turn_ids:
         try:
+            # Placeholders from the SEAM, not hardcoded `?` (§10a). This is a
+            # TENANCY filter, so a dialect mismatch is a security bug, not a
+            # portability nit: on PostgreSQL `?` is a syntax error, the execute
+            # raises, and the `except Exception: logger.debug(...)` below
+            # swallows it — dropping the expansion silently. Any future caller
+            # that catches higher up and keeps going would proceed with the
+            # tenancy clause GONE. The hardened siblings (graph._session_
+            # neighbor_ids, search_routing) already use dialect().param().
+            from .backends import dialect as _dialect_t
+            _d_t = _dialect_t()
+            _p_t = _d_t.param()
             _tenancy_sql = ""
             _tenancy_params: list = []
             if user_id:
-                _tenancy_sql += " AND user_id = ?"
+                _tenancy_sql += f" AND user_id = {_p_t}"
                 _tenancy_params.append(user_id)
             if scope:
-                _tenancy_sql += " AND scope = ?"
+                _tenancy_sql += f" AND scope = {_p_t}"
                 _tenancy_params.append(scope)
             with _db() as db:
-                placeholders = ",".join("?" * len(source_turn_ids))
+                placeholders = _d_t.placeholder(len(source_turn_ids))
                 turn_rows = db.execute(
                     f"SELECT id, content, title, type, importance "
                     f"FROM memory_items "
@@ -1863,7 +1877,8 @@ async def memory_search_routed_impl(
         if hit_ids:
             try:
                 with _db() as db:
-                    placeholders = ",".join("?" * len(hit_ids))
+                    from .backends import dialect as _dl_h
+                    placeholders = _dl_h().placeholder(len(hit_ids))
                     sup_rows = db.execute(
                         f"SELECT to_id FROM memory_relationships "
                         f"WHERE relationship_type = 'supersedes' "
@@ -1903,18 +1918,25 @@ async def memory_search_routed_impl(
                 for _s, item in final_hits
                 if isinstance(item, dict) and item.get("id")
             }
+            # Seam placeholders (§10a). Same reasoning as the other tenancy
+            # filters in this module: a hardcoded `?` is a syntax error on
+            # PostgreSQL, and this clause is what keeps bypass_surface rows
+            # inside the caller's tenant.
+            from .backends import dialect as _dialect_b
+            _d_b = _dialect_b()
+            _p_b = _d_b.param()
             params: list = [conversation_id]
             scope_clause = ""
             if scope:
-                scope_clause += " AND scope = ?"
+                scope_clause += f" AND scope = {_p_b}"
                 params.append(scope)
             if user_id:
-                scope_clause += " AND user_id = ?"
+                scope_clause += f" AND user_id = {_p_b}"
                 params.append(user_id)
             with _db() as db:
                 surf_rows = db.execute(
                     f"SELECT memory_id FROM bypass_surface "
-                    f"WHERE conversation_id = ?{scope_clause}",
+                    f"WHERE conversation_id = {_p_b}{scope_clause}",
                     params,
                 ).fetchall()
                 surf_ids = [r[0] for r in surf_rows if r[0] not in already]
@@ -1928,7 +1950,7 @@ async def memory_search_routed_impl(
                     )
                     surf_ids = surf_ids[:bypass_surface_cap]
                 if surf_ids:
-                    placeholders = ",".join("?" * len(surf_ids))
+                    placeholders = _d_b.placeholder(len(surf_ids))
                     item_rows = db.execute(
                         f"SELECT id, title, type, conversation_id FROM memory_items "
                         f"WHERE id IN ({placeholders})",
@@ -1977,13 +1999,22 @@ async def _maybe_expand_routed(
     user A's memory to user B's would pull B's row into A's results. The primary
     hits are already tenant-filtered; we pass the same tenancy down and gate every
     hydrated neighbor on it (defense at the materialization choke point)."""
+    # Placeholders from the SEAM (§10a). This is the tenancy gate for every
+    # neighbor this expansion hydrates — graph, session AND entity-graph — so a
+    # dialect mismatch here is a §7 security bug, not a portability nit: `?` is
+    # a syntax error on PostgreSQL, and a caller that catches and continues
+    # would then run with NO tenancy clause. graph._session_neighbor_ids and
+    # search_routing were hardened for exactly this; these two sites in search.py
+    # were missed.
+    from .backends import dialect as _dialect_e
+    _p_e = _dialect_e().param()
     _tenancy_sql = ""
     _tenancy_params: list = []
     if user_id:
-        _tenancy_sql += " AND user_id = ?"
+        _tenancy_sql += f" AND user_id = {_p_e}"
         _tenancy_params.append(user_id)
     if scope:
-        _tenancy_sql += " AND scope = ?"
+        _tenancy_sql += f" AND scope = {_p_e}"
         _tenancy_params.append(scope)
     _resolve_mc_callbacks()  # bind memory_core callbacks on first call
 
@@ -2011,7 +2042,7 @@ async def _maybe_expand_routed(
         neighbor_ids = _resolve_graph_helper("_graph_neighbor_ids")(seed_ids, depth=int(graph_depth))
         if neighbor_ids:
             with _db() as db:
-                placeholders = ",".join(["?"] * len(neighbor_ids))
+                placeholders = _dialect_e().placeholder(len(neighbor_ids))
                 rows = db.execute(
                     f"SELECT id, type, title, content, metadata_json, conversation_id, "
                     f"valid_from, user_id FROM memory_items "
@@ -2048,7 +2079,7 @@ async def _maybe_expand_routed(
             new_ids = eg_memory_ids - primary_ids - set(extra_rows.keys())
             if new_ids:
                 with _db() as db:
-                    placeholders = ",".join(["?"] * len(new_ids))
+                    placeholders = _dialect_e().placeholder(len(new_ids))
                     eg_rows = db.execute(
                         f"SELECT id, type, title, content, metadata_json, conversation_id, "
                         f"valid_from, user_id FROM memory_items "

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-memory",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "description": "Local-first agentic memory layer for MCP agents — 100+ tools, hybrid search, contradiction detection, cross-device sync, GDPR-ready. 100% local, no cloud APIs.",
   "homepage": "https://github.com/skynetcmd/m3-memory",
   "repository": "https://github.com/skynetcmd/m3-memory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m3-memory"
-version = "2026.8.19.14"
+version = "2026.8.19.15"
 description = "Give your AI agent a memory — local-first, private, easy to install. Guided setup wizard; works out of the box on your own machine, no cloud. For everyday agent users, homelabs, and developers alike · 99.2% LongMemEval-S retrieval @ k=10 · Works with Claude · Gemini · Antigravity · OpenCode · OpenClaw · Hermes · any MCP agent (native + one-command plugins) · Hybrid search (FTS5 + vector + MMR) · GDPR · FIPS 140-3 deployment-ready · 100% local (fully offline) or cloud capable"
 
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.skynetcmd/m3-memory",
   "title": "M3 Memory",
   "description": "Local-first memory — 100+ tools, 99.2% LongMemEval-S retrieval@10, hybrid search, GDPR, no cloud.",
-  "version": "2026.8.19.14",
+  "version": "2026.8.19.15",
   "repository": {
     "url": "https://github.com/skynetcmd/m3-memory",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "m3-memory",
-      "version": "2026.8.19.14",
+      "version": "2026.8.19.15",
       "runtimeHint": "python",
       "transport": {
         "type": "stdio"

--- a/tests/test_tenancy_sql_uses_the_seam.py
+++ b/tests/test_tenancy_sql_uses_the_seam.py
@@ -1,0 +1,88 @@
+r"""Tenancy predicates must build their placeholders from the SEAM, never `?`.
+
+A hardcoded `?` in an ordinary query is a portability bug. In a TENANCY filter it
+is a security bug, because of how it fails:
+
+  * on PostgreSQL `?` is a syntax error (verified against a live PG 16:
+    `SELECT ... WHERE 1=1 AND user_id = ?` -> SyntaxError),
+  * the expansion paths that carry these filters wrap their queries in
+    `except Exception: logger.debug(...)`,
+  * so the query dies silently and the expansion is dropped — and any caller
+    that catches higher up and *continues* proceeds with the tenancy clause
+    gone.
+
+`graph._session_neighbor_ids` and `search_routing` were hardened for exactly
+this on 2026-07-14. Two sites in `memory/search.py` (`_maybe_expand_routed` and
+the two-stage observation expansion) were missed and still used `?` — found
+2026-08-10 while investigating a one-off CI failure of
+test_search_tenant_isolation.
+
+This is a STATIC scan rather than a behavioural test on purpose: the failure it
+guards is invisible on SQLite (where `?` is valid), so only reading the source
+catches it before a PG deployment does.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_BIN = Path(__file__).resolve().parents[1] / "bin"
+
+# A tenancy predicate being appended to a SQL fragment with a literal `?`.
+# Matches:  _tenancy_sql += " AND user_id = ?"
+_RAW_TENANCY = re.compile(
+    r"""\+=\s*["'][^"']*\bAND\s+(?:user_id|scope)\s*=\s*\?""",
+    re.IGNORECASE,
+)
+
+# An IN-list built by hand rather than via dialect().placeholder(n).
+_RAW_IN_LIST = re.compile(r"""["']\s*,\s*["']\s*\.join\(\s*\[?\s*["']\?["']""")
+
+
+def _py_sources() -> list[Path]:
+    return [p for p in _BIN.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+@pytest.mark.parametrize("path", _py_sources(), ids=lambda p: p.name)
+def test_no_raw_qmark_in_a_tenancy_predicate(path):
+    """`user_id`/`scope` filters must use dialect().param()."""
+    src = path.read_text(encoding="utf-8", errors="ignore")
+    hits = [
+        f"{path.name}:{i}: {line.strip()}"
+        for i, line in enumerate(src.splitlines(), 1)
+        if _RAW_TENANCY.search(line)
+    ]
+    assert not hits, (
+        "tenancy filter built with a hardcoded '?' — a syntax error on "
+        "PostgreSQL, swallowed by the surrounding except, which drops the "
+        "tenancy clause:\n  " + "\n  ".join(hits)
+    )
+
+
+def test_the_two_known_sites_are_fixed():
+    """Pin the specific regression rather than trusting the scan alone."""
+    src = (_BIN / "memory" / "search.py").read_text(encoding="utf-8")
+    assert ' AND user_id = ?' not in src, "search.py still hardcodes a tenancy '?'"
+    assert ' AND scope = ?' not in src, "search.py still hardcodes a tenancy '?'"
+    # And the seam form IS present.
+    assert "param()" in src
+
+
+def test_expansion_in_lists_use_the_seam():
+    """The IN-lists these tenancy filters ride along with must port too.
+
+    Fixing only the tenancy clause would still leave the query unrunnable on
+    PostgreSQL, so the guard covers both halves of the same statement.
+    """
+    src = (_BIN / "memory" / "search.py").read_text(encoding="utf-8")
+    offenders = [
+        f"search.py:{i}: {line.strip()}"
+        for i, line in enumerate(src.splitlines(), 1)
+        if _RAW_IN_LIST.search(line)
+    ]
+    assert not offenders, (
+        "IN-list built with hardcoded '?' instead of dialect().placeholder(n):\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Found while investigating a one-off CI failure of `test_search_tenant_isolation::test_routed_expansion_no_leak`. **That test is still unexplained** (tracked separately) — this is a real defect the investigation surfaced, and it is worse than the flake.

## The defect

`memory/search.py` built **three tenancy filters** with a literal `?`:

```python
_tenancy_sql += " AND user_id = ?"     # _maybe_expand_routed
_tenancy_sql += " AND user_id = ?"     # two-stage observation expansion
scope_clause  += " AND scope = ?"      # bypass_surface hydration
```

In an ordinary query a hardcoded `?` is a portability bug. In a **tenancy filter** it is a security bug, because of *how* it fails:

- `?` is a **syntax error on PostgreSQL**. Verified against live PG 16: `SELECT ... WHERE 1=1 AND user_id = ?` → `SyntaxError`, while the `%s` form parses.
- Two of the three sit inside `except Exception: logger.debug(...)`.
- So on PG the query dies **silently**, the expansion is dropped — and any caller that catches higher up and *continues* proceeds with the tenancy clause **gone**.

`graph._session_neighbor_ids` and `search_routing` were hardened for exactly this on 2026-07-14 and already use `dialect().param()`. These three sites were missed.

## Also ported: the IN-lists they ride with

`",".join("?" * n)` → `dialect().placeholder(n)` — 4 more sites. Fixing only the tenancy clause would leave the same statement unrunnable on PG, so both halves move together.

## The guard found more than I did

`tests/test_tenancy_sql_uses_the_seam.py` scans every `bin/` module for a tenancy predicate built with `?`, plus hand-rolled IN-lists in `search.py`.

**Static on purpose:** this failure is invisible on SQLite, where `?` is valid, so only reading the source catches it before a PG deployment does. The guard immediately caught **a third tenancy site and 3 of the IN-lists I had missed by hand**.

## Verification

- **SQLite:** 543 pass across search/tenant/seam/dialect suites
- **PG-live:** **no regressions** vs a properly-taken baseline — 40 failing names on both sides, with one maintenance test swapping either way (it passes **6/6 in isolation**; pre-existing ordering pollution), and **+2 net passes**

## ⚠️ Scope

This does **not** claim to fix the original flaky tenancy test. It is adjacent — same function, same tenancy path — but I could not reproduce that failure in ~90 local runs, including with the embedder unreachable, and I am not asserting causation without evidence.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Breaking change

## Checklist
- [x] Tests pass — 543 SQLite; PG-live no regressions, +2 passes
- [x] Lint clean (`ruff check bin/ memory/`)
- [x] Type check passes (`mypy bin/ --ignore-missing-imports`)
- [x] Documentation updated if needed — rationale at each site
- [x] No new warnings introduced

## Related issues
Closes #