### PR TITLE
ci(hooks): include bin/gen_tool_inventory.py in pre-push drift gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -139,7 +139,7 @@ CHANGED="$(changed_files)"
 # Paths whose change can make the generated catalog/inventory or the hardcoded
 # "N tools" counts go stale. Mirrors check_tool_catalog_drift.py's universe.
 if printf '%s\n' "$CHANGED" | grep -qE \
-  '^bin/mcp_tool_catalog\.py$|^bin/mcp_proxy\.py$|^bin/gen_tool_manifest\.py$|^bin/gen_mcp_inventory\.py$|^docs/tools/MCP_CATALOG\.json$|^docs/MCP_TOOLS\.md$|^README\.md$|^docs/COMPARISON\.md$|^docs/MYTHS_AND_FACTS\.md$|^docs/tools/files_memory\.md$|^tests/test_tool_count_drift\.py$|^tests/test_mcp_catalog_manifest_fresh\.py$'
+  '^bin/mcp_tool_catalog\.py$|^bin/mcp_proxy\.py$|^bin/gen_tool_manifest\.py$|^bin/gen_mcp_inventory\.py$|^bin/gen_tool_inventory\.py$|^docs/tools/.*$|^docs/MCP_TOOLS\.md$|^README\.md$|^docs/COMPARISON\.md$|^docs/MYTHS_AND_FACTS\.md$|^docs/tools/files_memory\.md$|^tests/test_tool_count_drift\.py$|^tests/test_mcp_catalog_manifest_fresh\.py$'
 then
   echo "[pre-push] 1/3 tool-catalog drift gate (catalog/docs touched — checking)"
   if ! py_has_deps; then

--- a/bin/check_tool_catalog_drift.py
+++ b/bin/check_tool_catalog_drift.py
@@ -46,6 +46,7 @@ _PY = sys.executable
 _GENERATORS = [
     ["bin/gen_tool_manifest.py"],
     ["bin/gen_mcp_inventory.py"],
+    ["bin/gen_tool_inventory.py"],
 ]
 
 # Paths the generators (and hand-maintained count claims) touch. Drift is
@@ -53,6 +54,7 @@ _GENERATORS = [
 _GENERATED_PATHS = [
     "docs/tools/MCP_CATALOG.json",
     "docs/MCP_TOOLS.md",
+    "docs/tools/",
 ]
 
 # Drift tests that gate the count claims + manifest freshness.

--- a/docs/tools/check_tool_catalog_drift.md
+++ b/docs/tools/check_tool_catalog_drift.md
@@ -1,8 +1,8 @@
 ---
 tool: bin/check_tool_catalog_drift.py
-sha1: 6f5fa0c718d2
-mtime_utc: 2026-05-31T16:08:17.340434+00:00
-generated_utc: 2026-05-31T18:42:52.653159+00:00
+sha1: e6a4d6d6b0c4
+mtime_utc: 2026-09-12T12:18:56.130967+00:00
+generated_utc: 2026-09-12T12:19:02.527818+00:00
 private: false
 ---
 
@@ -46,7 +46,7 @@ Usage:
 
 ## Entry points
 
-- `def main()` (line 89)
+- `def main()` (line 91)
 - `if __name__ == "__main__"` guard
 
 ---
@@ -75,9 +75,9 @@ _(none detected)_
 
 **subprocess**
 
-- `subprocess.run()  → `['git', 'diff', '--name-only', '--', *_GENERATED_PATHS]`` (line 82)
-- `subprocess.run()  → `[_PY, '-m', 'pytest', '-q', '-p', 'no:cacheprovider', *_DRIFT_TESTS]`` (line 117)
-- `subprocess.run()  → `cmd`` (line 66)
+- `subprocess.run()  → `['git', 'diff', '--name-only', '--', *_GENERATED_PATHS]`` (line 84)
+- `subprocess.run()  → `[_PY, '-m', 'pytest', '-q', '-p', 'no:cacheprovider', *_DRIFT_TESTS]`` (line 119)
+- `subprocess.run()  → `cmd`` (line 68)
 
 
 ---


### PR DESCRIPTION
Fixes #145. Includes in/gen_tool_inventory.py and docs/tools/ in in/check_tool_catalog_drift.py and .githooks/pre-push to prevent un-inventoried in/ edits from reaching remote.