### PR TITLE
security(examples): update fastapi and uvicorn dependency pins in mac-agent requirements

### DIFF
--- a/examples/mac-agent/requirements.txt
+++ b/examples/mac-agent/requirements.txt
@@ -1,5 +1,5 @@
-fastapi>=0.135.3,<1
-uvicorn[standard]>=0.44.0,<1
+fastapi>=0.136.1,<1
+uvicorn[standard]>=0.46.0,<1
 httpx>=0.28.1,<1
 sentence-transformers>=5.4.1,<6
 python-dotenv>=1.2.2,<2


### PR DESCRIPTION
Fixes #146. Bumps fastapi to >=0.136.1 and uvicorn to >=0.46.0 in examples/mac-agent/requirements.txt to match security floor in pyproject.toml. Validated with V&V audit script.